### PR TITLE
[TRAFODION-2974] Make event log reader and JDBC real TMUDFs

### DIFF
--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -1331,6 +1331,7 @@ $1~String1 --------------------------------
 4320 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Stream access is not allowed on multi-partitioned table or index, when flag ATTEMPT_ASYNCHRONOUS_ACCESS is set to OFF. Object in scope: $0~TableName.
 4321 ZZZZZ 99999 BEGINNER MAJOR DBADMIN An embedded update/delete is not allowed on a partitioned table, when flag ATTEMPT_ASYNCHRONOUS_ACCESS is set to OFF. Object in scope: $0~TableName.
 4322 0A000 99999 BEGINNER MAJOR DBADMIN A column with BLOB datatype cannot be used in this clause or function.
+4323 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Use of predefined UDF $0~String0 is deprecated and this function will be removed in a future release. Please use the function with the same name in schema TRAFODION."_LIBMGR_" instead. You may need to issue this command first: INITIALIZE TRAFODION, UPGRADE LIBRARY MANAGEMENT.
 4330 ZZZZZ 99999 BEGINNER MAJOR DBADMIN An invalid audit compression option $0~Int0 was used in the call to INTERPRET_AS_ROW.
 4331 ZZZZZ 99999 BEGINNER MAJOR DBADMIN KEY_RANGE_COMPARISON of partitioning keys on hash partitioned table $1~TableName is not allowed.
 4332 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Table $1~TableName not exposed. Tables in scope: $2~string0.

--- a/core/sql/common/ComSmallDefs.h
+++ b/core/sql/common/ComSmallDefs.h
@@ -193,6 +193,7 @@ typedef NABoolean               ComBoolean;
 // Procedures are defined in CmpSeabaseDDLroutine.h
 #define SEABASE_LIBMGR_SCHEMA "_LIBMGR_"
 #define SEABASE_LIBMGR_LIBRARY "DB__LIBMGRNAME"
+#define SEABASE_LIBMGR_LIBRARY_CPP "DB__LIBMGR_LIB_CPP"
 
 // reserved column names for traf internal system usage
 #define TRAF_SALT_COLNAME "_SALT_"

--- a/core/sql/lib_mgmt/src/main/java/org/trafodion/libmgmt/JDBCUDR.java
+++ b/core/sql/lib_mgmt/src/main/java/org/trafodion/libmgmt/JDBCUDR.java
@@ -17,22 +17,6 @@ specific language governing permissions and limitations
 under the License.
 **********************************************************************/
 
-//*************************************************
-//
-//   ##    ##   ######   ########  ########
-//   ###   ##  ########  ########  ########
-//   ####  ##  ##    ##     ##     ##
-//   ## ## ##  ##    ##     ##     #####
-//   ##  ####  ##    ##     ##     ##
-//   ##   ###  ########     ##     ########
-//   ##    ##   ######      ##     ########
-//
-//**************************************************
-//
-// This file is deprecated. Please update file
-// core/sql/lib_mgmt/src/main/java/org/trafodion/sql/libmgmt/JDBCUDR.java
-// instead!!
-
 /***************************************************
  * A TMUDF that executes a generic JDBC query
  * and returns the result of the one SQL statement
@@ -71,7 +55,7 @@ under the License.
  * core/sql/regress/udr/TEST002.
  ***************************************************/
 
-package org.trafodion.sql.udr.predef;
+package org.trafodion.libmgmt;
 
 import org.trafodion.sql.udr.*;
 import java.sql.*;

--- a/core/sql/optimizer/BindRelExpr.cpp
+++ b/core/sql/optimizer/BindRelExpr.cpp
@@ -17226,6 +17226,18 @@ RelExpr *TableMappingUDF::bindNode(BindWA *bindWA)
           for (int i=0; i<getArity(); i++)
             result->child(i) = child(i);
 
+          if (opType == REL_TABLE_MAPPING_BUILTIN_LOG_READER ||
+              opType == REL_TABLE_MAPPING_BUILTIN_JDBC)
+            {
+              // The event log reader and JDBC TMUDFs are being migrated
+              // to real UDFs, use of the predefined UDFs is deprecated.
+              // Issue a warning. Eventually these predefined functions
+              // will be removed.
+              (*CmpCommon::diags())
+                << DgSqlCode(4323)
+                << DgString0(tmfuncName.getExposedNameAsAnsiString());
+            }
+
           // Abandon the current node and return the bound new node.
           // Next time it will reach this method it will call an
           // overloaded getRoutineMetadata() that will succeed.

