### PR TITLE
[TRAFODION-2895] Update Message Guide for messages 1700-1721 + some others

### DIFF
--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -222,8 +222,8 @@
 1224 ZZZZZ 99999 BEGINNER MAJOR DBADMIN --- unused ---
 1225 ZZZZZ 99999 BEGINNER MAJOR DBADMIN --- unused ---
 1226 ZZZZZ 99999 BEGINNER MAJOR DBADMIN --- unused ---
-1227 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Cannot unregister user.  User $0~String0 has been granted privileges on $1~String1.
-1228 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Cannot drop role.  Role $0~String0 has been granted privileges on $1~String1.
+1227 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Cannot unregister user. User $0~String0 has been granted privileges on $1~String1.
+1228 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Cannot drop role. Role $0~String0 has been granted privileges on $1~String1.
 1229 ZZZZZ 99999 BEGINNER MAJOR DBADMIN The $0~string0 option is not supported.
 1230 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Object owner must be the schema owner in private schemas.
 1231 ZZZZZ 99999 BEGINNER MAJOR DBADMIN User-defined routine $0~String0 could not be created.
@@ -494,28 +494,28 @@
 1600 ZZZZZ 99999 BEGINNER MAJOR DBADMIN --- unused ---
 1601 ZZZZZ 99999 BEGINNER MAJOR DBADMIN --- unused ---
 
-1700 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Object $0~string0 is not a universal user-defined function.
-1701 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Encountered an error while processing a routine definition. Too many pass through inputs.
-1702 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Only a character string literal can appear within the VALUE clause in a pass through input definition.
-1703 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Only BINARY option can appear together with a UCS2 character string literal within the VALUE clause in a pass through input definition.
-1704 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Only BINARY option can appear within the VALUE FROM FILE clause.
-1705 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Encountered an error while processing a routine definition. Unable to open file '$0~string0' for read.
-1706 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Encountered an error while processing a routine definition. Unable to read contents of file '$0~string0'.
-1707 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Routine action $0~string0 already exists in the list of actions used by universal user-defined function $1~string0
-1708 ZZZZZ 99999 BEGINNER MAJOR DBADMIN The number of items in the NUMBER OF UNIQUE OUTPUT VALUES clause exceeds the number of outputs declared in the RETURNS clause.
-1709 ZZZZZ 99999 BEGINNER MINOR DBADMIN Cannot drop the universal user-defined function $0~String0 - Associating routine action $1~String1 still exists.
-1710 ZZZZZ 99999 BEGINNER MINOR DBADMIN Encountered an error while processing the ALTER PASS THROUGH INPUTS clause. The specified position must start from 1, not 0.
-1711 ZZZZZ 99999 BEGINNER MINOR DBADMIN Encountered an error while processing the ALTER PASS THROUGH INPUTS clause. The specified position exceeds the number of existing pass through inputs.
-1712 ZZZZZ 99999 BEGINNER MINOR DBADMIN Encountered an error while processing the ALTER PASS THROUGH INPUTS clause. The specified position appears multiple times.
-1713 ZZZZZ 99999 BEGINNER MINOR DBADMIN Missing the required universal user-defined function name clause.
-1714 ZZZZZ 99999 BEGINNER MINOR DBADMIN An error occurred while retrieving metadata from catalog manager. Encountered an invalid routine action name '$0~string0'.
-1715 ZZZZZ 99999 BEGINNER MINOR DBADMIN An error occurred while retrieving metadata from catalog manager. Unable to start transaction.
-1716 ZZZZZ 99999 BEGINNER MINOR DBADMIN Number of declared formal parameters with SQL parameter style cannot exceed 32.
-1717 ZZZZZ 99999 BEGINNER MINOR DBADMIN Encountered an error while processing a routine definition. Pass through input value with BINARY type cannot be empty.
-1718 ZZZZZ 99999 BEGINNER MINOR DBADMIN Encountered an error while processing a routine definition. File '$0~string0' is empty. A pass through input value with BINARY type cannot be empty.
+1700 ZZZZZ 99999 BEGINNER MAJOR DBADMIN --- unused ---
+1701 ZZZZZ 99999 BEGINNER MAJOR DBADMIN --- unused ---
+1702 ZZZZZ 99999 BEGINNER MAJOR DBADMIN --- unused ---
+1703 ZZZZZ 99999 BEGINNER MAJOR DBADMIN --- unused ---
+1704 ZZZZZ 99999 BEGINNER MAJOR DBADMIN --- unused ---
+1705 ZZZZZ 99999 BEGINNER MAJOR DBADMIN --- unused ---
+1706 ZZZZZ 99999 BEGINNER MAJOR DBADMIN --- unused ---
+1707 ZZZZZ 99999 BEGINNER MAJOR DBADMIN --- unused ---
+1708 ZZZZZ 99999 BEGINNER MAJOR DBADMIN --- unused ---
+1709 ZZZZZ 99999 BEGINNER MINOR DBADMIN --- unused ---
+1710 ZZZZZ 99999 BEGINNER MINOR DBADMIN --- unused ---
+1711 ZZZZZ 99999 BEGINNER MINOR DBADMIN --- unused ---
+1712 ZZZZZ 99999 BEGINNER MINOR DBADMIN --- unused ---
+1713 ZZZZZ 99999 BEGINNER MINOR DBADMIN --- unused ---
+1714 ZZZZZ 99999 BEGINNER MINOR DBADMIN --- unused ---
+1715 ZZZZZ 99999 BEGINNER MINOR DBADMIN --- unused ---
+1716 ZZZZZ 99999 BEGINNER MINOR DBADMIN --- unused ---
+1717 ZZZZZ 99999 BEGINNER MINOR DBADMIN --- unused ---
+1718 ZZZZZ 99999 BEGINNER MINOR DBADMIN --- unused ---
 1719 ZZZZZ 99999 BEGINNER MINOR DBADMIN Access Type '$0~string0' is not supported.
 1720 ZZZZZ 99999 BEGINNER MINOR DBADMIN Isolation Level '$0~string0' is not supported.
