### PR TITLE
[TRAFODION-2911] Catalog Api gives wrong values about NON_UNIQUE column

### DIFF
--- a/core/conn/odbc/src/odbc/nsksrvrcore/srvrothers.cpp
+++ b/core/conn/odbc/src/odbc/nsksrvrcore/srvrothers.cpp
@@ -5078,7 +5078,7 @@ odbc_SQLSvc_GetSQLCatalogs_sme_(
                     "cast('%s' as varchar(128)) TABLE_CAT, "
                     "cast(trim(ob_table.SCHEMA_NAME) as varchar(128)) TABLE_SCHEM, "
                     "cast(trim(ob_table.OBJECT_NAME) as varchar(128)) TABLE_NAME, "
-                    "cast(idx.is_unique as smallint) NON_UNIQUE, "
+                    "cast(case when idx.is_unique = 1 then 0 else 1 end as smallint) NON_UNIQUE, "
                     "cast(NULL as varchar(128)) INDEX_QUALIFIER, " // not support
                     "cast(trim(ob.OBJECT_NAME) as varchar(128)) INDEX_NAME, "
                     "cast(3 as smallint) TYPE, " // SQL_INDEX_OTHER

--- a/dcs/src/test/jdbc_test/src/test/java/org/trafodion/jdbc_test/TestGetIndexInfo.java
+++ b/dcs/src/test/jdbc_test/src/test/java/org/trafodion/jdbc_test/TestGetIndexInfo.java
@@ -87,7 +87,7 @@ public class TestGetIndexInfo {
 		IndexInfo[] expIndexInfo = {
 				new IndexInfo("TRAFODION", "SEABASE", INDEX_INFO_TEST_TABLE, false, (String)null, (String)null, (short)0, (short)0, "C1", 0, 3, (short)0, (String)null),
 				new IndexInfo("TRAFODION", "SEABASE", INDEX_INFO_TEST_TABLE, false, (String)null, (String)null, (short)0, (short)0, "C2", 0, 3, (short)0, (String)null),
-				new IndexInfo("TRAFODION", "SEABASE", INDEX_INFO_TEST_TABLE, false, (String)null, INDEX_C1_NAME, (short)3, (short)0, "", 0, 0, (short)0, (String)null)
+				new IndexInfo("TRAFODION", "SEABASE", INDEX_INFO_TEST_TABLE, true, (String)null, INDEX_C1_NAME, (short)3, (short)0, "", 0, 0, (short)0, (String)null)
 		};
 		
 		try {


### PR DESCRIPTION
Table TRAFODION.\"_MD_\".INDEXES only has column "is_unique", but the output column is NON_UNIQUE.