--- a/core/sql/regress/udr/EXPECTED002
+++ b/core/sql/regress/udr/EXPECTED002
@@ -6515,9 +6515,19 @@ the                                                        611
 
 --- 6344 row(s) selected.
 >>
->>-- some simple tests for the event_log_reader predefined TMUDF
+>>-- make sure the event_log_reader and jdbc UDFs are created (this
+>>-- should only be needed while we are developing Trafodion 2.3, in
+>>-- future releases the installer should do this automatically, by
+>>-- executing the upgrade command below)
+>>initialize trafodion, upgrade library management;
+
+--- SQL operation complete.
+>>
+>>-- some simple tests for the event_log_reader TMUDF
 >>-- (result of the UDF is not deterministic)
 >>select [last 0] * from udf(event_log_reader());
+
+*** WARNING[4323] Use of predefined UDF EVENT_LOG_READER is deprecated and this function will be removed in a future release. Please use the function with the same name in schema TRAFODION."_LIBMGR_" instead. You may need to issue this command first: INITIALIZE TRAFODION, UPGRADE LIBRARY MANAGEMENT.
 
 --- 0 row(s) selected.
 >>select [last 0] log_ts + interval '1' day,
@@ -6533,11 +6543,13 @@ the                                                        611
 +>                log_file_name,
 +>                log_file_line -1,
 +>                case when parse_status = ' ' then 'ok' else parse_status end
-+>from udf(event_log_reader('f'));
++>from udf("_LIBMGR_".event_log_reader('f'));
 
 --- 0 row(s) selected.
 >>select coalesce(min(log_file_node), 0) from udf(event_log_reader('f')) x
 +>where x.log_file_line <100;
+
+*** WARNING[4323] Use of predefined UDF X is deprecated and this function will be removed in a future release. Please use the function with the same name in schema TRAFODION."_LIBMGR_" instead. You may need to issue this command first: INITIALIZE TRAFODION, UPGRADE LIBRARY MANAGEMENT.
 
 (EXPR)     
 -----------
@@ -6554,7 +6566,7 @@ the                                                        611
 +>       max(log_file_line) as num_lines,
 +>       count(distinct query_id) num_query_ids,
 +>       sum(case when parse_status = ' ' then 0 else 1 end) num_parse_errors
-+>from udf(event_log_reader('f'))
++>from udf("_LIBMGR_".event_log_reader('f'))
 +>where log_file_name = 'master_exec_regr_999_99999.log';
 
 NUM_EVENTS            NUM_LINES    NUM_QUERY_IDS         NUM_PARSE_ERRORS
@@ -6565,7 +6577,7 @@ NUM_EVENTS            NUM_LINES    NUM_QUERY_IDS         NUM_PARSE_ERRORS
 --- 1 row(s) selected.
 >>-- there are 22 events in 33 lines in this file, with 13 unique query ids and 3 parse errors
 >>
->>select * from udf(event_log_reader('f'))
+>>select * from udf("_LIBMGR_".event_log_reader('f'))
 +>where log_file_name = 'master_exec_regr_999_99999.log'
 +>  and (log_file_line in (1,3,8,16,23) or parse_status <> ' ')
 +>order by log_file_line;
@@ -6590,33 +6602,46 @@ LOG_TS                      SEVERITY    COMPONENT                               
 >>-- some negative test cases
 >>prepare s from select * from udf(event_log_reader(10));
 
+*** WARNING[4323] Use of predefined UDF EVENT_LOG_READER is deprecated and this function will be removed in a future release. Please use the function with the same name in schema TRAFODION."_LIBMGR_" instead. You may need to issue this command first: INITIALIZE TRAFODION, UPGRADE LIBRARY MANAGEMENT.
+
 *** ERROR[11252] Expecting a character constant as first parameter of the call to TRAFODION.SCH.EVENT_LOG_READER (SQLSTATE 38222)
 
 *** ERROR[8822] The statement was not prepared.
 
 >>-- parameter must be a string
