### PR TITLE
[TRAFODION-2983] Be careful to preserve inputs needed for output computation

### DIFF
--- a/core/sql/generator/GenPreCode.cpp
+++ b/core/sql/generator/GenPreCode.cpp
@@ -1154,12 +1154,14 @@ VEGReference::replaceVEGReference(const ValueIdSet &origAvailableValues,
 
   if (VEG_DEBUG)
     {
-      NAString av,iv,vb;
+      NAString av,iv,vb,vr;
       availableValues.unparse(av);
       inputValues.unparse(iv);
       valuesToBeBound.unparse(vb);
+      ValueIdSet thisVegRef(getValueId());
+      thisVegRef.unparse(vr);
       cout << endl;
-	  cout << "VEGReference " << getValueId() << " :" << endl;
+      cout << "VEGReference " << getValueId() << " (" << vr << "):" << endl;
       cout << "AV: " << av << endl;
       cout << "IV: " << iv << endl;
       cout << "VB: " << vb << endl;

--- a/core/sql/optimizer/RelExpr.cpp
+++ b/core/sql/optimizer/RelExpr.cpp
@@ -7812,6 +7812,8 @@ NABoolean GroupByAgg::tryToPullUpPredicatesInPreCodeGen(
   myLocalExpr += child(0).getGroupAttr()->getCharacteristicInputs();
   myLocalExpr += groupExpr();
   myLocalExpr += aggregateExpr();
+  // make sure we can still produce our characteristic outputs too
+  myLocalExpr += getGroupAttr()->getCharacteristicOutputs();
           
   // consider only preds that we can evaluate in the parent
   if (optionalMap)


### PR DESCRIPTION
This fix changes GroupByAgg::tryToPullUpPredicatesInPreCodeGen (optimizer/RelExpr.cpp) to make sure that characteristic inputs needed to calculate characteristic output expressions are not removed.

It also makes a small improvement to some ValueId Equivalence Group (VEG) debugging code.

