### PR TITLE
[TRAFODION-2939] odb copied data exceeds the max size specified by max option when copying data from oracle to Trafodion

### DIFF
--- a/core/conn/odb/src/odb.c
+++ b/core/conn/odb/src/odb.c
@@ -5491,7 +5491,7 @@ static void etabadd(char type, char *run, int id)
                     }
                 } else {                            /* not a load job */
                     etab[no].k = no;                /* record grandparent for copy/diff ops */
-                    if ( etab[no].ps ){
+                    if ( etab[no].ps > 1 ){
                         etab[no].TotalMaxRecords = etab[no].mr;
                         etab[no].mr /= etab[no].ps; /* each thread will get a portion of the max record to fetch */
                         if (etab[0].r > etab[0].mr) /* rowset size should not exceeds the max size */

--- a/core/conn/odb/src/odb.c
+++ b/core/conn/odb/src/odb.c
@@ -5494,6 +5494,8 @@ static void etabadd(char type, char *run, int id)
                     if ( etab[no].ps ){
                         etab[no].TotalMaxRecords = etab[no].mr;
                         etab[no].mr /= etab[no].ps; /* each thread will get a portion of the max record to fetch */
+                        if (etab[0].r > etab[0].mr) /* rowset size should not exceeds the max size */
+                            etab[0].r = etab[0].mr;
                     }
                     strmcpy(tabn, etab[no].src, sizeof(tabn));
                     if ( !SQL_SUCCEEDED(Oret=SQLAllocHandle(SQL_HANDLE_STMT, Oc, &Os))){


### PR DESCRIPTION
**root cause:** max rows were divided into each thread may cause etab[eid].mr < etab[eid].r, so even only one-time fetch, the actual fetched rows will exceed max row of each thread.
**fixed by:** limit etab[eid].r less or equal to etab[eid].mr.