->>prepare s from select * from udf(event_log_reader(?));
+>>prepare s from select * from udf("_LIBMGR_".event_log_reader(?));
 
 *** ERROR[11151] Unable to use 'type' 'UNSUPPORTED TYPE' in a user-defined routine. Details: unsupported type class.
 
 *** ERROR[8822] The statement was not prepared.
 
 >>-- parameter must be available at compile time
->>prepare s from select * from udf(event_log_reader(table(select * from (values (1)) as x)));
+>>prepare s from
++>select *
++>from udf("_LIBMGR_".event_log_reader(table(select * from (values (1)) as x)));
 
-*** ERROR[11252] There should be no table-valued parameters to the call to TRAFODION.SCH.EVENT_LOG_READER, got 1 (SQLSTATE 38220)
+*** ERROR[11252] There should be no table-valued parameters to the call to TRAFODION."_LIBMGR_".EVENT_LOG_READER, got 1 (SQLSTATE 38220)
 
 *** ERROR[8822] The statement was not prepared.
 
 >>-- table-valued input not allowed
 >>prepare s from select query_id, log_file_name, parse_status
-+>from udf(event_log_reader());
++>from udf("_LIBMGR_".event_log_reader());
 
 *** ERROR[4001] Column LOG_FILE_NAME is not found.  Tables in scope: NONE.  Default schema: TRAFODION.SCH.
 
 *** ERROR[8822] The statement was not prepared.
 
 >>-- log_file_name and parse_status columns not available without 'f' option
+>>prepare s from select * from udf(nosuchschema.event_log_reader());
+
+*** ERROR[1389] Object EVENT_LOG_READER does not exist in Trafodion.
+
+*** ERROR[4450] Function NOSUCHSCHEMA.EVENT_LOG_READER is not a built-in function or registered user-defined function.
+
+*** ERROR[8822] The statement was not prepared.
+
+>>-- Schema/UDF does not exist
 >>
 >>-- some simple tests for the timeseries builtin UDF
 >>
@@ -6759,7 +6784,10 @@ P            SLICE_TIME                  VAL1_FCI     VAL1_LCI     VAL2_FCI     
 +>              'source',
 +>              'select * from (values (''Hello'', ''World''), (''Hallo'', ''Welt'')) T(a,b)'));
 
+*** WARNING[4323] Use of predefined UDF JDBC is deprecated and this function will be removed in a future release. Please use the function with the same name in schema TRAFODION."_LIBMGR_" instead. You may need to issue this command first: INITIALIZE TRAFODION, UPGRADE LIBRARY MANAGEMENT.
+
 --- SQL command prepared.
+>>-- warning 4323, predefined UDF is deprecated
 >>execute s_traf;
 
 A           B         
@@ -6767,6 +6795,27 @@ A           B
 
 Hello       World     
 Hallo       Welt      
+
+--- 2 row(s) selected.
+>>
+>>prepare s_traf from
++>select *
++>from udf("_LIBMGR_".jdbc('jdbcT4-${TRAFODION_VER}.jar',
++>                         'org.trafodion.jdbc.t4.T4Driver',
++>                         $$QUOTE$$$$JDBC_T4_URL$$$$QUOTE$$,
++>                         'any', -- no user id
++>                         'any', -- no password
++>                         'source',
++>                         'select * from (values (''Bonjour'', ''Le monde''), (''Hola'', ''Mundo'')) T(a,b)'));
+
+--- SQL command prepared.
+>>execute s_traf;
+
+A               B               
+--------------  ----------------
+
+Bonjour         Le monde        
+Hola            Mundo           
 
 --- 2 row(s) selected.
 >>
@@ -6855,6 +6904,38 @@ Hallo       Welt
 *** ERROR[8822] The statement was not prepared.
 
 >>-- Arguments not in pairs of column names and instructions
