### PR TITLE
[TRAFODION-2727] Memory leak in the compiler part of the code in Traf…

### DIFF
--- a/core/sql/arkcmp/CmpConnection.cpp
+++ b/core/sql/arkcmp/CmpConnection.cpp
@@ -349,7 +349,7 @@ void ExCmpMessage::actOnReceive(IpcConnection* )
           // The number of NAMemory objects that reside in SYSTEM_MEMORY
           // is currently restricted to one at a time--see explanation in
           // NAMemory.h.
-          cmpStatement = new CTXTHEAP CmpStatement(cmpContext_, 0, NAMemory::SYSTEM_MEMORY);
+          cmpStatement = new CTXTHEAP CmpStatement(cmpContext_);
           CmpMessageSQLText sqltext(NULL,0,CTXTHEAP,SQLCHARSETCODE_UNKNOWN,
                                     (CmpMessageObj::MessageTypeEnum)typ);
           receiveAndSetUp(this, sqltext);
@@ -388,7 +388,7 @@ void ExCmpMessage::actOnReceive(IpcConnection* )
 
       case (CmpMessageObj::DDL) :
         {
-          cmpStatement = new CTXTHEAP CmpStatement(cmpContext_, 0, NAMemory::SYSTEM_MEMORY);
+          cmpStatement = new CTXTHEAP CmpStatement(cmpContext_);
           CmpMessageDDL statement(NULL, 0, CTXTHEAP);
 	  receiveAndSetUp(this, statement);
           cmpStatement->process(statement);
@@ -397,7 +397,7 @@ void ExCmpMessage::actOnReceive(IpcConnection* )
 
       case (CmpMessageObj::DESCRIBE) :
         {
-          cmpStatement = new CTXTHEAP CmpStatement(cmpContext_, 0, NAMemory::SYSTEM_MEMORY);
+          cmpStatement = new CTXTHEAP CmpStatement(cmpContext_);
           CmpMessageDescribe statement(NULL, 0, CTXTHEAP);
 	  receiveAndSetUp(this, statement);
           cmpStatement->process(statement);
@@ -433,7 +433,7 @@ void ExCmpMessage::actOnReceive(IpcConnection* )
 
       case (CmpMessageObj::DDL_WITH_STATUS) :
         {
-          cmpStatement = new CTXTHEAP CmpStatement(cmpContext_, 0, NAMemory::SYSTEM_MEMORY);
+          cmpStatement = new CTXTHEAP CmpStatement(cmpContext_);
           CmpMessageDDLwithStatus statement(NULL, 0, CTXTHEAP);
 	  receiveAndSetUp(this, statement);
           cmpStatement->process(statement);

--- a/core/sql/arkcmp/CmpStatement.h
+++ b/core/sql/arkcmp/CmpStatement.h
@@ -86,8 +86,7 @@ public:
   // memoryType parameter is ignored 
   CmpStatement(
       CmpContext*,
-      NAMemory* outHeap = 0,
-      NAMemory::NAMemoryType memoryType=NAMemory::DERIVED_MEMORY);
+      NAMemory *outHeap = NULL);
   
   // requests process
   ReturnStatus process(const CmpMessageObj&);
@@ -253,6 +252,11 @@ protected:
 
   // The reply to be sent back to executor after processing the request in CmpStatement
   CmpMessageReply* reply_;
+
+  // The result of Compile for statements like invoke, get tables, show stats
+  // that calls CmpDescribe internally immediately after compilation.
+
+  CmpMessageReply *bound_;
 
   // The flag to record whether exception has been raised in the
   // statement compilation/execution. This is used to clean up properly once the 

--- a/core/sql/optimizer/Rule.cpp
+++ b/core/sql/optimizer/Rule.cpp
@@ -394,6 +394,8 @@ RuleSet::~RuleSet()
 {
   for (Lng32 i = 0; i < (Lng32)allRules_.entries(); i++)
     delete allRules_[i];
+  for (Lng32 i = 0; i < (Lng32)passNRules_.entries(); i++)
+    delete passNRules_[i];
 }
 
 void RuleSet::insert(Rule * r)


### PR DESCRIPTION
…odion

It was found that CmpMessageReplyCode was not getting deleted at all times.
But, the handling of CmpMessageDescribe messages in the compiler code has some
mysterious issue that corrupts the memory causing unpredictable behavior when
CmpMessageReplyCode is deleted.  To circumvent this problem, the CmpStatement heap
is used for embedded compiler to allocate CmpMessageReplyCode and the Context heap
is used in case of standalone compiler. The handling of CmpMessageDescribe will
continue to leak memory in standalone compiler.