-1999 ZZZZZ 99999 UUUUUUUU UUUUU UUUUUUU Last Catalog Manager error
+1999 ZZZZZ 99999 UUUUUUUU UUUUU UUUUUUU --- Last Catalog Manager error ---
 2000 ZZZZZ 99999 UUUUUUUU UUUUU UUUUUUU Error messages for compiler main, IPC, and DEFAULTS table; assertions for optimizer.
 2001 ZZZZZ 99999 ADVANCED MAJOR DIALOUT Error or warning $0~Int0 occurred while opening or reading from DEFAULTS table $1~TableName.  Using $2~String0 values.
 2002 ZZZZZ 99999 ADVANCED MAJOR DIALOUT Internal error: cannot create compiler.

--- a/core/sql/sqlcomp/CmpDDLCatErrorCodes.h
+++ b/core/sql/sqlcomp/CmpDDLCatErrorCodes.h
@@ -434,27 +434,6 @@ enum CatErrorCode { CAT_FIRST_ERROR = 1000
                   // unused                                       = 1600
                   // unused                                       = 1601
 
-                  // UDF related errors
-                  , CAT_NOT_UUDF_OBJECT                           = 1700
-                  , CAT_TOO_MANY_PASS_THRU_INPUTS                 = 1701
-                  , CAT_ONLY_STRING_LITERAL                       = 1702
-                  , CAT_BINARY_ONLY_OPTION_WITH_UCS2              = 1703
-                  , CAT_BINARY_ONLY_OPTION_WITHIN_VALUE_FROM_FILE_CLAUSE = 1704
-                  , CAT_UNABLE_TO_OPEN_FILE                       = 1705
-                  , CAT_UNABLE_TO_READ_FILE                       = 1706
-                  , CAT_RA_ALREADY_EXISTS_UUDF                    = 1707
-                  , CAT_EXCEEDS_NUMBER_OF_OUTPUT_VALUES           = 1708
-                  , CAT_UNABLE_TO_DROP_UUDF_BEING_USED_BY_RA      = 1709
-                  , CAT_PASS_THRU_INPUT_WRONG_POSITION_SPECIFIED  = 1710
-                  , CAT_POSITION_SPECIFIED_EXCEEDS_NUMBER_OF_PASS_THRU_INPUTS = 1711
-                  , CAT_SPECIFIED_POSITION_APPEARS_MULTIPLE_TIMES = 1712
-                  , CAT_MISSING_UUDF_FUNCTION_NAME_CLAUSE         = 1713
-                  , CAT_INVALID_ROUTINE_ACTION_NAME               = 1714
-                  , CAT_UNABLE_TO_START_TRANSACTION               = 1715
-                  , CAT_SQL_STYLE_PARAMETER_EXCEEDS_LIMIT         = 1716
-                  , CAT_PASS_THRU_BINARY_INPUT_CANNOT_BE_EMPTY    = 1717
-                  , CAT_BINARY_TYPE_FILE_EMPTY                    = 1718
-
                   // Method validation failures
                   , CAT_CLASS_NOT_FOUND                           = 11205
                   , CAT_CLASS_DEFINITION_NOT_FOUND                = 11206

--- a/docs/messages_guide/src/asciidoc/_chapters/ddl_msgs.adoc
+++ b/docs/messages_guide/src/asciidoc/_chapters/ddl_msgs.adoc
@@ -363,6 +363,24 @@ you can reissue the statement specifying CASCADE. For other DROP
 statements, you must first drop each of the dependent objects, then drop
 the object.
 
+[[SQL-1026]]
+== SQL 1026
+
+```
+Specified object name <object-name> is invalid for this command.
+```
+
+Where <object-name> is the name of the object you specified.
+
+*Cause:* You attempted to register or unregister a Hive or HBase table, but the object name
+was not of the appropriate kind. For example, REGISTER HIVE TABLE TRAFODION.SCH.T1 will get this
+error because objects in the TRAFODION catalog are native {project-name} objects.
+
+*Effect:* The operation fails.
+
+*Recovery:* Correct the statement and resubmit.
+
+<<<
 [[SQL-1027]]
 == SQL 1027
 
@@ -380,7 +398,6 @@ on an earlier release of the {project-name} software, before column privileges w
 
 *Recovery:* Drop and recreate the view, then resubmit the grant request.
 
-<<<
 [[SQL-1028]]
 == SQL 1028
 
@@ -399,6 +416,7 @@ objects.
 *Recovery:* Either drop all the objects in <schema-name> and resubmit
 the statement, or resubmit the drop statement using the CASCADE option.
 
+<<<
 [[SQL-1029]]
 == SQL 1029
 
@@ -415,7 +433,6 @@ accompanying error messages to determine the cause.
 
 *Recovery:* Apply the recovery of the accompanying error messages.
 
-<<<
 [[SQL-1030]]
 == SQL 1030
 
@@ -435,6 +452,7 @@ is too long for HBase.
 
 *Recovery:* Use a shorter name and resubmit.
 
+<<<
 [[SQL-1031]]
 == SQL 1031
 
@@ -450,7 +468,6 @@ Where <object-name> is the SQL object.
 
 *Recovery:* Apply the recovery of the accompanying error message.
 
-<<<
 [[SQL-1032]]
 == SQL 1032
 
@@ -466,6 +483,22 @@ the query is not executed.
 
 *Recovery:* If you wish to execute the query, resubmit without
 the DISPLAY command.
+
+<<<
+[[SQL-1033]]
+== SQL 1033
+
+```
+Unable to obtain comments.
+```
+
+*Cause:* You attempted a DDL or SHOWDDL operation but {project-name}
+could not retrieve comment information needed to process the request.
+Additional error messages may give insight to the cause.
+
+*Effect:* The operation is not executed.
+
+*Recovery:* None. Contact the {project-name} Developer Distribution List.
 
 [[SQL-1034]]
 == SQL 1034
@@ -911,6 +944,25 @@ system error <error-number>.
 *Effect:* The operation fails.
 
 *Recovery:* For information about file system errors, see <<file_system_errors,File-System Errors>>.
+
+<<<
+[[SQL-1071]]
+== SQL 1071
+
+```
+View usage information for the following hive tables could not be set. Make sure that an external table either already exists or implicit creation has not been disabled. Hive tables: <hive-tables>
+```
+
+Where <hive-tables> is a list of Hive table names.
+
+*Cause:* You attempted to create a view referencing the listed Hive tables, but the Hive tables do not have external tables defined within {project-name}
+or have not been registered within {project-name}, and automatic registration has been turned off. (CQD HIVE_NO_REGISTER_OBJECTS controls whether automatic
+registration is enabled. If this CQD is 'ON' it has been disabled.)
+
+*Effect:* The operation fails.
+
+*Recovery:* Either register or create external tables within {project-name} for the Hive tables listed, then resubmit. Alternatively, set
+CQD HIVE_NO_REGISTER_OBJECTS 'OFF' and resubmit.
 
 <<<
 [[SQL-1073]]
@@ -2009,6 +2061,20 @@ about that object.
 *Recovery:* Determine the proper recovery action from the <diagnostics> then resubmit.
 
 <<<
+[[SQL-1220]]
+== SQL 1220
+
+```
+Code must contain two non-blank characters.
+```
+
+*Cause:* You attempted to create a component privilege but you specified a component code that is not two non-blank characters.
+
+*Effect:* The operation fails.
+
+*Recovery:* Correct the statement and resubmit.
+
+<<<
 [[SQL-1222]]
 == SQL 1222
 
@@ -2041,7 +2107,7 @@ Grant to self or DB__ROOT is not allowed.
 == SQL 1227
 
 ```
-Cannot unregister user.  User <user-name> has been granted privileges on <object-name>.
+Cannot unregister user. User <user-name> has been granted privileges on <object-name>.
 ```
 
 Where <user-name> is the name of a user that you are trying to unregister.
@@ -2058,7 +2124,7 @@ Where <object-name> is the name of a {project-name} object.
 == SQL 1228
 
 ```
-Cannot drop role.  Role <role-name> has been granted privileges on <object-name>.
+Cannot drop role. Role <role-name> has been granted privileges on <object-name>.
 ```
 
 Where <role-name> is the name of a role that you are trying to drop.
@@ -3573,6 +3639,37 @@ Where <purpose> is "ALTER SEQUENCE".
 
 *Cause:* You attempted to modify the MINVALUE or START WITH values for a sequence in an ALTER SEQUENCE statement but
 this is not allowed.
+
+*Effect:* The operation fails.
+
+*Recovery:* Correct the statement and resubmit.
+
+<<<
+[[SQL-1719]]
+== SQL 1719
+
+```
+Access Type '<access>' is not supported.
+```
+
+Where <access> is an access type you specified in a FOR ACCESS clause.
+
+*Cause:* The access type you specified is not presently supported by {project-name}.
+
+*Effect:* The operation fails.
+
+*Recovery:* Correct the statement and resubmit.
+
+[[SQL-1720]]
+== SQL 1720
+
+```
+Isolation Level '<level>' is not supported.
+```
+
+Where <level> is an isolation level you specified in a SET TRANSACTION ISOLATION LEVEL statement.
+
+*Cause:* The isolation level you specified is not presently supported by {project-name}.
 
 *Effect:* The operation fails.
 


### PR DESCRIPTION
Removed unused messages from the code.

Added messages 1719 and 1720. Added some other DDL messages that snuck in since the last time I visited their range or that I couldn't resolve on my first pass. Tweaked text in a couple of other messages.