### PR TITLE
TRAFODION-2981 mxosrvr crashes during explain using EXPLAIN_QID

### DIFF
--- a/core/sql/executor/ExExplain.cpp
+++ b/core/sql/executor/ExExplain.cpp
@@ -1724,9 +1724,9 @@ short ExExplainTcb::getExplainFromRepos(char * qid, Lng32 qidLen)
   if (vi->get(0, ptr, len))
     goto label_error2;
   
-  explainFragLen_ = str_decoded_len(len); // remove trailing null terminator
+  explainFragLen_ = str_decoded_len(len - 1); // remove trailing null terminator
   explainFrag_ = new(getHeap()) char[explainFragLen_];
-  if (str_decode(explainFrag_, explainFragLen_, ptr, len) < 0)
+  if (str_decode(explainFrag_, explainFragLen_, ptr, len - 1) < 0)
     {
       diagsArea = pEntryDown->getAtp()->getDiagsArea();
       ExRaiseSqlError(getGlobals()->getDefaultHeap(), 


### PR DESCRIPTION
SELECT * FROM TABLE(explain(null, 'EXPLAIN_QID=MXID11000007019212384153894533416000000002206U3333308T150010100_923_SQL_CUR_2'));
this is related to TRAFODION-1755
