### PR TITLE
TRAFODION-2847 optimize dcs log format

### DIFF
--- a/dcs/conf/log4j.properties
+++ b/dcs/conf/log4j.properties
@@ -42,7 +42,7 @@ log4j.appender.DRFA.DatePattern=.yyyy-MM-dd
 #log4j.appender.DRFA.MaxBackupIndex=30
 log4j.appender.DRFA.layout=org.apache.log4j.PatternLayout
 # Pattern format: Date LogLevel LoggerName LogMessage
-log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601}, %p, %c, Node Number: , CPU: , PIN: , Process Name: , , ,%m%n
+log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601}, [%t], %p, %l |    %m%n
 # Debugging Pattern format
 #log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n
 


### PR DESCRIPTION
previous logs look like

2017-12-14 05:31:11,417, INFO, org.trafodion.dcs.util.VersionInfo, Node Number: , CPU: , PIN: , Process Name: , , ,Dcs 2.3.0
2017-12-14 05:31:11,417, INFO, org.trafodion.dcs.util.VersionInfo, Node Number: , CPU: , PIN: , Process Name: , , ,Revision 1efa9db
2017-12-14 05:31:11,417, INFO, org.trafodion.dcs.util.VersionInfo, Node Number: , CPU: , PIN: , Process Name: , , ,Compiled by traf on Thu Dec 14 05:30:52 UTC 2017
2017-12-14 05:31:12,544, INFO, org.trafodion.dcs.master.DcsMaster, Node Number: , CPU: , PIN: , Process Name: , , ,Connected to ZooKeeper


now logs look like

2017-12-14 10:57:08,949, [Thread-2], INFO, org.trafodion.dcs.util.VersionInfo.logVersion(VersionInfo.java:107) |    Dcs 2.3.0
2017-12-14 10:57:08,952, [Thread-2], INFO, org.trafodion.dcs.util.VersionInfo.logVersion(VersionInfo.java:107) |    Revision 1efa9db
2017-12-14 10:57:08,953, [Thread-2], INFO, org.trafodion.dcs.util.VersionInfo.logVersion(VersionInfo.java:107) |    Compiled by traf on Thu Dec 14 09:46:05 UTC 2017
2017-12-14 10:57:10,071, [Thread-2], INFO, org.trafodion.dcs.master.DcsMaster.run(DcsMaster.java:141) |    Connected to ZooKeeper