+>>
+>>prepare s_traf from
++>select *
++>from udf("_LIBMGR_".jdbc('trafjdbcT2-99.99.99.jar',
++>                         'org.apache.trafodion.jdbc.t2.T2Driver',
++>                         'jdbc:t2jdbc:/something',
++>                         'any', -- no user id
++>                         'any', -- no password
++>                         'source',
++>                         'some sql'));
+
+*** ERROR[11252] Exception during connect: This UDF does not support the Trafodion T2 driver class org.apache.trafodion.jdbc.t2.T2Driver (SQLSTATE 38020)
+
+*** ERROR[8822] The statement was not prepared.
+
+>>-- T2 driver class is not supported
+>>
+>>prepare s_traf from
++>select *
++>from udf("_LIBMGR_".jdbc('trafjdbcT2-99.99.99.jar',
++>                         'someclass',
++>                         'jdbc:t2jdbc:/something',
++>                         'any', -- no user id
++>                         'any', -- no password
++>                         'source',
++>                         'some sql'));
+
+*** ERROR[11252] Exception during connect: This UDF does not support the Trafodion T2 driver URL jdbc:t2jdbc:/something (SQLSTATE 38020)
+
+*** ERROR[8822] The statement was not prepared.
+
+>>-- T2 driver URL is not supported
 >>
 >>-- eclipse timeseries builtin function with a true UDF
 >>create table_mapping function timeseries(pattern char(1))

--- a/core/sql/regress/udr/TEST002
+++ b/core/sql/regress/udr/TEST002
@@ -147,7 +147,13 @@ order by 2,1;
 
 execute s1 ;
 
--- some simple tests for the event_log_reader predefined TMUDF
+-- make sure the event_log_reader and jdbc UDFs are created (this
+-- should only be needed while we are developing Trafodion 2.3, in
+-- future releases the installer should do this automatically, by
+-- executing the upgrade command below)
+initialize trafodion, upgrade library management;
+
+-- some simple tests for the event_log_reader TMUDF
 -- (result of the UDF is not deterministic)
 select [last 0] * from udf(event_log_reader());
 select [last 0] log_ts + interval '1' day,
@@ -163,7 +169,7 @@ select [last 0] log_ts + interval '1' day,
                 log_file_name,
                 log_file_line -1,
                 case when parse_status = ' ' then 'ok' else parse_status end
-from udf(event_log_reader('f'));
+from udf("_LIBMGR_".event_log_reader('f'));
 select coalesce(min(log_file_node), 0) from udf(event_log_reader('f')) x
 where x.log_file_line <100;
 
@@ -175,11 +181,11 @@ select count(*) as num_events,
        max(log_file_line) as num_lines,
        count(distinct query_id) num_query_ids,
        sum(case when parse_status = ' ' then 0 else 1 end) num_parse_errors
-from udf(event_log_reader('f'))
+from udf("_LIBMGR_".event_log_reader('f'))
 where log_file_name = 'master_exec_regr_999_99999.log';
 -- there are 22 events in 33 lines in this file, with 13 unique query ids and 3 parse errors
 
-select * from udf(event_log_reader('f'))
+select * from udf("_LIBMGR_".event_log_reader('f'))
 where log_file_name = 'master_exec_regr_999_99999.log'
   and (log_file_line in (1,3,8,16,23) or parse_status <> ' ')
 order by log_file_line;
@@ -190,13 +196,17 @@ sh rm $$TRAF_HOME$$/logs/master_exec_regr_999_99999.log;
 -- some negative test cases
 prepare s from select * from udf(event_log_reader(10));
 -- parameter must be a string
-prepare s from select * from udf(event_log_reader(?));
+prepare s from select * from udf("_LIBMGR_".event_log_reader(?));
 -- parameter must be available at compile time
-prepare s from select * from udf(event_log_reader(table(select * from (values (1)) as x)));
+prepare s from
+select *
+from udf("_LIBMGR_".event_log_reader(table(select * from (values (1)) as x)));
 -- table-valued input not allowed
 prepare s from select query_id, log_file_name, parse_status
-from udf(event_log_reader());
+from udf("_LIBMGR_".event_log_reader());
 -- log_file_name and parse_status columns not available without 'f' option
+prepare s from select * from udf(nosuchschema.event_log_reader());
+-- Schema/UDF does not exist
 
 -- some simple tests for the timeseries builtin UDF
 
