### PR TITLE
TRAFODION-2932 ConnectionTimeout value for jdbc cannot lager than 32768

### DIFF
--- a/core/conn/jdbcT4/src/main/java/org/trafodion/jdbc/t4/T4Properties.java
+++ b/core/conn/jdbcT4/src/main/java/org/trafodion/jdbc/t4/T4Properties.java
@@ -1292,6 +1292,11 @@ public class T4Properties {
 	 * @see #setServerDataSource(String)
 	 */
 	void setConnectionTimeout(int connectionTimeout) {
+        if (connectionTimeout > Short.MAX_VALUE) {
+            sqlExceptionMessage_ = "Incorrect value for connectionTimeout set: [" + connectionTimeout
+                    + "]. Max value is: [" + Short.MAX_VALUE + "]";
+        }
+
 		if (connectionTimeout < 0) {
 			/*
 			 * sqlExceptionMessage_ = "Incorrect value for connectionTimeout


### PR DESCRIPTION
if the given value is 32768 throw err msg : org.trafodion.jdbc.t4.TrafT4Exception: Invalid connection property setting: Incorrect value for connectionTimeout set: [40001]. Max value is: [32767]