### PR TITLE
TRAFODION-2962 : Enable LDAP authentication flag at install time

### DIFF
--- a/install/python-installer/scripts/traf_ldap.py
+++ b/install/python-installer/scripts/traf_ldap.py
@@ -69,7 +69,7 @@ def run():
     #    err('Failed to access LDAP server with user %s' % db_root_user)
 
     print 'Modfiy sqenvcom.sh to turn on authentication'
-    mod_file(sqenv_file, {'TRAFODION_ENABLE_AUTHENTICATION=NO':'TRAFODION_ENABLE_AUTHENTICATION=YES'})
+    mod_file(sqenv_file, {'TRAFODION_ENABLE_AUTHENTICATION=.*':'TRAFODION_ENABLE_AUTHENTICATION=YES'})
 
 # main
 try:


### PR DESCRIPTION
Fix the code that sets the TRAF_AUTHENTICATION flag to YES if LDAP is enabled.