### PR TITLE
[TRAFODION-2840] Make [first n] with ORDER BY views non-updatable

### DIFF
--- a/core/sql/generator/GenPreCode.cpp
+++ b/core/sql/generator/GenPreCode.cpp
@@ -1604,8 +1604,20 @@ RelExpr * RelRoot::preCodeGen(Generator * generator,
   // can teach optimizer to do this.
   if ((getFirstNRows() != -1) || (getFirstNRowsParam()))
     {
+      // As of JIRA TRAFODION-2840, the binder always adds the FirstN,
+      // except in the case of output rowsets. So, the only time we 
+      // should now be going through this code is a SELECT query using
+      // output rowsets + FirstN + ORDER BY. A follow-on JIRA,
+      // TRAFODION-2924, will take care of that case and delete this code.
+      // (As a matter of design, it is highly undesireable to sometimes
+      // create the FirstN in the Binder and sometimes in the Generator;
+      // that means that any FirstN-related semantic checks in the 
+      // intervening passes will need two completely separate 
+      // implementations.)
+
       RelExpr * firstn = new(generator->wHeap()) FirstN(child(0),
 							getFirstNRows(),
+							needFirstSortedRows(),   
                                                         getFirstNRowsParam());
 
       // move my child's attributes to the firstN node.
@@ -5872,7 +5884,8 @@ RelExpr * GroupByAgg::preCodeGen(Generator * generator,
       && (getFirstNRows() == 1))
     {
       RelExpr * firstnNode = new(generator->wHeap()) FirstN(child(0),
-							    getFirstNRows());
+							    getFirstNRows(),
+							    FALSE /* [any n] is good enough */);
       firstnNode->setEstRowsUsed(getEstRowsUsed());
       firstnNode->setMaxCardEst(getMaxCardEst());
       firstnNode->setInputCardinality(child(0)->getInputCardinality());
@@ -10565,7 +10578,8 @@ RelExpr* PhyPack::preCodeGen(Generator* generator,
   if (getFirstNRows() != -1)
     {
       RelExpr * firstn = new(generator->wHeap()) FirstN(child(0),
-                                                        getFirstNRows());
+                                                        getFirstNRows(),
+                                                        FALSE /* [any n] is good enough */);
 
       // move my child's attributes to the firstN node.
       // Estimated rows will be mine.

--- a/core/sql/optimizer/Inlining.cpp
+++ b/core/sql/optimizer/Inlining.cpp
@@ -3132,7 +3132,7 @@ RelExpr *GenericUpdate::inlineOnlyRIandIMandMVLogging(BindWA *bindWA,
 	{
 	  // create a firstN node to delete N rows.
 	  FirstN * firstn = new(bindWA->wHeap())
-	    FirstN(topNode, topNode->getFirstNRows());
+	    FirstN(topNode, topNode->getFirstNRows(), FALSE /* No ordering requirement */);
 	  firstn->bindNode(bindWA);
 	  if (bindWA->errStatus())
 	    return NULL;
@@ -3314,7 +3314,7 @@ RelExpr *GenericUpdate::inlineAfterOnlyBackbone(BindWA *bindWA,
   {
     // create a firstN node to delete N rows.
     FirstN * firstn = new(bindWA->wHeap())
-      FirstN(topNode, topNode->getFirstNRows());
+      FirstN(topNode, topNode->getFirstNRows(), FALSE /* No ordering requirement */);
     firstn->bindNode(bindWA);
     if (bindWA->errStatus())
       return NULL;
@@ -3429,7 +3429,7 @@ RelExpr *GenericUpdate::inlineAfterOnlyBackboneForUndo(BindWA *bindWA,
     {
       // create a firstN node to delete N rows.
       FirstN * firstn = new(bindWA->wHeap())
-	FirstN(topNode, topNode->getFirstNRows());
+	FirstN(topNode, topNode->getFirstNRows(), FALSE /* No ordering requirement */);
       firstn->bindNode(bindWA);
       if (bindWA->errStatus())
 	return NULL;

--- a/core/sql/optimizer/OptPhysRelExpr.cpp
+++ b/core/sql/optimizer/OptPhysRelExpr.cpp
@@ -15527,36 +15527,15 @@ Context * FirstN::createContextForAChild(Context* myContext,
 
   if (reqdOrder().entries() > 0)
     {
-      // replace our sort requirement with that implied by our ORDER BY clause
-
-      rg.removeSortKey();
-
-      ValueIdList sortKey;
-      sortKey.insert(reqdOrder());
+      // add our sort requirement as implied by our ORDER BY clause
 
       // Shouldn't/Can't add a sort order type requirement
       // if we are in DP2
       if (rppForMe->executeInDP2())
-        rg.addSortKey(sortKey,NO_SOT);
+        rg.addSortKey(reqdOrder(),NO_SOT);
       else
-        rg.addSortKey(sortKey,ESP_SOT);
+        rg.addSortKey(reqdOrder(),ESP_SOT);
     }
-
-  if (NOT pws->isEmpty())
-  {
-    const Context* childContext = pws->getLatestChildContext();
-
-    // ------------------------------------------------------------------
-    // Cost limit exceeded or got no solution? Give up since we only
-    // try one plan.
-    // ------------------------------------------------------------------
-    if(NOT (childContext AND childContext->hasOptimalSolution()))
-      return NULL;
-
-    if (NOT pws->isLatestContextWithinCostLimit())
-      return NULL;
-
-  }
 
   if (NOT rg.checkFeasibility())
     return NULL;

--- a/core/sql/optimizer/RelExpr.cpp
+++ b/core/sql/optimizer/RelExpr.cpp
@@ -11651,12 +11651,14 @@ RelExpr * FirstN::copyTopNode(RelExpr *derivedNode,
   FirstN *result;
 
   if (derivedNode == NULL) {
-    result = new (outHeap) FirstN(NULL, getFirstNRows(), getFirstNRowsParam(),
+    result = new (outHeap) FirstN(NULL, getFirstNRows(), isFirstN(), getFirstNRowsParam(),
                                   outHeap);
     result->setCanExecuteInDp2(canExecuteInDp2());
   }
   else
     result = (FirstN *) derivedNode;
+
+  result->reqdOrder().insert(reqdOrder());
 
   return RelExpr::copyTopNode(result, outHeap);
 }

--- a/core/sql/optimizer/RelMisc.h
+++ b/core/sql/optimizer/RelMisc.h
@@ -1600,12 +1600,14 @@ class FirstN : public RelExpr
 public:
  FirstN(RelExpr * child,
         Int64 firstNRows,
+        NABoolean isFirstN,
         ItemExpr * firstNRowsParam = NULL,
         CollHeap *oHeap = CmpCommon::statementHeap())
    : RelExpr(REL_FIRST_N, child, NULL, oHeap),
     firstNRows_(firstNRows),
     firstNRowsParam_(firstNRowsParam),
-    canExecuteInDp2_(FALSE)
+    canExecuteInDp2_(FALSE),
+    isFirstN_(isFirstN)
     {
       setNonCacheable();
     };
@@ -1613,6 +1615,12 @@ public:
   // sets the canExecuteInDp2 flag for the [LAST 1] operator
   // of an MTS delete and calls the base class implementation of bindNode.
   virtual RelExpr* bindNode(BindWA* bindWA);
+
+  // takes care of any ordering requirement on the child
+  virtual Context* createContextForAChild(Context* myContext,
+                     PlanWorkSpace* pws,
+                     Lng32& childIndex);
+
   //
   // Physical properties implemented in OptPhysRelExpr.cpp
   //
@@ -1650,11 +1658,20 @@ public:
   NABoolean canExecuteInDp2() const             { return canExecuteInDp2_; }
   virtual NABoolean computeRowsAffected()   const ;
 
+  NABoolean isFirstN()                          { return isFirstN_; }
+
+  ValueIdList & reqdOrder()                     { return reqdOrder_; }
+
 private:
   // Otherwise, return firstNRows_ at runtime.
   Int64 firstNRows_;
   ItemExpr * firstNRowsParam_;
   NABoolean canExecuteInDp2_;
+  NABoolean isFirstN_;  // TRUE if [first n], FALSE if [any n] or [last n]
+
+  // Optional ORDER BY to force ordering before applying First N; populated
+  // at normalizeNode time.
+  ValueIdList reqdOrder_;
 
 }; // class FirstN
 


### PR DESCRIPTION
JIRA TRAFODION-2822 attempted to make views containing [first n] in the select list non-updatable. It missed one case, the case where both [first n] and ORDER BY are present in the view definition.

The reason it missed that case is because of a design oddity in how [first n] is implemented. When there is no ORDER BY clause, the Binder pass introduces a FirstN node into the query tree. But if an ORDER BY is present, it defers doing this to the Generator. That means any FirstN-related semantic checks in earlier passes will not be applied when ORDER BY is present.

This set of changes refactors the FirstN implementation a little bit so that the FirstN can be introduced in the Binder when ORDER BY is present. Then the check added in JIRA TRAFODION-2822 will apply, and such views will be marked non-updatable as desired.

The refactored design copies a bound and transformed version of the ORDER BY clause into the FirstN node at Normalize time. (Aside: I tried copying the unbound ORDER BY tree into the FirstN node at Bind time initially, but this fails if there are expressions in the select list referenced by the ORDER BY; different ValueIds get assigned to parts of the expressions than in the original resulting in expression coverage check failures at Optimize time.)

The refactored design has been implemented for all code paths that are involved in view definition, which is all that is required to satisfy this JIRA. However, there is another code path that hasn't been addressed: If a query uses output rowsets, has [first n] + ORDER BY, then the FirstN is still added in the Generator. I took a look at fixing this one too, but it proved more tedious than I wanted to tackle just now. A follow-on JIRA, TRAFODION-2924, has been written to track that case.

In addition, I noticed some code paths that use [first n] today that do not work correctly. The parser supports [first n] syntax on UPDATE and DELETE statements. But I discovered (even before my changes) that UPDATE ignores its [first n] specification. And if [first n] is specified for DELETE, the query fails with a compiler error 2235 (cannot produce plan). So those evidently are incomplete features, or features that broke sometime in the past and no-one noticed until now.