@@ -248,6 +258,18 @@ from udf(jdbc('jdbcT4-${TRAFODION_VER}.jar',
               'any', -- no password
               'source',
               'select * from (values (''Hello'', ''World''), (''Hallo'', ''Welt'')) T(a,b)'));
+-- warning 4323, predefined UDF is deprecated
+execute s_traf;
+
+prepare s_traf from
+select *
+from udf("_LIBMGR_".jdbc('jdbcT4-${TRAFODION_VER}.jar',
+                         'org.trafodion.jdbc.t4.T4Driver',
+                         $$QUOTE$$$$JDBC_T4_URL$$$$QUOTE$$,
+                         'any', -- no user id
+                         'any', -- no password
+                         'source',
+                         'select * from (values (''Bonjour'', ''Le monde''), (''Hola'', ''Mundo'')) T(a,b)'));
 execute s_traf;
 
 -- negative tests
@@ -305,6 +327,28 @@ from udf(timeseries(table(select * from t002_Timeseries
                     'VAL9', 'FC',
                     'VAL1'));
 -- Arguments not in pairs of column names and instructions
+
+prepare s_traf from
+select *
+from udf("_LIBMGR_".jdbc('trafjdbcT2-99.99.99.jar',
+                         'org.apache.trafodion.jdbc.t2.T2Driver',
+                         'jdbc:t2jdbc:/something',
+                         'any', -- no user id
+                         'any', -- no password
+                         'source',
+                         'some sql'));
+-- T2 driver class is not supported
+
+prepare s_traf from
+select *
+from udf("_LIBMGR_".jdbc('trafjdbcT2-99.99.99.jar',
+                         'someclass',
+                         'jdbc:t2jdbc:/something',
+                         'any', -- no user id
+                         'any', -- no password
+                         'source',
+                         'some sql'));
+-- T2 driver URL is not supported
 
 -- eclipse timeseries builtin function with a true UDF
 create table_mapping function timeseries(pattern char(1))

--- a/core/sql/sqlcomp/CmpSeabaseDDL.h
+++ b/core/sql/sqlcomp/CmpSeabaseDDL.h
@@ -1306,6 +1306,7 @@ protected:
   short dropSeabaseLibmgr(ExeCliInterface *inCliInterface);
   short createLibmgrProcs(ExeCliInterface * cliInterface);
   short grantLibmgrPrivs(ExeCliInterface *cliInterface);
+  short createSeabaseLibmgrCPPLib(ExeCliInterface * cliInterface);
 
   short registerNativeTable
   (

--- a/core/sql/sqlcomp/CmpSeabaseDDLroutine.h
+++ b/core/sql/sqlcomp/CmpSeabaseDDLroutine.h
@@ -50,6 +50,8 @@
 #define SYSTEM_PROC_RM           "RM"
 #define SYSTEM_PROC_RMREX        "RMREX"
 #define SYSTEM_TMUDF_SYNCLIBUDF  "SYNCLIBUDF"
+#define SYSTEM_TMUDF_EVENT_LOG_READER "EVENT_LOG_READER"
+#define SYSTEM_TMUDF_JDBC        "JDBC"
 
 // Create procedure text for system procedures
 static const QString seabaseProcAddlibDDL[] =
@@ -244,6 +246,24 @@ static const QString seabaseProcRmrexDDL[] =
   {" ; "}
 };
 
+  static const QString seabaseTMUDFEventLogReaderDDL[] = 
+{
+  {"  CREATE TABLE_MAPPING FUNCTION IF NOT EXISTS %s.\"%s\".EVENT_LOG_READER() "},
+  {"  EXTERNAL NAME 'TRAF_CPP_EVENT_LOG_READER' "},
+  {"  LIBRARY %s.\"%s\".%s "},
+  {"  LANGUAGE CPP "},
+  {" ; "}
+};
+
+  static const QString seabaseTMUDFJDBCDDL[] = 
+{
+  {"  CREATE TABLE_MAPPING FUNCTION IF NOT EXISTS %s.\"%s\".JDBC() "},
+  {"  EXTERNAL NAME 'org.trafodion.libmgmt.JDBCUDR' "},
+  {"  LIBRARY %s.\"%s\".%s "},
+  {"  LANGUAGE JAVA "},
+  {" ; "}
+};
+
 struct LibmgrRoutineInfo
 {
   // type of the UDR (used in grant)
@@ -255,79 +275,131 @@ struct LibmgrRoutineInfo
   // ddl stmt corresponding to the current ddl.
   const QString *newDDL;
   Lng32 sizeOfnewDDL;
+
+  enum LibmgrLibEnum
+    {
+      JAVA_LIB,
+      CPP_LIB
+    } whichLib;
+
+  enum LibmgrRoleEnum
+    {
+      LIBMGR_ROLE,
+      PUBLIC
+    } whichRole;
 };
 
 static const LibmgrRoutineInfo allLibmgrRoutineInfo[] = {
   {"PROCEDURE",
    SYSTEM_PROC_ADDLIB, 
    seabaseProcAddlibDDL, 
-   sizeof(seabaseProcAddlibDDL)
+   sizeof(seabaseProcAddlibDDL),
+   LibmgrRoutineInfo::JAVA_LIB,
+   LibmgrRoutineInfo::LIBMGR_ROLE
   },
 
   {"PROCEDURE",
    SYSTEM_PROC_ALTERLIB, 
    seabaseProcAlterlibDDL, 
-   sizeof(seabaseProcAlterlibDDL)
+   sizeof(seabaseProcAlterlibDDL),
+   LibmgrRoutineInfo::JAVA_LIB,
+   LibmgrRoutineInfo::LIBMGR_ROLE
   },
 
   {"PROCEDURE",
    SYSTEM_PROC_DROPLIB, 
    seabaseProcDroplibDDL, 
-   sizeof(seabaseProcDroplibDDL)
+   sizeof(seabaseProcDroplibDDL),
+   LibmgrRoutineInfo::JAVA_LIB,
+   LibmgrRoutineInfo::LIBMGR_ROLE
   },
 
   {"PROCEDURE",
    SYSTEM_PROC_GETFILE, 
    seabaseProcGetfileDDL, 
-   sizeof(seabaseProcGetfileDDL)
+   sizeof(seabaseProcGetfileDDL),
+   LibmgrRoutineInfo::JAVA_LIB,
+   LibmgrRoutineInfo::LIBMGR_ROLE
   },
 
   {"PROCEDURE",
    SYSTEM_PROC_HELP, 
    seabaseProcHelpDDL, 
-   sizeof(seabaseProcHelpDDL)
+   sizeof(seabaseProcHelpDDL),
+   LibmgrRoutineInfo::JAVA_LIB,
+   LibmgrRoutineInfo::LIBMGR_ROLE
   },
 
   {"PROCEDURE",
    SYSTEM_PROC_LS, 
    seabaseProcLsDDL, 
-   sizeof(seabaseProcLsDDL)
+   sizeof(seabaseProcLsDDL),
+   LibmgrRoutineInfo::JAVA_LIB,
+   LibmgrRoutineInfo::LIBMGR_ROLE
   },
 
   {"PROCEDURE",
    SYSTEM_PROC_LSALL, 
    seabaseProcLsallDDL, 
-   sizeof(seabaseProcLsallDDL)
+   sizeof(seabaseProcLsallDDL),
+   LibmgrRoutineInfo::JAVA_LIB,
+   LibmgrRoutineInfo::LIBMGR_ROLE
   },
 
   {"PROCEDURE",
    SYSTEM_PROC_PUT, 
    seabaseProcPutDDL, 
-   sizeof(seabaseProcPutDDL)
+   sizeof(seabaseProcPutDDL),
+   LibmgrRoutineInfo::JAVA_LIB,
+   LibmgrRoutineInfo::LIBMGR_ROLE
   },
 
   {"PROCEDURE",
    SYSTEM_PROC_PUTFILE, 
    seabaseProcPutFileDDL, 
-   sizeof(seabaseProcPutFileDDL)
+   sizeof(seabaseProcPutFileDDL),
+   LibmgrRoutineInfo::JAVA_LIB,
+   LibmgrRoutineInfo::LIBMGR_ROLE
   },
 
   {"PROCEDURE",
    SYSTEM_PROC_RM, 
    seabaseProcRmDDL, 
-   sizeof(seabaseProcRmDDL)
+   sizeof(seabaseProcRmDDL),
+   LibmgrRoutineInfo::JAVA_LIB,
+   LibmgrRoutineInfo::LIBMGR_ROLE
   },
 
   {"PROCEDURE",
    SYSTEM_PROC_RMREX, 
    seabaseProcRmrexDDL, 
-   sizeof(seabaseProcRmrexDDL)
+   sizeof(seabaseProcRmrexDDL),
+   LibmgrRoutineInfo::JAVA_LIB,
+   LibmgrRoutineInfo::LIBMGR_ROLE
   },
 
   {"FUNCTION",
    SYSTEM_TMUDF_SYNCLIBUDF,
    seabaseTMUDFSyncLibDDL,
-   sizeof(seabaseTMUDFSyncLibDDL)
+   sizeof(seabaseTMUDFSyncLibDDL),
+   LibmgrRoutineInfo::JAVA_LIB,
+   LibmgrRoutineInfo::LIBMGR_ROLE
+  },
+
+  {"FUNCTION",
+   SYSTEM_TMUDF_EVENT_LOG_READER,
+   seabaseTMUDFEventLogReaderDDL,
+   sizeof(seabaseTMUDFEventLogReaderDDL),
+   LibmgrRoutineInfo::CPP_LIB,
+   LibmgrRoutineInfo::PUBLIC
+  },
+
+  {"FUNCTION",
+   SYSTEM_TMUDF_JDBC,
+   seabaseTMUDFJDBCDDL,
+   sizeof(seabaseTMUDFJDBCDDL),
+   LibmgrRoutineInfo::JAVA_LIB,
+   LibmgrRoutineInfo::PUBLIC
   }
 
 };

--- a/core/sql/src/main/java/org/trafodion/sql/udr/LmT2Driver.java
+++ b/core/sql/src/main/java/org/trafodion/sql/udr/LmT2Driver.java
@@ -195,6 +195,18 @@ public class LmT2Driver implements java.sql.Driver
     return false;
   }
 
