### PR TITLE
fix TRAFODION-2931 call udf function on chinese character will cause…

### DIFF
--- a/core/sql/parser/sqlparser.y
+++ b/core/sql/parser/sqlparser.y
@@ -8333,8 +8333,15 @@ user_defined_scalar_function : user_defined_function_name '(' udr_value_expressi
             = ParScannedTokens->getScannedTokenInfo(0);
         Int32 pos = tokInfo.tokenStrPos - tokInfo.tokenStrOffset +
                     tokInfo.tokenStrLen;
-        NAString *input = unicodeToChar(&inputStr[0], pos, (long) SqlParser_ISO_MAPPING,
-                                         PARSERHEAP());
+        //TRAFODION-2931
+	//Chinese character of inputStr will cause core dump
+        //NAString *input = unicodeToChar(&inputStr[0], pos, (long) SqlParser_ISO_MAPPING,
+        //                                 PARSERHEAP());
+        NAString *input = unicodeToChar(&inputStr[0],
+                                        pos,
+                                        (CharInfo::CharSet) (ComGetNameInterfaceCharSet()),
+                                        PARSERHEAP());
+        //TRAFODION-2931
         char *inputC = new (PARSERHEAP()) char[pos+1];
         strncpy(inputC, input->data(), pos+1);
         delete input;


### PR DESCRIPTION
select char_lentgh('中国人') from (values(1));

will cause sqlci core dump.

use ISO88591 will cause unicodeToChar failure and *input will be null.

so here use utf-8