### PR TITLE
[TRAFODION-2913] Tweak some MDAM-related heuristics

### DIFF
--- a/core/sql/optimizer/ScanOptimizer.cpp
+++ b/core/sql/optimizer/ScanOptimizer.cpp
@@ -3124,8 +3124,7 @@ NABoolean ScanOptimizer::canStillConsiderMDAM(const ValueIdSet partKeyPreds,
 					 const ValueIdSet nonKeyColumnSet,
 					 const Disjuncts &curDisjuncts,
 					 const IndexDesc * indexDesc,
-					 const ValueIdSet externalInputs,
-					 NABoolean mdamFlag)
+					 const ValueIdSet externalInputs)
 {
 
   NABoolean canDoMdam = TRUE;
@@ -3135,11 +3134,6 @@ NABoolean ScanOptimizer::canStillConsiderMDAM(const ValueIdSet partKeyPreds,
   // Check whether MDAM can be considered for this node:
   // -----------------------------------------------------------------------
 
-  if(CURRSTMT_OPTDEFAULTS->indexEliminationLevel() != OptDefaults::MINIMUM
-     AND mdamFlag == MDAM_OFF)
-       	canDoMdam = FALSE;
-
-  else
   if (NOT indexDesc->getNAFileSet()->isKeySequenced())
   {
     // -----------------------------------------------------------
@@ -3474,17 +3468,6 @@ ScanOptimizer::getMdamStatus(const FileScan& fileScan
     ActiveControlDB()->getControlTableValue(
       fileScan.getIndexDesc()->getNAFileSet()->getExtFileSetName(), "MDAM");
   if ((val) && (*val == "OFF")) {
-    return ScanForceWildCard::MDAM_OFF;
-  }
-
-  // The Index elimination project added the MdamFlag which can force
-  // MDAM off
-  //
-  if(CURRSTMT_OPTDEFAULTS->indexEliminationLevel() != OptDefaults::MINIMUM
-     AND fileScan.getMdamFlag() == MDAM_OFF 
-	 && (CmpCommon::getDefault(RANGESPEC_TRANSFORMATION) != DF_ON )
-	 )
-  { 
     return ScanForceWildCard::MDAM_OFF;
   }
 
@@ -4166,7 +4149,6 @@ FileScanOptimizer::optimize(SearchKey*& searchKeyPtr   /* out */
        else
        {
 	 ValueIdSet externalInputs = getExternalInputs();
-	 NABoolean mdamFlag = getMdamFlag();
 
 	 if (NOT partKeyPreds.isEmpty())
 	 {
@@ -4174,8 +4156,7 @@ FileScanOptimizer::optimize(SearchKey*& searchKeyPtr   /* out */
 						 nonKeyColumnSet,
 						 *curDisjuncts,
 						 indexDesc,
-						 externalInputs,
-						 mdamFlag);
+						 externalInputs);
 	 }
 	 else
 	 {
@@ -4183,8 +4164,7 @@ FileScanOptimizer::optimize(SearchKey*& searchKeyPtr   /* out */
 						 nonKeyColumnSet,
 						 getDisjuncts(),
 						 indexDesc,
-						 externalInputs,
-						 mdamFlag);
+						 externalInputs);
 	 }
 
        }

--- a/core/sql/optimizer/ScanOptimizer.h
+++ b/core/sql/optimizer/ScanOptimizer.h
@@ -387,8 +387,7 @@ public:
 					 const ValueIdSet nonKeyColumnSet,
 					 const Disjuncts &curDisjuncts,
 					 const IndexDesc * indexDesc,
-					 const ValueIdSet externalInputs,
-					 NABoolean mdamFlag);
+					 const ValueIdSet externalInputs);
 
   // get and set various probing counters for all partitions.
 

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -1877,7 +1877,7 @@ SDDkwd__(ISO_MAPPING,           (char *)SQLCHARSETSTRING_ISO88591),
  // mdam off on open source at this point
   XDDkwd__(MDAM_SCAN_METHOD,			"ON"),
 
-  DDflt0_(MDAM_SELECTION_DEFAULT,		"0.5"),
+  DDflt0_(MDAM_SELECTION_DEFAULT,		"8.0"),
 
   // Overhead charge for a subset in the rewritten MDAM costing code
   DDflt0_(MDAM_SUBSET_FACTOR,                   "8.0"),


### PR DESCRIPTION
There are two changes in this pull request.

1. The default value for CQD MDAM_SELECTION_DEFAULT has been changed from 0.5 to 8.0. This is a recalibration of this default; it had not been changed since predecessor product days. The old value resulted in MDAM not being considered at times when it is the better plan. Details of how this recalibration was done will be documented in the JIRA.

2. The heuristic implemented by IndexDesc::pruneMdam is now limited to index elimination logic and no longer used by the scan optimizer. As a practical matter this was already true in most circumstances: ScanOptimizer::getMdamStatus ignored the mdamFlag when CQD RANGESPEC_TRANSFORMATION is set to 'ON'. (And 'ON' is the default value for that CQD.) The one case when this was not true was if CQD FSO_IN_USE was set to '0'. So, ironically, when the user is trying to encourage MDAM using CQD FSO_IN_USE, we would pay attention to this heuristic that prevents MDAM.

It should be noted that the heuristic in IndexDesc::pruneMdam depends on counting the number of leading columns without a key predicate. It does so without taking into account parallelization, which means it does not see potential equality predicates on a leading "_SALT_" column, which can cause it to reject MDAM when MDAM would be useful. Even so, the heuristic there seems reasonable for narrowing the set of indexes that we might consider so it is still good for index elimination purposes though not perfect. But once an index is being considered, it is better to let the costing code, which does know about parallelization, to have the final word.