+  // similar to acceptsURL, but a static method that checks for substrings
+  // acceptsURL is used by the DriverManager, this static method is used
+  // internally by Trafodion (JDBC TMUDF)
+  public static boolean checkURL( String url ) 
+  {
+    for (int i = 0; i < acceptedURLs.length; i++)
+      if (url.indexOf(acceptedURLs[i]) >= 0)
+        return true;
+
+    return false;
+  }
+
   public Connection connect( String url, java.util.Properties props )
       throws SQLException
   {

--- a/docs/messages_guide/src/asciidoc/_chapters/binder_msgs.adoc
+++ b/docs/messages_guide/src/asciidoc/_chapters/binder_msgs.adoc
@@ -2889,3 +2889,16 @@ the flag ATTEMPT_ASYNCHRONOUS_ACCESS was set to OFF.
 
 *Recovery:* Set the ATTEMPT_ASYNCHRONOUS_ACCESS flag to ON and resubmit.
 
+[[SQL-4323]]
+== SQL 4323
+
+```
+Use of predefined UDF <name> is deprecated and this function will be removed in a future release. Please use the function with the same name in schema TRAFODION."_LIBMGR_" instead. You may need to issue this command first: INITIALIZE TRAFODION, UPGRADE LIBRARY MANAGEMENT.
+```
+
+*Cause:* See message.
+
+*Effect:* The operation succeeds - this is only a warning.
+
+*Recovery:* See message.
+


### PR DESCRIPTION
Roberta pointed out that we have two predefined UDFs, EVENT_LOG_READER
and JDBC, where the system administrator should have the ability to
control who can execute these functions.

To do this, these two UDFs cannot be "predefined" UDFs anymore, since
those don't have the metadata that's required for doing grant and
revoke.

Roberta also pointed out that the JDBC UDF should refuse to connect to
the T2 driver, for security reasons.

The fix leaves the predefined TMUDFs in place, for now, they will be
removed in R2.4 (see TRAFODION-2975).

The new "real" TMUDFs are in the "_LIBMGR_" schema, mostly for
convenience, as this schema has other UDFs that are created when
Trafodion is initialized.

Note for reviewers: The new JDBCUDR.java file is the same as the existing file, except for the package name and for the note added to the old file.