### PR TITLE
[TRAFODION-2990] Fix CREATE TABLE LIKE having long numeric default constant

### DIFF
--- a/core/sql/common/NAString.cpp
+++ b/core/sql/common/NAString.cpp
@@ -1815,7 +1815,8 @@ size_t LineBreakSqlText(NAString &sqlText,
 
 	  } // unquoted space
 
-	else if (*s == '.')
+	else if ((*s == '.') &&
+                 (!isDigit8859_1((unsigned char)s[1]))) // ignore dots in numeric constants
 	  {
 	    dot[2] = dot[1];
 	    dot[1] = dot[0];


### PR DESCRIPTION
The routine LineBreakSqlText (common/NAString.cpp) was inserting a line break after the decimal point in a numeric constant, making one token into two. The code has been changed to distinguish between a dot that separates two identifiers (a legitimate place to insert line breaks) and decimal points.