### PR TITLE
[TRAFODION-2969] Fix interaction of [first n] etc. with subqueries

### DIFF
--- a/core/sql/optimizer/BindRelExpr.cpp
+++ b/core/sql/optimizer/BindRelExpr.cpp
@@ -6094,10 +6094,10 @@ RelExpr *RelRoot::bindNode(BindWA *bindWA)
   if (prevScope)
     inRowSubquery = prevScope->context()->inRowSubquery();
 
-  NABoolean GroupByAggNodeAdded = FALSE;
+  NABoolean groupByAggNodeAdded = FALSE;
   if (inRowSubquery && (CmpCommon::getDefault(COMP_BOOL_137) == DF_OFF))
     // force adding one row aggregates in the [last 0] case
-    GroupByAggNodeAdded = addOneRowAggregates(bindWA, 
+    groupByAggNodeAdded = addOneRowAggregates(bindWA, 
                             getFirstNRows() == -2 /* [last 0] case */);
 
   returnedRoot = 
@@ -6690,7 +6690,7 @@ RelExpr *RelRoot::bindNode(BindWA *bindWA)
           // to force the aggregates to become NULL. Adding a one-row 
           // aggregate group on top of the scalar aggregate, with the FirstN
           // node in between them does the trick.
-          if (GroupByAggNodeAdded &&
+          if (groupByAggNodeAdded &&
                ( (getFirstNRows() == 1) ||   // [first 1] or [any 1]
                  (getFirstNRows() == -2) ||  // [last 0]
                  (getFirstNRows() == -3) ) ) // [last 1]
@@ -6698,9 +6698,9 @@ RelExpr *RelRoot::bindNode(BindWA *bindWA)
               nodeToInsertUnder = child(0);
               CMPASSERT(nodeToInsertUnder->getOperatorType() == REL_GROUPBY);             
             }
-          else if (!GroupByAggNodeAdded && (getFirstNRows() == -2))  // [last 0]
+          else if (!groupByAggNodeAdded && (getFirstNRows() == -2))  // [last 0]
             {
-              CMPASSERT(GroupByAggNodeAdded);  // a GroupByAgg should have been forced
+              CMPASSERT(groupByAggNodeAdded);  // a GroupByAgg should have been forced
             }
           else  // a case where we can throw the [first/any/last N] away
             {

--- a/core/sql/optimizer/BindRelExpr.cpp
+++ b/core/sql/optimizer/BindRelExpr.cpp
@@ -6094,8 +6094,11 @@ RelExpr *RelRoot::bindNode(BindWA *bindWA)
   if (prevScope)
     inRowSubquery = prevScope->context()->inRowSubquery();
 
+  NABoolean GroupByAggNodeAdded = FALSE;
   if (inRowSubquery && (CmpCommon::getDefault(COMP_BOOL_137) == DF_OFF))
-      addOneRowAggregates(bindWA);
+    // force adding one row aggregates in the [last 0] case
+    GroupByAggNodeAdded = addOneRowAggregates(bindWA, 
+                            getFirstNRows() == -2 /* [last 0] case */);
 
   returnedRoot = 
     transformGroupByWithOrdinalPhase2(bindWA);
@@ -6665,36 +6668,79 @@ RelExpr *RelRoot::bindNode(BindWA *bindWA)
   if ((getFirstNRows() != -1) ||
        (getFirstNRowsParam()))
     {
-      // create a firstN node to retrieve firstN rows.
-      FirstN * firstn = new(bindWA->wHeap())
-        FirstN(child(0), getFirstNRows(), needFirstSortedRows(), getFirstNRowsParam());   
+      // [first/any/last N] processing
 
-      firstn->bindNode(bindWA);
-      if (bindWA->errStatus())
-        return NULL;
+      RelExpr * nodeToInsertUnder = this;
+      if (inRowSubquery)
+        {
+          // [first/any/last N] in a row subquery special case
+          //
+          // In this case, if N > 1 it is first/any N, and we can simply
+          // ignore that as row subqueries already enforce an at-most-one
+          // row semantic. For [first 1], [last 1], [last 0], we need to
+          // add the node below any one-row aggregate group by node created
+          // earlier in this method. (If it put it above that group by node,
+          // that is too late; the one-row aggregate will raise an 8401 error
+          // before our FirstN node has a chance to narrow the result down to
+          // zero or one rows.) There is an interesting nuance with [last 0]:
+          // We forced the addition of a one-row aggregate group by node
+          // in that case, because [last 0] returns no rows. We might have
+          // a scalar aggregate subquery which ordinarily would not require
+          // a one-row aggregate group, but when [last 0] is present we want
+          // to force the aggregates to become NULL. Adding a one-row 
+          // aggregate group on top of the scalar aggregate, with the FirstN
+          // node in between them does the trick.
+          if (GroupByAggNodeAdded &&
+               ( (getFirstNRows() == 1) ||   // [first 1] or [any 1]
+                 (getFirstNRows() == -2) ||  // [last 0]
+                 (getFirstNRows() == -3) ) ) // [last 1]
+            {
+              nodeToInsertUnder = child(0);
+              CMPASSERT(nodeToInsertUnder->getOperatorType() == REL_GROUPBY);             
+            }
+          else if (!GroupByAggNodeAdded && (getFirstNRows() == -2))  // [last 0]
+            {
+              CMPASSERT(GroupByAggNodeAdded);  // a GroupByAgg should have been forced
+            }
+          else  // a case where we can throw the [first/any/last N] away
+            {
+              nodeToInsertUnder = NULL;
+            }
+        }
+          
+      if (nodeToInsertUnder)
+        {
+          // create a firstN node to retrieve firstN rows.
+          FirstN * firstn = new(bindWA->wHeap())
+            FirstN(nodeToInsertUnder->child(0), getFirstNRows(), needFirstSortedRows(), getFirstNRowsParam());   
 
-      // Note: For ORDER BY + [first n], we want to sort the rows before 
-      // picking just n of them. (We don't do this for [any n].) We might
-      // be tempted to copy the orderByTree into the FirstN node at this
-      // point, but this doesn't work. Instead, we copy the bound ValueIds
-      // at normalize time. We have to do this in case there are expressions
-      // involved in the ORDER BY and there is a DESC. The presence of the
-      // Inverse node at the top of the expression tree seems to cause the
-      // expressions underneath to be bound to different ValueIds, which 
-      // causes coverage tests in FirstN::createContextForAChild requirements
-      // generation to fail. An example of where this occurs is:
-      //
-      // prepare s1 from
-      //   select [first 2] y, x from
-      //    (select a,b + 26 from t1) as t(x,y)
-      //   order by y desc;
-      //
-      // If we copy the ORDER BY ItemExpr tree and rebind, we get a different
-      // ValueId for the expression b + 26 in the child characteristic outputs
-      // than what we get for the child of Inverse in Inverse(B + 26). The
-      // trick of copying the already-bound ORDER BY clause later avoids this.
+          firstn->bindNode(bindWA);
+          if (bindWA->errStatus())
+            return NULL;
 
-      setChild(0, firstn);
+          // Note: For ORDER BY + [first n], we want to sort the rows before 
+          // picking just n of them. (We don't do this for [any n].) We might
+          // be tempted to copy the orderByTree into the FirstN node at this
+          // point, but this doesn't work. Instead, we copy the bound ValueIds
+          // at normalize time. We have to do this in case there are expressions
+          // involved in the ORDER BY and there is a DESC. The presence of the
+          // Inverse node at the top of the expression tree seems to cause the
+          // expressions underneath to be bound to different ValueIds, which 
+          // causes coverage tests in FirstN::createContextForAChild requirements
+          // generation to fail. An example of where this occurs is:
+          //
+          // prepare s1 from
+          //   select [first 2] y, x from
+          //    (select a,b + 26 from t1) as t(x,y)
+          //   order by y desc;
+          //
+          // If we copy the ORDER BY ItemExpr tree and rebind, we get a different
+          // ValueId for the expression b + 26 in the child characteristic outputs
+          // than what we get for the child of Inverse in Inverse(B + 26). The
+          // trick of copying the already-bound ORDER BY clause later avoids this.
+
+          nodeToInsertUnder->setChild(0, firstn);
+        }
 
       // reset firstN indication in the root node.
       setFirstNRows(-1);

--- a/core/sql/optimizer/RelExpr.cpp
+++ b/core/sql/optimizer/RelExpr.cpp
@@ -11390,7 +11390,7 @@ void RelRoot::setMvBindContext(MvBindContext * pMvBindContext)
 
 NABoolean RelRoot::addOneRowAggregates(BindWA* bindWA, NABoolean forceGroupByAgg)
 {
-  NABoolean GroupByAggNodeAdded = FALSE;
+  NABoolean groupByAggNodeAdded = FALSE;
   RelExpr * childOfRoot = child(0);
   GroupByAgg *aggNode = NULL;
   // If the One Row Subquery is already enforced by a scalar aggregate
@@ -11426,7 +11426,7 @@ NABoolean RelRoot::addOneRowAggregates(BindWA* bindWA, NABoolean forceGroupByAgg
 
     }
   if (aggNode)
-    return GroupByAggNodeAdded;
+    return groupByAggNodeAdded;
 
   const RETDesc *oldTable = getRETDesc();
   RETDesc *resultTable = new(bindWA->wHeap()) RETDesc(bindWA);
@@ -11474,12 +11474,12 @@ NABoolean RelRoot::addOneRowAggregates(BindWA* bindWA, NABoolean forceGroupByAgg
 
   newGrby->bindNode(bindWA) ;
   child(0) = newGrby ;
-  GroupByAggNodeAdded = TRUE;
+  groupByAggNodeAdded = TRUE;
   // Set the return descriptor
   //
   setRETDesc(resultTable);
 
-  return GroupByAggNodeAdded;
+  return groupByAggNodeAdded;
 }
 // -----------------------------------------------------------------------
 // member functions for class PhysicalRelRoot

--- a/core/sql/optimizer/RelMisc.h
+++ b/core/sql/optimizer/RelMisc.h
@@ -521,7 +521,8 @@ public:
   // defined in generator/GenRelMisc.cpp
   TrafQuerySimilarityInfo * genSimilarityInfo(Generator *generator);
 
-  void addOneRowAggregates(BindWA * bindWA);
+  // returns TRUE if a GroupByAgg node was added
+  NABoolean addOneRowAggregates(BindWA * bindWA, NABoolean forceGroupByAgg);
 
   inline void setNumBMOs(unsigned short num) { numBMOs_ = num; }
   inline unsigned short getNumBMOs() { return numBMOs_; }

--- a/core/sql/regress/core/EXPECTED002.LINUX
+++ b/core/sql/regress/core/EXPECTED002.LINUX
@@ -21,6 +21,13 @@
 --- SQL operation complete.
 >>#ifMX
 >>
+>>create table t002main (a int not null, b int, primary key (a));
+
+--- SQL operation complete.
+>>create table t002sub  (x int not null, y int, primary key (x));
+
+--- SQL operation complete.
+>>
 >>?section dml
 >>-- INSERT queries
 >>insert into t002t1 values (10, 'abc', 20, 'xy');
@@ -47,6 +54,13 @@
 
 --- 2 row(s) inserted.
 >>#ifMX
+>>
+>>insert into t002main values (1,1);
+
+--- 1 row(s) inserted.
+>>insert into t002sub values (1,1), (2,1);
+
+--- 2 row(s) inserted.
 >>
 >>?section subqtests
 >>-- Expect 2 identical rows saying "2 2";
@@ -464,22 +478,16 @@ A            AMAX         B                   BMAX                C            C
 >>
 >>
 >>------------------------------------------------------------------------
->>?section Genesis_10_000222_6892_p1
->>SELECT 1 FROM T002T3 T1
-+>GROUP BY T1.A
-+>HAVING T1.A >ANY
-+>  ( SELECT 2 FROM T002T1 T2
-+>    WHERE T2.C >SOME
-+>      ( SELECT AVG (T1.A) FROM T002T1 T3 )
-+>  );
-
-(EXPR)
-------
-
-     1
-     1
-
---- 2 row(s) selected.
+>>-- This test disabled since it is non -deterministic.
+>>-- It will be enabled after further investigation.
+>>-- ?section Genesis_10_000222_6892_p1
+>>-- SELECT 1 FROM T002T3 T1
+>>-- GROUP BY T1.A
+>>-- HAVING T1.A >ANY
+>>--  ( SELECT 2 FROM T002T1 T2
+>>--    WHERE T2.C >SOME
+>>--      ( SELECT AVG (T1.A) FROM T002T1 T3 )
+>>--  );
 >>
 >>?section Genesis_10_000222_6892_p2
 >>SELECT 1 FROM T002T1 T1
@@ -1148,5 +1156,112 @@ A            AMAX         B                   BMAX                C            C
 --- 1 row(s) selected.
 >> -- cnt
 >>------------------------------------------------------------------------
+>>
+>>-- Tests of the interaction of [first n] etc. with subqueries
+>>
+>>-- Should return 1
+>>select 
++>(select [FIRST 1] y aa from t002sub b where b.x = a.b) as result_value
++>from t002main a;
+
+RESULT_VALUE
+------------
+
+           1
+
+--- 1 row(s) selected.
+>>
+>>-- Should return null
+>>select 
++>(select [last 0] y aa from t002sub b where b.x = a.b) as result_value
++>from t002main a;
+
+RESULT_VALUE
+------------
+
+           ?
+
+--- 1 row(s) selected.
+>>
+>>-- Should get a cardinality violation (error 8401)
+>>select 
++>(select [first 2] y aa from t002sub b where b.y = a.b) as result_value
++>from t002main a;
+
+*** ERROR[8401] A row subquery or SELECT...INTO statement cannot return more than one row.
+
+--- 0 row(s) selected.
+>>
+>>-- Should return 1
+>>select 
++>(select [first 1] y aa from t002sub b where b.y = a.b) as result_value
++>from t002main a;
+
+RESULT_VALUE
+------------
+
+           1
+
+--- 1 row(s) selected.
+>>
+>>-- Should return 1
+>>select 
++>(select [last 1] y aa from t002sub b where b.y = a.b) as result_value
++>from t002main a;
+
+RESULT_VALUE
+------------
+
+           1
+
+--- 1 row(s) selected.
+>>
+>>-- Should return null
+>>select 
++>(select [last 0] y aa from t002sub b where b.y = a.b) as result_value
++>from t002main a;
+
+RESULT_VALUE
+------------
+
+           ?
+
+--- 1 row(s) selected.
+>>
+>>-- Should return null
+>>select
++>(select [last 0] count(*) from t002sub) as result_value
++>from t002main;
+
+RESULT_VALUE        
+--------------------
+
+                   ?
+
+--- 1 row(s) selected.
+>>
+>>-- Should return 2
+>>select
++>(select [first 20] count(*) from t002sub) as result_value
++>from t002main;
+
+RESULT_VALUE        
+--------------------
+
+                   2
+
+--- 1 row(s) selected.
+>>
+>>-- Should return null
+>>select
++>(select [last 0] x from t002sub) as result_value
++>from t002main;
+
+RESULT_VALUE
+------------
+
+           ?
+
+--- 1 row(s) selected.
 >>
 >>log;

--- a/core/sql/regress/core/TEST002
+++ b/core/sql/regress/core/TEST002
@@ -50,6 +50,9 @@ create table t002ut1 (a int, b nchar(9), c int, d nchar(4));
 create table t002ut2 (a int not null, b nchar(9), c int, d nchar(4), primary key (a));
 #ifMX
 
+create table t002main (a int not null, b int, primary key (a));
+create table t002sub  (x int not null, y int, primary key (x));
+
 ?section dml
 -- INSERT queries
 insert into t002t1 values (10, 'abc', 20, 'xy');
@@ -62,6 +65,9 @@ insert into t002ut1 values (10, N'abc', 20, N'xy');
 insert into t002ut1(b,d,a,c) values (N'defg', N'wx', 10+10, 30);
 insert into t002ut2 select * from t002ut1;
 #ifMX
+
+insert into t002main values (1,1);
+insert into t002sub values (1,1), (2,1);
 
 ?section subqtests
 -- Expect 2 identical rows saying "2 2";
@@ -533,6 +539,53 @@ select SUM  (O.X) from t002FU O having exists(select COUNT(I.X) from t002FUI I);
 select COUNT(O.X) from t002FU O having exists(select COUNT(I.X) from t002FUI I); -- cnt
 ------------------------------------------------------------------------
 
+-- Tests of the interaction of [first n] etc. with subqueries
+
+-- Should return 1
+select 
+(select [FIRST 1] y aa from t002sub b where b.x = a.b) as result_value
+from t002main a;
+
+-- Should return null
+select 
+(select [last 0] y aa from t002sub b where b.x = a.b) as result_value
+from t002main a;
+
+-- Should get a cardinality violation (error 8401)
+select 
+(select [first 2] y aa from t002sub b where b.y = a.b) as result_value
+from t002main a;
+
+-- Should return 1
+select 
+(select [first 1] y aa from t002sub b where b.y = a.b) as result_value
+from t002main a;
+
+-- Should return 1
+select 
+(select [last 1] y aa from t002sub b where b.y = a.b) as result_value
+from t002main a;
+
+-- Should return null
+select 
+(select [last 0] y aa from t002sub b where b.y = a.b) as result_value
+from t002main a;
+
+-- Should return null
+select
+(select [last 0] count(*) from t002sub) as result_value
+from t002main;
+
+-- Should return 2
+select
+(select [first 20] count(*) from t002sub) as result_value
+from t002main;
+
+-- Should return null
+select
+(select [last 0] x from t002sub) as result_value
+from t002main;
+
 log;
 obey TEST002(clnup);
 exit;
@@ -553,6 +606,9 @@ drop table t002FUI;
 drop table t002ut1;
 drop table t002ut2;
 #ifMX
+
+drop table t002main;
+drop table t002sub;
 
 ?section clnup_end
 


### PR DESCRIPTION
Formerly, a [first n] in a subquery in a SELECT list resulted in an internal error in the Normalizer. The problem was that the Normalizer method Subquery::transformToRelExpr was not expecting a FirstN node at the top of the subquery tree.

Besides the fact that the Normalizer doesn't like it, having FirstN above the GroupByAgg node that enforces the one-row cardinality rule doesn't make sense.

In this set of changes, the FirstN node is placed underneath the GroupByAgg node when it matters. For [first n] / [any n] where n > 1, we can simply throw the [first n] / [any n] away, since the subquery already enforces at most one row semantics. For [first 1] and [last 1], we need to insert the FirstN node below the GroupByAgg node so that we narrow the result set down to one (or zero) rows before GroupByAgg enforces the cardinality rule. So, adding [first 1] to a subquery avoids cardinality violations. For [last 0] there is a subtlety. [last 0] by definition returns no rows, so we want the subquery to return null. The way we chose to do this is to force the creation of a one-row GroupByAgg node always, and put the FirstN node under that. In this way, GroupByAgg will see zero rows and produce a null result.

Regression test core/TEST002 has had many [first n] - subquery interaction tests added.

