### PR TITLE
[TRAFODION-2967] Fix CommonLogger::buildMsgBuffer core in UPDATE STATS

### DIFF
--- a/core/sql/ustat/hs_log.cpp
+++ b/core/sql/ustat/hs_log.cpp
@@ -307,7 +307,7 @@ void HSLogMan::Log(const char *data)
   {
     if (logNeeded_)
       {
-        QRLogger::log(CAT_SQL_USTAT, LL_INFO, data);
+        QRLogger::log(CAT_SQL_USTAT, LL_INFO, "%s", data);
       }
   }
 


### PR DESCRIPTION
Instead of passing raw data as a message template to the logging layers, pass "%s", and then pass the raw data as a parameter. That prevents misinterpretation of substrings that look like printf format strings, avoiding cores.