### PR TITLE
Trafodion 2916

### DIFF
--- a/core/conn/odb/src/odb.c
+++ b/core/conn/odb/src/odb.c
@@ -2314,7 +2314,6 @@ int main(int ac, char *av[])
             (void)signal(SIGINT, sigcatch);                     /* Keyboard Ctrl-C */
             (void)signal(SIGTERM, sigcatch);                    /* Software termination (kill) */
             WaitForMultipleObjects(i, thhn, TRUE, INFINITE);    /* wait threads */
-            Sleep(1000 * 10);
             for ( i = 0 ; i < tn ; i++)                         /* close thread handles */
                 CloseHandle(thhn[i]);
 #else


### PR DESCRIPTION
**the root cause**:  the allocating size of str is determined by max field length + 128(here is 1500+128), but during loading, str will be filled with actual field data exceeding this size(here maybe 2000 characters) if str overflow the client app will crash. 
**solution**: increase the size of str to the size of one-time fread(default is 262144). there is still a risk of a crash when a user provides an incredibly large size of an invalid field.
**additional fix**: also fix other same type potential bugs in Oload2 and OloadJason.