### PR TITLE
[TRAFODION-2912] Better handling of non-deterministic scalar UDFs

### DIFF
--- a/core/sql/optimizer/NormItemExpr.cpp
+++ b/core/sql/optimizer/NormItemExpr.cpp
@@ -949,7 +949,8 @@ void UDFunction::transformToRelExpr(NormWA & normWARef,
 
        // The routine desc points to both the NARoutine structs.
        isUdf->setRoutineDesc(udfDesc_);
-    
+       isUdf->getGroupAttr()->setHasNonDeterministicUDRs(
+            !getRoutineDesc()->getEffectiveNARoutine()->isDeterministic());
 
        // Get the valueIds of the parameters
        isUdf->gatherParamValueIds(isUdf->getProcAllParamsTree(), 

--- a/core/sql/regress/udr/EXPECTED103
+++ b/core/sql/regress/udr/EXPECTED103
@@ -209,6 +209,68 @@ CREATE LIBRARY TRAFODION.UDR103SCH.FUNCTIONSFORTEST103 FILE '/mnt2/ansharma/ansh
 
 --- SQL operation complete.
 >>
+>>create function nonDeterministicRandom
++>  () returns (r integer)
++>  language c parameter style sql external name 'nonDeterministicRandom'
++>  library functionsForTest103
++>  not deterministic no sql final call allow any parallelism state area size 1024 ;
+
+--- SQL operation complete.
+>>
+>>cqd nested_joins 'off';
+
+--- SQL operation complete.
+>>cqd merge_joins 'off';
+
+--- SQL operation complete.
+>>cqd join_order_by_user 'on';
+
+--- SQL operation complete.
+>>prepare s from
++>select a, nonDeterministicRandom() r1,
++>       generateRandomNumber(a, 4) r2, generateRandomNumber(123, 4) r3
++>from (values (1), (2), (3)) T(a);
+
+--- SQL command prepared.
+>>explain options 'f' s;
+
+LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
+---- ---- ---- --------------------  --------  --------------------  ---------
+
+8    .    9    root                                                  3.00E+000
+7    1    8    hybrid_hash_join                                      3.00E+000
+4    6    7    nested_join                                           3.00E+000
+5    .    6    probe_cache                                           1.00E+000
+.    .    5    isolated_scalar_udf             GENERATERANDOMNUMBER  1.00E+000
+2    3    4    nested_join                                           3.00E+000
+.    .    3    isolated_scalar_udf             NONDETERMINISTICRAND  1.00E+000
+.    .    2    tuplelist                                             3.00E+000
+.    .    1    isolated_scalar_udf             GENERATERANDOMNUMBER  1.00E+000
+
+--- SQL operation complete.
+>>-- r1: Nested join, no probe cache, because it's non-deterministic
+>>-- r2: Nested join, probe cache, because it refers to the outer table
+>>-- r3: Hash join, because it's deterministic, no refs to outer
+>>execute s;
+
+A       R1           R2              R3            
+------  -----------  --------------  --------------
+
+     1          555  3675            3330          
+     2          316  1985            3330          
+     3          209  6580            3330          
+
+--- 3 row(s) selected.
+>>cqd nested_joins reset;
+
+--- SQL operation complete.
+>>cqd merge_joins reset;
+
+--- SQL operation complete.
+>>cqd join_order_by_user reset;
+
+--- SQL operation complete.
+>>
 >>-- procedures
 >>create procedure updateSubscriptions(
 +>  IN operation char(20),
@@ -398,6 +460,68 @@ CREATE LIBRARY TRAFODION.UDR103SCH.FUNCTIONSFORTEST103 FILE '/mnt2/ansharma/ansh
 
 --- SQL operation complete.
 >>
+>>create function nonDeterministicRandom
++>  () returns (r integer)
++>  language c parameter style sql external name 'nonDeterministicRandom'
++>  library functionsForTest103
++>  not deterministic no sql final call allow any parallelism state area size 1024 ;
+
+--- SQL operation complete.
+>>
+>>cqd nested_joins 'off';
+
+--- SQL operation complete.
+>>cqd merge_joins 'off';
+
+--- SQL operation complete.
+>>cqd join_order_by_user 'on';
+
+--- SQL operation complete.
+>>prepare s from
++>select a, nonDeterministicRandom() r1,
++>       generateRandomNumber(a, 4) r2, generateRandomNumber(123, 4) r3
++>from (values (1), (2), (3)) T(a);
+
+--- SQL command prepared.
+>>explain options 'f' s;
+
+LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
+---- ---- ---- --------------------  --------  --------------------  ---------
+
+8    .    9    root                                                  3.00E+000
+7    1    8    hybrid_hash_join                                      3.00E+000
+4    6    7    nested_join                                           3.00E+000
+5    .    6    probe_cache                                           1.00E+000
+.    .    5    isolated_scalar_udf             GENERATERANDOMNUMBER  1.00E+000
+2    3    4    nested_join                                           3.00E+000
+.    .    3    isolated_scalar_udf             NONDETERMINISTICRAND  1.00E+000
+.    .    2    tuplelist                                             3.00E+000
+.    .    1    isolated_scalar_udf             GENERATERANDOMNUMBER  1.00E+000
+
+--- SQL operation complete.
+>>-- r1: Nested join, no probe cache, because it's non-deterministic
+>>-- r2: Nested join, probe cache, because it refers to the outer table
+>>-- r3: Hash join, because it's deterministic, no refs to outer
+>>execute s;
+
+A       R1           R2              R3            
+------  -----------  --------------  --------------
+
+     1          555  3675            3330          
+     2          316  1985            3330          
+     3          209  6580            3330          
+
+--- 3 row(s) selected.
+>>cqd nested_joins reset;
+
+--- SQL operation complete.
+>>cqd merge_joins reset;
+
+--- SQL operation complete.
+>>cqd join_order_by_user reset;
+
+--- SQL operation complete.
+>>
 >>-- procedures
 >>create procedure updateSubscriptions(
 +>  IN operation char(20),
@@ -427,6 +551,7 @@ Functions in Schema TRAFODION.UDR103SCH
 CANACCESSVIEW
 GENERATEPHONENUMBER
 GENERATERANDOMNUMBER
+NONDETERMINISTICRANDOM
 
 --- SQL operation complete.
 >>get procedures in schema udr103sch;

--- a/core/sql/regress/udr/TEST103
+++ b/core/sql/regress/udr/TEST103
@@ -225,6 +225,28 @@ create function generateRandomNumber
   library functionsForTest103
   deterministic no sql final call allow any parallelism state area size 1024 ;
 
+create function nonDeterministicRandom
+  () returns (r integer)
+  language c parameter style sql external name 'nonDeterministicRandom'
+  library functionsForTest103
+  not deterministic no sql final call allow any parallelism state area size 1024 ;
+
+cqd nested_joins 'off';
+cqd merge_joins 'off';
+cqd join_order_by_user 'on';
+prepare s from
+select a, nonDeterministicRandom() r1,
+       generateRandomNumber(a, 4) r2, generateRandomNumber(123, 4) r3
+from (values (1), (2), (3)) T(a);
+explain options 'f' s;
+-- r1: Nested join, no probe cache, because it's non-deterministic
+-- r2: Nested join, probe cache, because it refers to the outer table
+-- r3: Hash join, because it's deterministic, no refs to outer
+execute s;
+cqd nested_joins reset;
+cqd merge_joins reset;
+cqd join_order_by_user reset;
+
 -- procedures
 create procedure updateSubscriptions(
   IN operation char(20),

--- a/core/sql/regress/udr/TEST103_functions.cpp
+++ b/core/sql/regress/udr/TEST103_functions.cpp
@@ -139,12 +139,11 @@ SQLUDR_LIBFUNC SQLUDR_INT32 nonDeterministicRandom(SQLUDR_INT32 *out1,
       *my_state = 555;
     }
   else
-    // Use a simple linear congruential generator, we
-    // want deterministic regression results, despite
-    // the name of this function. Note that a
-    // this UDF is still "not deterministic", since it
-    // returns different results when called with the
-    // same (empty) inputs.
+    // Use a simple linear congruential generator, we want
+    // deterministic regression results, despite the name of this
+    // function. Note that this UDF is still "not deterministic",
+    // since it returns different results when called with the same
+    // (empty) inputs.
     *my_state = (13 * (*my_state) + 101) % 1000;
 
   (*out1) = *my_state;


### PR DESCRIPTION
Fix some issues found by Andy Yang and others while writing a
non-deterministic scalar UDF (a random generator in this case).

This UDF was transformed into a hash join, which executes the UDF
only once and not once per row. Another problem is the probe cache,
which can also lead to a single execution instead of once per row.

The fix records the non-deterministic UDF attribute in the group
attributes and it adds checks in the normalizer to suppress the
conversion from a TSJ to a non-TSJ when non-deterministic UDFs are
present. The probe cache logic already had this check, so all that was
needed was to set the attribute.

Note that there may be some more complex queries where we still won't
execute the UDF once per row. In general, there is no absolute
guarantee that a non-deterministic scalar UDF is executed once per row
(of the cartesian product of all the tables joined??). However, in
simple cases like the added test we should try to call the UDF for
every row that satisfies the join predicates.