### PR TITLE
[TRAFODION-2892] remove code about SP_EXPORT_LIB

### DIFF
--- a/core/seamonster/src/Makefile
+++ b/core/seamonster/src/Makefile
@@ -56,7 +56,6 @@ $(LIBOBJ): $(LIBSRC) $(INCSRC)
 	$(CC) $(CCFLAGS) $(INCLUDES) $*.c $(LDFLAGS) -c
 
 $(LIBSM): $(LIBOBJ)
-	-mkdir -p $(SP_EXPORT_LIB)
 	$(CC) $(LDFLAGS) $(CCFLAGS) -Wall -Werror -shared \
 		-Wl,-soname,libsm.so -o $@ $(LIBOBJ) -lrt
 

--- a/core/sql/nskgmake/executor/Makefile
+++ b/core/sql/nskgmake/executor/Makefile
@@ -130,8 +130,5 @@ CPPSRC += vers_libexecutor.cpp \
 	ExSMReadyList.cpp \
 	ExFastTransport.cpp
 
-ifneq ($(SP_DIS),)
-EXTERN_LIBS := $(SP_EXPORT_LIB)/libwrappersq.so
-endif
 SYS_LIBS := -lrt -lpthread
 SRCPATH := bin executor runtimestats porting_layer qmscommon

--- a/core/sql/nskgmake/tdm_sqlmxevents/Makefile
+++ b/core/sql/nskgmake/tdm_sqlmxevents/Makefile
@@ -29,6 +29,5 @@ DEFS := -DSQLMXEVENTS_LIB
 
 ifeq ($(TARGTYPE),linux)
 EXTERN_LIBS := $(XMPIROOT)/libevlsq.so
-#EXTERN_LIBS += $(SP_EXPORT_LIB)/libwrappersq.so
 CPPSRC += vers_libtdm_sqlmxevents.cpp
 endif


### PR DESCRIPTION
Because the SP_EXPORT_LIB is empty.
make a build error, as:
mkdir -p        ##(SEAMONSTER)
mkdir: 缺少操作数       ##(SEAMONSTER)
请尝试执行"mkdir --help"来获取更多信息。        ##(SEAMONSTER)