### PR TITLE
[TRAFODION-2853] memory leak of ComDiagsArea in CmpContext heap of mxosrvr

### DIFF
--- a/core/sql/arkcmp/CmpConnection.cpp
+++ b/core/sql/arkcmp/CmpConnection.cpp
@@ -554,7 +554,9 @@ void ExCmpMessage::actOnReceive(IpcConnection* )
   
   if (cmpStatement)
   {
-    *this << *cmpStatement->diags();
+    ComDiagsArea *diags = cmpStatement->diags();
+    if (diags->getNumber() > 0)
+       *this << *cmpStatement->diags();
     if (cmpStatement->reply()) 
       *this << *cmpStatement->reply();
   }

--- a/core/sql/arkcmp/CmpContext.cpp
+++ b/core/sql/arkcmp/CmpContext.cpp
@@ -714,8 +714,6 @@ void CmpContext::switchContext()
       ActiveSchemaDB()->getDefaults().getSqlParser_NADefaults_Ptr();
   gpClusterInfo = clusterInfo_;
   SqlParser_Diags = diags();
-  if (CmpCommon::diags())
-     CmpCommon::diags()->clear();
   cmpMemMonitor = cmpMemMonitor_;
 }
 
@@ -1088,6 +1086,7 @@ CmpContext::compileDirect(char *data, UInt32 data_len, CollHeap *outHeap,
      if (diagsArea == NULL)
        diagsArea = ComDiagsArea::allocate(outHeap);
      diagsArea->mergeAfter(*compileDiagsArea);
+     compileDiagsArea->clear();
   }
   // cleanup and return
   if (cmpStatement && cmpStatement->readyToDie())

--- a/core/sql/arkcmp/CmpContext.cpp
+++ b/core/sql/arkcmp/CmpContext.cpp
@@ -763,7 +763,7 @@ CmpContext::compileDirect(char *data, UInt32 data_len, CollHeap *outHeap,
                           char *&gen_code, UInt32 &gen_code_len,
                           UInt32 parserFlags, const char *parentQid,
                           Int32 parentQidLen,
-                          ComDiagsArea *diagsArea)
+                          ComDiagsArea *&diagsArea)
 {
 
   CmpStatement::ReturnStatus rs = CmpStatement::CmpStatement_SUCCESS;
@@ -1081,10 +1081,14 @@ CmpContext::compileDirect(char *data, UInt32 data_len, CollHeap *outHeap,
       }
   }
 
-  // get any errors or warnings from compilation out before distroy it
-  if (diagsArea)
-    diagsArea->mergeAfter(*CmpCommon::diags());
-
+  ComDiagsArea *compileDiagsArea = CmpCommon::diags();
+  if (compileDiagsArea->getNumber() > 0)
+  {
+     // get any errors or warnings from compilation out before distroy it
+     if (diagsArea == NULL)
+       diagsArea = ComDiagsArea::allocate(outHeap);
+     diagsArea->mergeAfter(*compileDiagsArea);
+  }
   // cleanup and return
   if (cmpStatement && cmpStatement->readyToDie())
     delete cmpStatement;

--- a/core/sql/arkcmp/CmpContext.h
+++ b/core/sql/arkcmp/CmpContext.h
@@ -381,7 +381,7 @@ public :
                 CmpMessageObj::MessageTypeEnum op, char *&gen_code,
                 UInt32 &gen_code_len, UInt32 parserFlags,
                 const char *parentQid, Int32 parentQidLen,
-                ComDiagsArea *diagsArea = NULL);
+                ComDiagsArea *&diagsArea);
 
   // set/reset an env in compiler envs
   void setArkcmpEnvDirect(const char *name, const char *value,

--- a/core/sql/cli/Cli.cpp
+++ b/core/sql/cli/Cli.cpp
@@ -8314,7 +8314,7 @@ Lng32 SQLCLI_LOBcliInterface
   ContextCli   & currContext = *(cliGlobals->currContext());
   ComDiagsArea & diags       = currContext.diags();
 
-  ComDiagsArea * myDiags = ComDiagsArea::allocate(currContext.exHeap());
+  ComDiagsArea * myDiags = NULL;
 
   ExeCliInterface *cliInterface = NULL;
   if (inCliInterface && (*inCliInterface))
@@ -8413,11 +8413,7 @@ Lng32 SQLCLI_LOBcliInterface
 	cliRC = cliInterface->executeImmediate(query);
 
 	if (cliRC < 0)
-	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
 	    goto error_return;
-	  }
 
 	cliRC = 0;
       }
@@ -8439,12 +8435,7 @@ Lng32 SQLCLI_LOBcliInterface
 	currContext.resetSqlParserFlags(0x1);
 
 	if (cliRC < 0)
-	  {
-	    
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
 	    goto error_return;
-	  }
 
            	// create lob descriptor chunks table salted
        	str_sprintf(query, "create ghost table %s (descPartnKey largeint not null, descSysKey largeint not null, chunkNum int not null, chunkLen largeint not null, dataOffset largeint, stringParam varchar(400), primary key(descPartnKey, descSysKey, chunkNum)) salt using 8 partitions",
@@ -8459,13 +8450,7 @@ Lng32 SQLCLI_LOBcliInterface
 	currContext.resetSqlParserFlags(0x1);
 
 	if (cliRC < 0)
-	  {
-	    
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
 	    goto error_return;
-	  }
-	
 	cliRC = 0;
       }
       break;
@@ -8483,11 +8468,7 @@ Lng32 SQLCLI_LOBcliInterface
 	currContext.resetSqlParserFlags(0x1);
 	
 	if (cliRC < 0)
-	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
 	    goto error_return;
-	  }
 
 	str_sprintf(query, "drop ghost table %s",
 		    lobDescChunksName);
@@ -8501,14 +8482,7 @@ Lng32 SQLCLI_LOBcliInterface
 
 	
 	if (cliRC < 0)
-	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
 	    goto error_return;
-	  }
-
-	  
-	
 	cliRC = 0;
       }
       break;
@@ -8526,10 +8500,7 @@ Lng32 SQLCLI_LOBcliInterface
 	currContext.resetSqlParserFlags(0x1);
 
 	if (cliRC < 0)
-	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
 	    goto error_return;
-	  }
 
 	str_sprintf(query, "cleanup table %s",
 		    lobDescChunksName);
@@ -8542,10 +8513,7 @@ Lng32 SQLCLI_LOBcliInterface
 	currContext.resetSqlParserFlags(0x1);
 	
 	if (cliRC < 0)
-	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
 	    goto error_return;
-	  }	   
 	cliRC = 0;
       }
       break;
@@ -8567,10 +8535,7 @@ Lng32 SQLCLI_LOBcliInterface
 	currContext.resetSqlParserFlags(0x1);
 
 	if (cliRC < 0)
-	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);	    
 	    goto error_return;
-	  }
 
         
         // insert into lob descriptor chunks table
@@ -8601,11 +8566,7 @@ Lng32 SQLCLI_LOBcliInterface
         currContext.resetSqlParserFlags(0x1);
 
         if (cliRC < 0)
-          {
-            cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
-            goto error_return;
-          }
+	    goto error_return;
         
 	if (inoutDescPartnKey)
 	  *inoutDescPartnKey = descPartnKey;
@@ -8650,11 +8611,7 @@ Lng32 SQLCLI_LOBcliInterface
 	currContext.resetSqlParserFlags(0x1);
 
 	if (cliRC < 0)
-	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
 	    goto error_return;
-	  }
 
 	str_sprintf(query, "select numChunks from table(ghost table %s) h where h.descPartnKey = %ld and h.syskey = %ld for read committed access",
 		    lobDescHandleName,  
@@ -8670,11 +8627,7 @@ Lng32 SQLCLI_LOBcliInterface
 	currContext.resetSqlParserFlags(0x1);
 
 	if (cliRC < 0)
-	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
 	    goto error_return;
-	  }
 	
 	// insert into lob descriptor chunks table
 	if (blackBox && (blackBoxLen && (*blackBoxLen > 0)))
@@ -8704,11 +8657,7 @@ Lng32 SQLCLI_LOBcliInterface
 	currContext.resetSqlParserFlags(0x1);
 
 	if (cliRC < 0)
-	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
 	    goto error_return;
-	  }
       	if (inoutDescPartnKey)
 	  *inoutDescPartnKey = descPartnKey;
 
@@ -8741,11 +8690,7 @@ Lng32 SQLCLI_LOBcliInterface
 	currContext.resetSqlParserFlags(0x1);
 
 	if (cliRC < 0)
-	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
 	    goto error_return;
-	  }
 
 
 
@@ -8761,11 +8706,7 @@ Lng32 SQLCLI_LOBcliInterface
 	currContext.resetSqlParserFlags(0x1);
 
 	if (cliRC < 0)
-	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
 	    goto error_return;
-	  }
 
         if ((lobType != Lob_External_HDFS_File) && blackBox)
           {
@@ -8801,11 +8742,7 @@ Lng32 SQLCLI_LOBcliInterface
 	currContext.resetSqlParserFlags(0x1);
 
 	if (cliRC < 0)
-	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
-	    goto error_return;
-	  }
+	   goto error_return;
        
 	// update lob handle with the returned values
 	if (outLobHandle)
@@ -8839,11 +8776,7 @@ Lng32 SQLCLI_LOBcliInterface
 	currContext.resetSqlParserFlags(0x1);
 
 	if (cliRC < 0)
-	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
-	    goto error_return;
-	  }
+	   goto error_return;
 
 	// delete from lob descriptor chunks table
 	str_sprintf(query, "delete from table(ghost table %s) where descPartnKey = %ld and descSysKey = %ld",
@@ -8857,11 +8790,7 @@ Lng32 SQLCLI_LOBcliInterface
 	currContext.resetSqlParserFlags(0x1);
 
 	if (cliRC < 0)
-	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
 	    goto error_return;
-	  }
         
       }
       break;
@@ -8882,16 +8811,11 @@ Lng32 SQLCLI_LOBcliInterface
 	currContext.resetSqlParserFlags(0x1);
 
 	if (cliRC < 0)
-	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
 	    goto error_return;
-	  }
+
         cliRC = cliInterface->fetch();
 	if (cliRC < 0)
 	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
-
 	    cliInterface->fetchRowsEpilogue(0);
 	    goto error_return;
 	  }
@@ -8922,10 +8846,7 @@ Lng32 SQLCLI_LOBcliInterface
 	  {	    
 	    cliRC = cliInterface->fetchRowsEpilogue(0);
 	    if (cliRC < 0)
-	      {
-		cliInterface->retrieveSQLDiagnostics(myDiags);	    
 		goto error_return;	 	  
-	      }
 	  }
 	
 	// This lob has only one chunk. Read and return the single descriptor.
@@ -8943,16 +8864,11 @@ Lng32 SQLCLI_LOBcliInterface
 	currContext.resetSqlParserFlags(0x1);
 
 	if (cliRC < 0)
-	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
 	    goto error_return;
-	  }
 
 	cliRC = cliInterface->fetch();
 	if (cliRC < 0)
 	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
 
 	    cliInterface->fetchRowsEpilogue(0);
 
@@ -9007,11 +8923,7 @@ Lng32 SQLCLI_LOBcliInterface
 
 	cliRC = cliInterface->fetchRowsEpilogue(0);
 	if (cliRC < 0)
-	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
 	    goto error_return;
-	  }
 
 	cliRC = saveCliErr;
       }
@@ -9030,11 +8942,7 @@ Lng32 SQLCLI_LOBcliInterface
 	currContext.resetSqlParserFlags(0x1);
 
 	if (cliRC < 0)
-	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
 	    goto error_return;
-	  }
 
 	if (inCliInterface)
 	  *inCliInterface = cliInterface;
@@ -9046,8 +8954,6 @@ Lng32 SQLCLI_LOBcliInterface
 	cliRC = cliInterface->fetch();
 	if (cliRC < 0)
 	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
-
 	    cliInterface->fetchRowsEpilogue(0);
 
 	    if (inCliInterface)
@@ -9093,7 +8999,6 @@ Lng32 SQLCLI_LOBcliInterface
 	cliRC = cliInterface->fetchRowsEpilogue(0);
 	if (cliRC < 0)
 	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
 	    
 	    if (inCliInterface)
 	      *inCliInterface = NULL;
@@ -9121,11 +9026,7 @@ Lng32 SQLCLI_LOBcliInterface
 	currContext.resetSqlParserFlags(0x1);
 
 	if (cliRC < 0)
-	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
 	    goto error_return;
-	  }
 
 	// delete data from the chunks desc table
 	str_sprintf(query, "delete from table(ghost table %s)",
@@ -9139,11 +9040,7 @@ Lng32 SQLCLI_LOBcliInterface
 	currContext.resetSqlParserFlags(0x1);
 
 	if (cliRC < 0)
-	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
-	    goto error_return;
-	  }
+           goto error_return;
 
       }
       break;
@@ -9208,11 +9105,7 @@ Lng32 SQLCLI_LOBcliInterface
 
 	
 	if (cliRC < 0)
-	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
 	    goto error_return;
-	  }
 
 	cliRC = saveCliErr;
       }
@@ -9241,20 +9134,19 @@ Lng32 SQLCLI_LOBcliInterface
 
   NADELETEBASIC(query, currContext.exHeap());
 
+  if (cliRC < 0)
+    {
+      if (myDiags == NULL)
+         myDiags = ComDiagsArea::allocate(currContext.exHeap());
+      cliInterface->retrieveSQLDiagnostics(myDiags);
+      diags.mergeAfter(*myDiags);
+      myDiags->decrRefCount();
+    }
   if (NOT (inCliInterface && (*inCliInterface)))
     {
       delete cliInterface;
       cliInterface = NULL;
     }
-
-  if (cliRC < 0)
-    {
-      if (myDiags->getNumber() > 0)
-	{
-	  diags.mergeAfter(*myDiags);
-	}
-    }
-  myDiags->deAllocate();
   if (cliRC < 0)
      return cliRC;
   else if (cliRC == 100)
@@ -9297,7 +9189,7 @@ Lng32 SQLCLI_LOB_GC_Interface
   ContextCli   & currContext = *(cliGlobals->currContext());
   ComDiagsArea & diags       = currContext.diags();
 
-  ComDiagsArea * myDiags = ComDiagsArea::allocate(currContext.exHeap());
+  ComDiagsArea * myDiags = NULL;
 
   ExeCliInterface *cliInterface = NULL;
   cliInterface = new (currContext.exHeap()) 
@@ -9360,11 +9252,7 @@ Lng32 SQLCLI_LOB_GC_Interface
   currContext.resetSqlParserFlags(0x1);
 
   if (cliRC < 0)
-    {
-      cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
       goto error_return;
-    }  
   {     
   //Allocate an inmemory array of numEntries.
   ExLobInMemoryDescChunksEntry *dcInMemoryArray = new ExLobInMemoryDescChunksEntry[numEntries];
@@ -9381,18 +9269,11 @@ Lng32 SQLCLI_LOB_GC_Interface
   currContext.resetSqlParserFlags(0x1);
 
   if (cliRC < 0)
-    {
-      cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
       goto error_return;
-    }
   cliRC = cliInterface->fetch();
   if (cliRC < 0)
     {
-      cliInterface->retrieveSQLDiagnostics(myDiags);
-
       cliInterface->fetchRowsEpilogue(0);
-
       goto error_return;
     }
   
@@ -9436,21 +9317,14 @@ Lng32 SQLCLI_LOB_GC_Interface
       i++;
       if (cliRC < 0)
         {
-          cliInterface->retrieveSQLDiagnostics(myDiags);
-
           cliInterface->fetchRowsEpilogue(0);
-
           goto error_return;
         }
     }
 	
   cliRC = cliInterface->fetchRowsEpilogue(0);
   if (cliRC < 0)
-    {
-      cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
       goto error_return;
-    }
  
   // adjust in memory array to calculate holes and new offsets.
   ExpLOBoper::calculateNewOffsets(dcInMemoryArray,numEntries);
@@ -9486,8 +9360,6 @@ Lng32 SQLCLI_LOB_GC_Interface
 
           if (cliRC < 0)
             {
-              cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
               //tbd Give warning and rollback just these updates  and return with warning. For now return error and abort the iud operation itself since there is no support for nested transactions or SUSPEND and RESUME. 
               goto error_return;
             }
@@ -9539,12 +9411,12 @@ Lng32 SQLCLI_LOB_GC_Interface
 
   if (cliRC < 0)
     {
-      if (myDiags->getNumber() > 0)
-	{
-	  diags.mergeAfter(*myDiags);
-	}
+      if (myDiags == NULL)
+         myDiags = ComDiagsArea::allocate(currContext.exHeap());
+      diags.mergeAfter(*myDiags);
+      myDiags->decrRefCount();
+    	
     }
-  myDiags->deAllocate();
   if (cliRC < 0)
      return cliRC;
   else if (cliRC == 100)
@@ -9577,7 +9449,8 @@ Lng32 SQLCLI_LOBddlInterface
   ContextCli   & currContext = *(cliGlobals->currContext());
   ComDiagsArea & diags       = currContext.diags();
 
-  ComDiagsArea * myDiags = ComDiagsArea::allocate(currContext.exHeap());
+  ComDiagsArea * myDiags = NULL;
+
   char logBuf[4096];
   lobDebugInfo("In LOBddlInterface",0,__LINE__,lobTrace);
   ExeCliInterface *cliInterface = NULL;
@@ -9612,11 +9485,7 @@ Lng32 SQLCLI_LOBddlInterface
 	currContext.resetSqlParserFlags(0x1);
 	
 	if (cliRC < 0)
-	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
 	    goto error_return;
-	  }
 	
 	// populate the lob metadata table
 	for (Lng32 i = 0; i < numLOBs; i++)
@@ -9634,11 +9503,7 @@ Lng32 SQLCLI_LOBddlInterface
 	    currContext.resetSqlParserFlags(0x1);
 	    
 	    if (cliRC < 0)
-	      {
-		cliInterface->retrieveSQLDiagnostics(myDiags);
-		
-		goto error_return;
-	      }
+	       goto error_return;
 	    
 	  } // for
 
@@ -9654,7 +9519,7 @@ Lng32 SQLCLI_LOBddlInterface
 			    &rc, NULL, (char*)"ExpLOBInterfaceCreate",
 
 			    getLobErrStr(rc));
-            goto error_return;
+            goto non_cli_error_return;
           }
           
 	for (Lng32 i = 0; i < numLOBs; i++)
@@ -9674,7 +9539,7 @@ Lng32 SQLCLI_LOBddlInterface
 			    &rc, NULL, (char*)"ExpLOBInterfaceCreate",
 
 			    getLobErrStr(rc));
-		goto error_return;
+		goto non_cli_error_return;
 	      }
 	    
 	    // create LOB descriptor and LOB header tables
@@ -9701,11 +9566,7 @@ Lng32 SQLCLI_LOBddlInterface
 					     NULL,
 					     0,lobTrace);
 	    if (cliRC < 0)
-	      {
-		cliInterface->retrieveSQLDiagnostics(myDiags);
-		
-		goto error_return;
-	      }
+	       goto error_return;
 	    
 	  } // for
 	
@@ -9726,11 +9587,7 @@ Lng32 SQLCLI_LOBddlInterface
 	currContext.resetSqlParserFlags(0x1);
 
 	if (cliRC < 0)
-	  {
-	    cliInterface->retrieveSQLDiagnostics(&diags);
-	    
-	    goto error_return;
-	  }
+           goto error_return;
 	
 	// drop descriptor table
 	for (Lng32 i = 0; i < numLOBs; i++)
@@ -9760,11 +9617,7 @@ Lng32 SQLCLI_LOBddlInterface
 					     NULL,
 					     0,lobTrace);
 	    if (cliRC < 0)
-	      {
-		cliInterface->retrieveSQLDiagnostics(myDiags);
-		
 		goto error_return;
-	      }
 	    
 	  } // for
         //If all the descriptor tables got dropped correctly, drop the hdfs 
@@ -9782,7 +9635,7 @@ Lng32 SQLCLI_LOBddlInterface
 			    (ExeErrorCode)(8442), NULL, &cliRC    , 
 			    &rc, NULL, (char*)"ExpLOBInterfaceCreate",
 			    getLobErrStr(rc));
-            goto error_return;
+            goto non_cli_error_return;
 	      
           }
         for (Lng32 i = 0; i < numLOBs; i++)
@@ -9800,8 +9653,8 @@ Lng32 SQLCLI_LOBddlInterface
 			    (ExeErrorCode)(8442), NULL, &cliRC    , 
 			    &rc, NULL, (char*)"ExpLOBInterfaceDrop  ",
 			    getLobErrStr(rc));
-		goto error_return;
-                }
+		goto non_cli_error_return;
+              }
           }//for
       }
       break;
@@ -9819,11 +9672,8 @@ Lng32 SQLCLI_LOBddlInterface
 	currContext.resetSqlParserFlags(0x1);
 	
 	if (cliRC < 0)
-	  {
-	    cliInterface->retrieveSQLDiagnostics(&diags);
-	    
-	    goto error_return;
-	  }
+           goto error_return;
+
 	//Initialize LOB interface 
         
         Int32 rc= ExpLOBoper::initLOBglobal(exLobGlob,currContext.exHeap(),&currContext,hdfsServer,hdfsPort);
@@ -9835,7 +9685,7 @@ Lng32 SQLCLI_LOBddlInterface
 			    (ExeErrorCode)(8442), NULL, &cliRC    , 
                             &rc, NULL, (char*)"ExpLOBInterfaceCreate",
                             getLobErrStr(rc));
-            goto error_return;	      
+            goto non_cli_error_return;	      
           }
 	// drop descriptor table
 	for (Lng32 i = 0; i < numLOBs; i++)
@@ -9853,7 +9703,7 @@ Lng32 SQLCLI_LOBddlInterface
 			    (ExeErrorCode)(8442), NULL, &cliRC    , 
 			    &rc, NULL, (char*)"ExpLOBInterfaceDrop  ",
 			    getLobErrStr(rc));
-		goto error_return;
+		goto non_cli_error_return;
 	      }
 	    
 	    // drop LOB descriptor and LOB header tables
@@ -9880,11 +9730,7 @@ Lng32 SQLCLI_LOBddlInterface
 					     NULL,
 					     0,lobTrace);
 	    if (cliRC < 0)
-	      {
-		cliInterface->retrieveSQLDiagnostics(myDiags);
-		
 		goto error_return;
-	      }
 	    
 	  } // for
 	
@@ -9911,11 +9757,7 @@ Lng32 SQLCLI_LOBddlInterface
 	currContext.resetSqlParserFlags(0x1);
 
 	if (cliRC < 0)
-	  {
-	    cliInterface->retrieveSQLDiagnostics(myDiags);
-	    
 	    goto error_return;
-	  }
 
 	cliRC = 0;
 	Lng32 j = 0;
@@ -9925,7 +9767,6 @@ Lng32 SQLCLI_LOBddlInterface
 	    cliRC = cliInterface->fetch();
 	    if (cliRC < 0)
 	      {
-		cliInterface->retrieveSQLDiagnostics(myDiags);
 		
 		cliInterface->fetchRowsEpilogue(0);
 		
@@ -9971,7 +9812,6 @@ Lng32 SQLCLI_LOBddlInterface
 		if (ccliRC < 0)
 		  {
 		    cliRC = ccliRC;
-		    cliInterface->retrieveSQLDiagnostics(myDiags);
 		    goto error_return;
 		  }
 	      }
@@ -9990,19 +9830,19 @@ Lng32 SQLCLI_LOBddlInterface
     } // switch
 
  error_return:
+  if (cliRC < 0)
+    {
+      if (myDiags == NULL)
+         myDiags = ComDiagsArea::allocate(currContext.exHeap());
+      cliInterface->retrieveSQLDiagnostics(myDiags);
+      diags.mergeAfter(*myDiags);
+      myDiags->decrRefCount();
+    }
+ non_cli_error_return:
   ExpLOBinterfaceCleanup(exLobGlob);
   NADELETEBASIC(query, currContext.exHeap());
   NADELETEBASIC(hdfsServer,currContext.exHeap());
   delete cliInterface;
- 
-  if (cliRC < 0)
-    {
-      if (myDiags->getNumber() > 0)
-	{
-	  diags.mergeAfter(*myDiags);
-	}
-    }
-  myDiags->deAllocate();
   if (cliRC < 0)
      return cliRC;
   else if (cliRC == 100)
@@ -10358,7 +10198,6 @@ static Lng32 SeqGenCliInterfacePrepQry(
 				       const char * qryName,
 				       ExeCliInterface ** cliInterfaceArr,
 				       SequenceGeneratorAttributes* sga,
-				       ComDiagsArea * myDiags,
 				       ContextCli &currContext,
 				       ComDiagsArea & diags,
 				       NAHeap *exHeap)
@@ -10369,6 +10208,8 @@ static Lng32 SeqGenCliInterfacePrepQry(
   char stmtName[200];
 
   Int64 rowsAffected = 0;
+
+  ComDiagsArea *myDiags = NULL;
 
   ExeCliInterface * cliInterface = NULL;
   ExeCliInterface * cqdCliInterface = NULL;
@@ -10406,9 +10247,11 @@ static Lng32 SeqGenCliInterfacePrepQry(
       cliRC = cqdCliInterface->holdAndSetCQD("limit_max_numeric_precision", "ON");
       if (cliRC < 0)
 	{
+         if (myDiags == NULL)
+             myDiags = ComDiagsArea::allocate(exHeap);
 	  cqdCliInterface->retrieveSQLDiagnostics(myDiags);
 	  diags.mergeAfter(*myDiags);
-	  
+          myDiags->decrRefCount();
 	  return cliRC;
 	}
 
@@ -10418,11 +10261,12 @@ static Lng32 SeqGenCliInterfacePrepQry(
 						    stmtName);
       if (cliRC < 0)
 	{
+          if (myDiags == NULL)
+             myDiags = ComDiagsArea::allocate(exHeap);
 	  cliInterface->retrieveSQLDiagnostics(myDiags);
 	  diags.mergeAfter(*myDiags);
-	  
+          myDiags->decrRefCount();
 	  cqdCliInterface->restoreCQD("limit_max_numeric_precision");
-
 	  return cliRC;
 	}
 
@@ -10438,7 +10282,6 @@ static Lng32 SeqGenCliInterfaceUpdAndValidate(
 					      SequenceGeneratorAttributes* sga,
 					      NABoolean recycleQry,
                                               NABoolean startLocalXn,
-					      ComDiagsArea * myDiags,
 					      ContextCli &currContext,
 					      ComDiagsArea & diags,
 					      NAHeap *exHeap,
@@ -10456,6 +10299,8 @@ static Lng32 SeqGenCliInterfaceUpdAndValidate(
   Int64 rowsAffected = 0;
 
   ExeCliInterface * cliInterface = NULL;
+
+  ComDiagsArea *myDiags = NULL;
   
   char queryBuf[2000];
 
@@ -10469,7 +10314,7 @@ static Lng32 SeqGenCliInterfaceUpdAndValidate(
                                             "update %s.\"%s\".%s set upd_ts = cast(? as largeint not null) where seq_uid = %ld",
                                             SEQ_UPD_TS_QRY_IDX,
                                             "SEQ_UPD_TS_QRY_IDX",
-                                            cliInterfaceArr, sga, myDiags, currContext, diags, exHeap);
+                                            cliInterfaceArr, sga, currContext, diags, exHeap);
           if (cliRC < 0)
             return cliRC;
         }
@@ -10487,9 +10332,11 @@ static Lng32 SeqGenCliInterfaceUpdAndValidate(
         ((char*)inputValues, inputValuesLen, NULL, NULL, &rowsAffected);
       if (cliRC < 0)
         {
+         if (myDiags == NULL)
+             myDiags = ComDiagsArea::allocate(exHeap);
           cliInterface->retrieveSQLDiagnostics(myDiags);
           diags.mergeAfter(*myDiags);
-          
+          myDiags->decrRefCount();
           return cliRC;
         }
       
@@ -10510,7 +10357,7 @@ static Lng32 SeqGenCliInterfaceUpdAndValidate(
                                         "select  case when cast(? as largeint not null) = 1 then t.startVal else t.nextValue end, t.redefTS from (update %s.\"%s\".%s set next_value = (case when cast(? as largeint not null) = 1 then start_value + cast(? as largeint not null) else (case when next_value + cast(? as largeint not null) > max_value then max_value+1 else next_value + cast(? as largeint not null) end) end), num_calls = num_calls + 1 where seq_uid = %ld return old.start_value, old.next_value, old.redef_ts) t(startVal, nextValue, redefTS);",
                                         SEQ_PROCESS_QRY_IDX,
                                         "SEQ_PROCESS_QRY_IDX",
-                                        cliInterfaceArr, sga, myDiags, currContext, diags, exHeap);
+                                        cliInterfaceArr, sga, currContext, diags, exHeap);
       if (cliRC < 0)
         return cliRC;
     }
@@ -10532,9 +10379,11 @@ static Lng32 SeqGenCliInterfaceUpdAndValidate(
      &rowsAffected);
   if (cliRC < 0)
     {
+      if (myDiags == NULL)
+         myDiags = ComDiagsArea::allocate(exHeap);
       cliInterface->retrieveSQLDiagnostics(myDiags);
       diags.mergeAfter(*myDiags);
-
+      myDiags->decrRefCount();
       if (diags.mainSQLCODE() == -EXE_NUMERIC_OVERFLOW)
         {
           cliRC = -EXE_SG_MAXVALUE_EXCEEDED;
@@ -10575,7 +10424,7 @@ static Lng32 SeqGenCliInterfaceUpdAndValidate(
                                             "select upd_ts from %s.\"%s\".%s where seq_uid = %ld",
                                             SEQ_SEL_TS_QRY_IDX,
                                             "SEQ_SEL_TS_QRY_IDX",
-                                            cliInterfaceArr, sga, myDiags, currContext, diags, exHeap);
+                                            cliInterfaceArr, sga, currContext, diags, exHeap);
           if (cliRC < 0)
             return cliRC;
         }
@@ -10585,9 +10434,11 @@ static Lng32 SeqGenCliInterfaceUpdAndValidate(
         (NULL, 0, (char*)outputValues, &outputValuesLen, &rowsAffected);
       if (cliRC < 0)
         {
+          if (myDiags == NULL)
+             myDiags = ComDiagsArea::allocate(exHeap);
           cliInterface->retrieveSQLDiagnostics(myDiags);
           diags.mergeAfter(*myDiags);
-          
+          myDiags->decrRefCount();
           return cliRC;
         }
       
@@ -10620,7 +10471,6 @@ static Lng32 SeqGenCliInterfaceUpdAndValidateMulti(
 						   ExeCliInterface ** cliInterfaceArr,
 						   SequenceGeneratorAttributes* sga,
 						   NABoolean recycleQry,
-						   ComDiagsArea * myDiags,
 						   ContextCli &currContext,
 						   ComDiagsArea & diags,
 						   NAHeap *exHeap,
@@ -10629,6 +10479,7 @@ static Lng32 SeqGenCliInterfaceUpdAndValidateMulti(
 {
   Lng32 cliRC = 0;
   Lng32 retCliRC = 0;
+  ComDiagsArea *myDiags = NULL;
 
   if (! cliInterfaceArr[SEQ_CQD_IDX])
     cliInterfaceArr[SEQ_CQD_IDX] = new (currContext.exHeap()) 
@@ -10661,9 +10512,11 @@ static Lng32 SeqGenCliInterfaceUpdAndValidateMulti(
           cliRC = cqdCliInterface->beginWork();
           if (cliRC < 0)
             {
+              if (myDiags != NULL)
+                 myDiags = ComDiagsArea::allocate(exHeap);
               cqdCliInterface->retrieveSQLDiagnostics(myDiags);
               diags.mergeAfter(*myDiags);
-
+              myDiags->decrRefCount();
               retCliRC = cliRC;
               goto label_return;
             }
@@ -10674,7 +10527,6 @@ static Lng32 SeqGenCliInterfaceUpdAndValidateMulti(
 					       sga,
 					       recycleQry,
                                                startLocalXn,
-					       myDiags,
 					       currContext,
 					       diags,
 					       exHeap,
@@ -10753,8 +10605,6 @@ Lng32 SQLCLI_SeqGenCliInterface
   ContextCli   & currContext = *(cliGlobals->currContext());
   ComDiagsArea & diags       = currContext.diags();
 
-  ComDiagsArea * myDiags = ComDiagsArea::allocate(currContext.exHeap());
-
   ExeCliInterface ** cliInterfaceArr = NULL;
   if (inCliInterfaceArr && (*inCliInterfaceArr))
     {
@@ -10782,14 +10632,12 @@ Lng32 SQLCLI_SeqGenCliInterface
 						cliInterfaceArr,
 						sga,
 						FALSE,
-						myDiags,
 						currContext,
 						diags,
 						currContext.exHeap(),
 						nextValue,
 						endValue);
   if (cliRC < 0) {
-     myDiags->deAllocate();     
      return cliRC;
   }
   
@@ -10800,19 +10648,15 @@ Lng32 SQLCLI_SeqGenCliInterface
 						    cliInterfaceArr,
 						    sga,
 						    TRUE,
-						    myDiags,
 						    currContext,
 						    diags,
 						    currContext.exHeap(),
 						    nextValue,
 						    endValue);
       if (cliRC < 0) {
-         myDiags->deAllocate();     
 	 return cliRC;
       }
     }
-
-  myDiags->deAllocate();     
   sga->setSGNextValue(nextValue);
   sga->setSGEndValue(endValue);
 

--- a/core/sql/cli/Context.h
+++ b/core/sql/cli/Context.h
@@ -305,6 +305,8 @@ private:
   NABoolean isEmbeddedArkcmpInitialized_;
   CmpContext * embeddedArkcmpContext_;
 
+  CmpContext * prevCmpContext_;
+
   // pointer to the array of server  versions used to communicate with ARKCMP.
   ARRAY(ExSqlComp *) arkcmpArray_;
 
@@ -810,6 +812,7 @@ public:
   Int32 switchToCmpContext(Int32 cmpCntxtType);
   Int32 switchToCmpContext(void *cmpCntxt);
   Int32 switchBackCmpContext(void);
+  void copyDiagsAreaToPrevCmpContext();
   NABoolean isDropInProgress() { return dropInProgress_; }
   void setDropInProgress() { dropInProgress_ = TRUE; };
 

--- a/core/sql/cli/ExSqlComp.cpp
+++ b/core/sql/cli/ExSqlComp.cpp
@@ -634,7 +634,7 @@ ExSqlComp::ReturnStatus ExSqlComp::resendControls(NABoolean ctxSw)   // Genesis 
                       (ULng32) sizeof(userMessage));
   }
 
-  ComDiagsArea loopDiags(h_);
+  ComDiagsArea *loopDiags = NULL;
   ExControlArea *ca = ctxt->getControlArea();
   Queue *q = ca->getControlList();
 
@@ -797,10 +797,14 @@ ExSqlComp::ReturnStatus ExSqlComp::resendControls(NABoolean ctxSw)   // Genesis 
           }
           else
           {
-            loopDiags.mergeAfter(*diagArea_);
-            diagArea_->clear();
+            if (diagArea_->getNumber() > 0)
+            {
+               if (loopDiags == NULL)
+                   loopDiags = ComDiagsArea::allocate(h_);
+               loopDiags->mergeAfter(*diagArea_);
+               diagArea_->clear();
+            }
           }
-          
           ret = SUCCESS;
         }
         else
@@ -834,10 +838,13 @@ ExSqlComp::ReturnStatus ExSqlComp::resendControls(NABoolean ctxSw)   // Genesis 
     } // control list is NOT empty
   } // if (ret != ERROR)
   //
-  if (ret != SUCCESS || diagArea_->getNumber() || loopDiags.getNumber())
+  if (ret != SUCCESS || diagArea_->getNumber() || loopDiags != NULL )
   {
-    diagArea_->mergeAfter(loopDiags);
-    loopDiags.clear();
+    if (loopDiags != NULL)
+    {
+       diagArea_->mergeAfter(*loopDiags);
+       loopDiags->decrRefCount();
+    }
     if (ret != ERROR)
       ret = diagArea_->getNumber(DgSqlCode::ERROR_) ? ERROR : WARNING;
     if (ret == ERROR)

--- a/core/sql/cli/Statement.cpp
+++ b/core/sql/cli/Statement.cpp
@@ -1687,7 +1687,7 @@ RETCODE Statement::prepare2(char *source, ComDiagsArea &diagsArea,
 		  //!aqRetry  && cliGlobals_->isEmbeddedArkcmpInitialized())
                 {
                   Int32 compStatus;
-                  ComDiagsArea *da = ComDiagsArea::allocate(&heap_);
+                  ComDiagsArea *da = NULL;
 
                   // clean up diags area of regular arkcmp, it could contain
                   // old errors from last use
@@ -1698,14 +1698,17 @@ RETCODE Statement::prepare2(char *source, ComDiagsArea &diagsArea,
                   compStatus = CmpCommon::context()->compileDirect(
                                    (char *)data, dataLen,
                                    // use arkcmp heap to store the plan
+                                   // check why indexIntoCompilerArray is used here?
                                    cliGlobals_->getArkcmp(indexIntoCompilerArray)->getHeap(),
                                    charset, op,
                                    fetched_gen_code, fetched_gen_code_len,
                                    context_->getSqlParserFlags(), 
                                    NULL, 0, da);
-
-                  diagsArea.mergeAfter(*da);
-                  da->decrRefCount();
+                  if (da != NULL) 
+                  {
+                     diagsArea.mergeAfter(*da);
+                     da->decrRefCount();
+                  }
 
                   if (compStatus == ExSqlComp::SUCCESS)
                     {

--- a/core/sql/executor/ExCancel.cpp
+++ b/core/sql/executor/ExCancel.cpp
@@ -249,14 +249,13 @@ ExWorkProcRetcode ExCancelTcb::work()
               break;
             }
           }
-          ComDiagsArea *tempDiagsArea =
-                ComDiagsArea::allocate(getGlobals()->getDefaultHeap());
-          tempDiagsArea->clear();
+          
+          ComDiagsArea *tempDiagsArea = NULL;
  
           ContextCli *context = getGlobals()->castToExExeStmtGlobals()->
                 castToExMasterStmtGlobals()->getStatement()->getContext();
           ExSsmpManager *ssmpManager = context->getSsmpManager(); 
-          cbServer_ = ssmpManager->getSsmpServer(
+          cbServer_ = ssmpManager->getSsmpServer((NAHeap *)getGlobals()->getDefaultHeap(),
                                  nodeName_,
                                  cpu_, tempDiagsArea);
           if (cbServer_ == NULL) {
@@ -266,8 +265,6 @@ ExWorkProcRetcode ExCancelTcb::work()
              step_ = DONE;
              break;
           }
-          else
-             tempDiagsArea->decrRefCount();
 
           //Create the stream on the IpcHeap, since we don't dispose 
           // of it immediately.  We just add it to the list of completed 

--- a/core/sql/executor/ExExeUtilCli.cpp
+++ b/core/sql/executor/ExExeUtilCli.cpp
@@ -2088,17 +2088,17 @@ Lng32 ExeCliInterface::deleteContext(char* contextHandle) // in buf contains con
   return SQL_EXEC_DeleteContext(*(SQLCTX_HANDLE*)contextHandle);
 }
 
-Lng32 ExeCliInterface::retrieveSQLDiagnostics(ComDiagsArea * toDiags)
+Lng32 ExeCliInterface::retrieveSQLDiagnostics(ComDiagsArea *toDiags)
 {
   Lng32 retcode;
 
-  if (diagsArea_)
+  if (diagsArea_ != NULL)
     {
       diagsArea_->clear();
       diagsArea_->deAllocate();
     }
 
-  if (toDiags)
+  if (toDiags != NULL)
     {
       retcode = SQL_EXEC_MergeDiagnostics_Internal(*toDiags);
       SQL_EXEC_ClearDiagnostics(NULL);

--- a/core/sql/executor/ExExeUtilCli.h
+++ b/core/sql/executor/ExExeUtilCli.h
@@ -245,7 +245,7 @@ private:
   Lng32 currentContext(char* contextHandle); // out buf will return context handle
   Lng32 deleteContext(char* contextHandle); // in buf contains context handle
 
-  Lng32 retrieveSQLDiagnostics(ComDiagsArea * toDiags);
+  Lng32 retrieveSQLDiagnostics(ComDiagsArea *toDiags);
 
   CollHeap * getHeap() { return heap_; }
 

--- a/core/sql/executor/ExExplain.cpp
+++ b/core/sql/executor/ExExplain.cpp
@@ -1527,7 +1527,7 @@ RtsExplainFrag *ExExplainTcb::sendToSsmp()
     return NULL;
   }
 
-  IpcServer *ssmpServer = ssmpManager->getSsmpServer(nodeName, cpu, diagsArea_);
+  IpcServer *ssmpServer = ssmpManager->getSsmpServer((NAHeap *)getHeap(), nodeName, cpu, diagsArea_);
   if (ssmpServer == NULL)
     return NULL; // diags are in diagsArea_
 

--- a/core/sql/executor/ExStats.cpp
+++ b/core/sql/executor/ExStats.cpp
@@ -8164,7 +8164,7 @@ ExStatisticsArea *ExStatsTcb::sendToSsmp()
     cpu = cliGlobals->myCpu();
   else
     cpu = cpu_;
-  IpcServer *ssmpServer = ssmpManager->getSsmpServer(nodeName_, cpu, diagsArea_);
+  IpcServer *ssmpServer = ssmpManager->getSsmpServer((NAHeap *)getHeap(), nodeName_, cpu, diagsArea_);
   if (ssmpServer == NULL)
     return NULL; // diags are in diagsArea_
 

--- a/core/sql/executor/ex_control.cpp
+++ b/core/sql/executor/ex_control.cpp
@@ -197,7 +197,7 @@ short ExControlTcb::work()
       {
          
         NAHeap *arkcmpHeap = currCtxt->exHeap();
-	ComDiagsArea *da = ComDiagsArea::allocate(getHeap());
+	ComDiagsArea *da = NULL;
         cmpStatus = CmpCommon::context()->compileDirect(
                                (char *) data, dataLen, arkcmpHeap,
                                SQLCHARSETCODE_UTF8,
@@ -217,11 +217,12 @@ short ExControlTcb::work()
             
 	    // da->clear();
             getHeap()->deallocateMemory(emsText);
+            if (da != NULL)
+               da->decrRefCount();
           }
         else
           saveControl = TRUE; // need to save control to exe ControlInfoTable
 
-        da->decrRefCount();
         if (dummyReply != NULL)
           {
             arkcmpHeap->deallocateMemory((void*)dummyReply);

--- a/core/sql/executor/ex_ddl.cpp
+++ b/core/sql/executor/ex_ddl.cpp
@@ -258,8 +258,6 @@ short ExDDLTcb::work()
           const char *parentQid = masterGlob->getStatement()->
             getUniqueStmtId();
           CmpCommon::context()->sqlSession()->setParentQid(parentQid);
-          if (cpDiagsArea == NULL)
-	    cpDiagsArea = ComDiagsArea::allocate(getHeap());
           // Despite its name, the compileDirect method is where 
           // the DDL is actually performed. 
           Int32 cpStatus = CmpCommon::context()->compileDirect(
@@ -606,8 +604,6 @@ short ExDDLwithStatusTcb::work()
               getUniqueStmtId();
             CmpCommon::context()->sqlSession()->setParentQid(parentQid);
             
-            if (cpDiagsArea == NULL)
-              cpDiagsArea = ComDiagsArea::allocate(getHeap());
             cmpStatus = CmpCommon::context()->compileDirect(
                data_, dataLen_,
                currContext->exHeap(),
@@ -987,8 +983,6 @@ short ExDescribeTcb::work()
                   getUniqueStmtId();
                 CmpCommon::context()->sqlSession()->setParentQid(parentQid);
 
-                if (da == NULL)
-                  da = ComDiagsArea::allocate(arkcmpHeap);
                 compStatus = CmpCommon::context()->compileDirect(
                                  describeTdb().query_,
                                  describeTdb().queryLen_,

--- a/core/sql/executor/ex_ddl.cpp
+++ b/core/sql/executor/ex_ddl.cpp
@@ -947,6 +947,7 @@ short ExDescribeTcb::work()
   ComDiagsArea *da = NULL;  
   ComDiagsArea *diagsArea;  
   NAHeap *arkcmpHeap = currContext()->exHeap(); // same heap, see cli/Context.h
+  NABoolean deleteTmpDa = FALSE;
   while (1)
     {
       switch (pstate.step_)
@@ -1015,6 +1016,9 @@ short ExDescribeTcb::work()
                   {
                     pstate.step_ = HANDLE_ERROR_;
                   }
+                  // ComDiagsDa is allocated in compileDirect, needs to be deallocated
+                  if (da != NULL)
+                    deleteTmpDa = TRUE; 
               }
             else if (getArkcmp())  // regular arkcmp exists
               {
@@ -1144,6 +1148,8 @@ short ExDescribeTcb::work()
  	        up_entry->setDiagsArea(da);
 	        up_entry->getAtp()->getDiagsArea()->incrRefCount();
                 // Reset the da for the next error/warning.
+                if (deleteTmpDa)
+                   da->decrRefCount();
                 da = NULL;
               }
 
@@ -1188,6 +1194,8 @@ short ExDescribeTcb::work()
  	    // insert into parent
 	    qparent_.up->insert();
 	    
+            if (deleteTmpDa)
+               da->decrRefCount();
  	    // reset the diagsArea for the next error to be set properly.
  	    da = NULL;
  	    pstate.step_ = DONE_;

--- a/core/sql/export/ComDiags.h
+++ b/core/sql/export/ComDiags.h
@@ -837,7 +837,7 @@ public:
 
   // These members provide set and get operations on the data
   // of a ComDiagsArea that is defined in ANSI table 21, in subclause
-  // 18.1.  See also, ``Creating Errors Korrectly.''
+  // 18.1.  See also, ``Creating Errors Correctly.''
 
   Lng32	              getNumber           () const;
   Lng32		      getNumber           (DgSqlCode::ErrorOrWarning) const;
@@ -1017,6 +1017,12 @@ public:
  {
    while (getNumber(DgSqlCode::ERROR_))
      negateCondition(0);
+ }
+
+ void negateErrors (Lng32 fromCondition)
+ {
+   while (getNumber(DgSqlCode::ERROR_) > fromCondition)
+        negateCondition(fromCondition);
  }
  
 void negateAllWarnings  ()

--- a/core/sql/generator/GenRelScan.cpp
+++ b/core/sql/generator/GenRelScan.cpp
@@ -102,7 +102,7 @@ short Describe::codeGen(Generator * generator)
   else if (format_ == SHOWSTATS_) type = ComTdbDescribe::SHOWSTATS_;
   else if (format_ == TRANSACTION_) type = ComTdbDescribe::TRANSACTION_;
   else if (format_ == SHORT_) type = ComTdbDescribe::SHORT_;
-  else if (format_ == LONG_) type = ComTdbDescribe::LONG_;
+  else if (format_ == SHOWDDL_) type = ComTdbDescribe::LONG_;
   else if (format_ == PLAN_) type = ComTdbDescribe::PLAN_;
   else if (format_ == LABEL_) type = ComTdbDescribe::LABEL_;
   else if (format_ == SHAPE_) type = ComTdbDescribe::SHAPE_;

--- a/core/sql/optimizer/BindRelExpr.cpp
+++ b/core/sql/optimizer/BindRelExpr.cpp
@@ -14715,7 +14715,7 @@ RelExpr *Describe::bindNode(BindWA *bindWA)
               (getLabelAnsiNameSpace() == COM_TABLE_NAME) &&
               (NOT getIsSchema()))
             {
-              bindWA->getNATable(describedTableName_);
+              bindWA->getNATableInternal(describedTableName_);
               if (bindWA->errStatus())
                 {
                   return this;

--- a/core/sql/optimizer/OptimizerSimulator.cpp
+++ b/core/sql/optimizer/OptimizerSimulator.cpp
@@ -1882,7 +1882,7 @@ short OptimizerSimulator::fetchAllRowsFromMetaContext(Queue * &q, const char* qu
    retcode = cliInterface_->fetchAllRows(queue_, query, 0, FALSE, FALSE, TRUE);
    //retrieve idag area runing the query above,
    //if there's any error, we can get the detail.
-   cliInterface_->retrieveSQLDiagnostics(0);
+   cliInterface_->retrieveSQLDiagnostics(CmpCommon::diags());
 
    cmpSBD_->switchBackCompiler();
    

--- a/core/sql/optimizer/RelScan.h
+++ b/core/sql/optimizer/RelScan.h
@@ -1615,7 +1615,7 @@ public:
     INVOKE_,  // describe sql/mp INVOKE style
     SHOWSTATS_, //display histograms for specified table
     SHORT_,   // just show ddl for table
-    LONG_,    // show everything about this table (ddl, indexes, views, etc)
+    SHOWDDL_,    // show everything about this table (ddl, indexes, views, etc)
     PLAN_,    // return information about runtime plan. Currently, details
               // about expressions and clauses are the only info returned.
               // For internal debugging use only. Not externalized to users.
@@ -1658,7 +1658,7 @@ public:
 
   Describe(char * originalQuery,
            const CorrName &describedTableName,
-           Format format = LONG_,
+           Format format = SHOWDDL_,
            ComAnsiNameSpace labelAnsiNameSpace = COM_TABLE_NAME,
            ULng32 flags = 0,
 	   NABoolean header = TRUE)
@@ -1689,7 +1689,7 @@ public:
 
   Describe(char * originalQuery,
            const SchemaName &schemaName,
-           Format format = LONG_,
+           Format format = SHOWDDL_,
            ULng32 flags = 0,
 	   NABoolean header = TRUE)
     : Scan(REL_DESCRIBE),
@@ -1732,7 +1732,7 @@ public:
   Describe(char * originalQuery,
            ComIdClass authIDClass,
            const NAString &authIDName,
-           Format format = LONG_,
+           Format format = SHOWDDL_,
            ULng32 flags = 0,
            NABoolean header = TRUE)
     : Scan(REL_DESCRIBE),
@@ -1765,7 +1765,7 @@ public:
   // constructor used for SHOWDDL USER and SHOWDDL ROLE
   Describe(char * originalQuery,
            const NAString &componentName,
-           Format format = LONG_,
+           Format format = SHOWDDL_,
            ULng32 flags = 0,
            NABoolean header = TRUE)
     : Scan(REL_DESCRIBE),
@@ -1873,6 +1873,9 @@ public:
   {
     return labelAnsiNameSpace_;
   }
+
+  NABoolean getIsControl() const { return ((getFormat() >= CONTROL_FIRST_) &&
+                                           (getFormat() <= CONTROL_LAST_)); }
 
   // TRUE  => output detail (long) label info
   // FALSE => output short label info
@@ -2008,7 +2011,7 @@ public:
       format_ == INVOKE_    ||
       format_ == SHOWSTATS_ ||
       format_ == SHORT_     ||
-      format_ == LONG_      ||
+      format_ == SHOWDDL_   ||
       format_ == LABEL_) ;
   }
 

--- a/core/sql/parser/SqlParserAux.cpp
+++ b/core/sql/parser/SqlParserAux.cpp
@@ -3231,7 +3231,7 @@ SqlParserAux_buildDescribeForFunctionAndAction
     pDescribe = new (PARSERHEAP())
       Describe ( SQLTEXT()
                , *optional_showddl_action_name_clause // in - const CorrName & - deep copy
-               , Describe::LONG_
+               , Describe::SHOWDDL_
                , COM_UUDF_ACTION_NAME                 // in - ComAnsiNameSpace labelAnsiNameSpace_
                , optional_showddlroutine_options      // in - long optional_showddlroutine_options
                );
@@ -3242,7 +3242,7 @@ SqlParserAux_buildDescribeForFunctionAndAction
     pDescribe = new (PARSERHEAP())
       Describe ( SQLTEXT()
                , *actual_routine_name_of_udf_or_uudf // in - const CorrName & - deep copy
-               , Describe::LONG_
+               , Describe::SHOWDDL_
                , COM_UDF_NAME                        // in - ComAnsiNameSpace labelAnsiNameSpace_
                , optional_showddlroutine_options     // in - long optional_showddlroutine_options
                );

--- a/core/sql/parser/sqlparser.y
+++ b/core/sql/parser/sqlparser.y
@@ -22695,7 +22695,7 @@ show_statement:
 	     {
 	       $$ = new (PARSERHEAP())
 		 RelRoot(new (PARSERHEAP())
-			 Describe(SQLTEXT(), *$2, Describe::LONG_,
+			 Describe(SQLTEXT(), *$2, Describe::SHOWDDL_,
 			          COM_TABLE_NAME, $3/*optional_sqlmp_option*/),
 			 REL_ROOT,	
 			 new (PARSERHEAP())
@@ -22711,7 +22711,7 @@ show_statement:
 	     {
 	       $$ = new (PARSERHEAP())
 		 RelRoot(new (PARSERHEAP())
-			 Describe(SQLTEXT(), *$3, Describe::LONG_, 
+			 Describe(SQLTEXT(), *$3, Describe::SHOWDDL_, 
 			          COM_TABLE_NAME, $4/*optional_sqlmp_option*/),
 			 REL_ROOT,	
 			 new (PARSERHEAP())
@@ -22724,7 +22724,7 @@ show_statement:
                  ->getQualifiedNameObj().setObjectNameSpace(COM_UDF_NAME);
 	       $$ = new (PARSERHEAP())
 		 RelRoot(new (PARSERHEAP())
-			 Describe(SQLTEXT(), *$3/*actual_routine_name*/, Describe::LONG_, 
+			 Describe(SQLTEXT(), *$3/*actual_routine_name*/, Describe::SHOWDDL_, 
 			          COM_UDF_NAME, $4/*optional_showddl_options_lsit*/),
 			 REL_ROOT,
 			 new (PARSERHEAP())
@@ -22734,7 +22734,7 @@ show_statement:
 	     {
 	       $$ = new (PARSERHEAP())
 		 RelRoot(new (PARSERHEAP())
-			 Describe(SQLTEXT(), *$3, Describe::LONG_, $4),
+			 Describe(SQLTEXT(), *$3, Describe::SHOWDDL_, $4),
 			 REL_ROOT,	
 			 new (PARSERHEAP())
 			 ColReference(new (PARSERHEAP()) ColRefName(TRUE, PARSERHEAP())));
@@ -22743,7 +22743,7 @@ show_statement:
             {
               $$ = new (PARSERHEAP())
                 RelRoot(new (PARSERHEAP())
-                  Describe(SQLTEXT(), COM_USER_CLASS, *$3, Describe::LONG_),
+                  Describe(SQLTEXT(), COM_USER_CLASS, *$3, Describe::SHOWDDL_),
                   REL_ROOT,
                   new (PARSERHEAP())
                   ColReference(new (PARSERHEAP()) ColRefName(TRUE, PARSERHEAP()))); 
@@ -22753,7 +22753,7 @@ show_statement:
             {
               $$ = new (PARSERHEAP())
                 RelRoot(new (PARSERHEAP())
-                  Describe(SQLTEXT(), COM_ROLE_CLASS, *$2, Describe::LONG_, $3),
+                  Describe(SQLTEXT(), COM_ROLE_CLASS, *$2, Describe::SHOWDDL_, $3),
                   REL_ROOT,
                   new (PARSERHEAP())
                   ColReference(new (PARSERHEAP()) ColRefName(TRUE, PARSERHEAP())));
@@ -22776,7 +22776,7 @@ show_statement:
                    ->getQualifiedNameObj().setObjectNameSpace(COM_LIBRARY_NAME); 
   	         $$ = new (PARSERHEAP())
         		 RelRoot(new (PARSERHEAP()) 
-    	  		 Describe(SQLTEXT(), *$2, Describe::LONG_, COM_LIBRARY_NAME, $3),
+    	  		 Describe(SQLTEXT(), *$2, Describe::SHOWDDL_, COM_LIBRARY_NAME, $3),
   	  	           	 REL_ROOT, new (PARSERHEAP())
   			     ColReference(new (PARSERHEAP()) ColRefName(TRUE, PARSERHEAP())));
   	         delete $2; // CorrName * qualified_name
@@ -22786,7 +22786,7 @@ show_statement:
 	     {
 	       $$ = new (PARSERHEAP())
 		 RelRoot(new (PARSERHEAP())
-			 Describe(SQLTEXT(), *$2, Describe::LONG_, 
+			 Describe(SQLTEXT(), *$2, Describe::SHOWDDL_, 
 			          COM_SEQUENCE_GENERATOR_NAME, $3),
 			 REL_ROOT,	
 			 new (PARSERHEAP())
@@ -22803,7 +22803,7 @@ show_statement:
 		 ->getQualifiedNameObj().setObjectNameSpace(COM_UDF_NAME); // SPJ
 	       $$ = new (PARSERHEAP())
 		 RelRoot(new (PARSERHEAP())
-			 Describe(SQLTEXT(), *$3, Describe::LONG_, COM_UDF_NAME, $4),
+			 Describe(SQLTEXT(), *$3, Describe::SHOWDDL_, COM_UDF_NAME, $4),
 			 REL_ROOT,	
 			 new (PARSERHEAP())
 			 ColReference(new (PARSERHEAP()) ColRefName(TRUE, PARSERHEAP())));

--- a/core/sql/regress/core/EXPECTED116
+++ b/core/sql/regress/core/EXPECTED116
@@ -710,7 +710,8 @@ T116T1
 
 *** ERROR[4082] Object TRAFODION.SCH.T116T2 does not exist or is inaccessible.
 
---- SQL operation failed with errors.
+*** ERROR[8822] The statement was not prepared.
+
 >>create table t116t2 (a int);
 
 --- SQL operation complete.
@@ -732,7 +733,8 @@ T116T1
 
 *** ERROR[4082] Object TRAFODION.SCH.T116T2 does not exist or is inaccessible.
 
---- SQL operation failed with errors.
+*** ERROR[8822] The statement was not prepared.
+
 >>create table t116t2 (a int);
 
 --- SQL operation complete.

--- a/core/sql/regress/executor/EXPECTED001
+++ b/core/sql/regress/executor/EXPECTED001
@@ -50,7 +50,8 @@
 
 *** ERROR[4082] Object TRAFODION.SCH.T001TN does not exist or is inaccessible.
 
---- SQL operation failed with errors.
+*** ERROR[8822] The statement was not prepared.
+
 >>invoke t001t2;
 
 -- Definition of Trafodion table TRAFODION.SCH.T001T2

--- a/core/sql/regress/executor/EXPECTED013.SB
+++ b/core/sql/regress/executor/EXPECTED013.SB
@@ -801,7 +801,8 @@ CREATE VOLATILE TABLE T013T1
 
 *** ERROR[4082] Object TRAFODION.T013SCH1.T013T1 does not exist or is inaccessible.
 
---- SQL operation failed with errors.
+*** ERROR[8822] The statement was not prepared.
+
 >>
 >>
 >>-- store by a, 4 partns

--- a/core/sql/regress/privs1/EXPECTED141
+++ b/core/sql/regress/privs1/EXPECTED141
@@ -703,7 +703,8 @@ CREATE VIEW TRAFODION.T141_USER1.U2V1 AS
 
 *** ERROR[4082] Object TRAFODION.T141_USER1.U2V2 does not exist or is inaccessible.
 
---- SQL operation failed with errors.
+*** ERROR[8822] The statement was not prepared.
+
 >>
 >>-- these creates should fail
 >>-- user2 has no privs on u1t1

--- a/core/sql/regress/privs2/EXPECTED135
+++ b/core/sql/regress/privs2/EXPECTED135
@@ -266,7 +266,8 @@ CREATE VIEW TRAFODION.T135SCH.T135_V2_T1 AS
 
 *** ERROR[4082] Object TRAFODION.T135SCH.USER1_V1 does not exist or is inaccessible.
 
---- SQL operation failed with errors.
+*** ERROR[8822] The statement was not prepared.
+
 >>drop view user1_v1;
 
 *** ERROR[1389] Object TRAFODION.T135SCH.USER1_V1 does not exist in Trafodion.
@@ -347,7 +348,8 @@ End of MXCI Session
 
 *** ERROR[4082] Object TRAFODION.T135SCH.USER2_V1 does not exist or is inaccessible.
 
---- SQL operation failed with errors.
+*** ERROR[8822] The statement was not prepared.
+
 >>drop view user2_v1;
 
 *** ERROR[1389] Object TRAFODION.T135SCH.USER2_V1 does not exist in Trafodion.
@@ -518,7 +520,8 @@ End of MXCI Session
 
 *** ERROR[4082] Object TRAFODION.T135SCH_USER3.T135_V1_USER3 does not exist or is inaccessible.
 
---- SQL operation failed with errors.
+*** ERROR[8822] The statement was not prepared.
+
 >>
 >>exit;
 
@@ -691,7 +694,8 @@ CREATE TABLE TRAFODION.T135SCH.T135_T3
 
 *** ERROR[4082] Object TRAFODION.T135SCH_USER5.T135_V1_USER5 does not exist or is inaccessible.
 
---- SQL operation failed with errors.
+*** ERROR[8822] The statement was not prepared.
+
 >>select * from t135_v1_user5;
 
 *** ERROR[4082] Object TRAFODION.T135SCH_USER5.T135_V1_USER5 does not exist or is inaccessible.
@@ -710,7 +714,8 @@ CREATE TABLE TRAFODION.T135SCH.T135_T3
 
 *** ERROR[4082] Object TRAFODION.T135SCH.T135_V1_USER5 does not exist or is inaccessible.
 
---- SQL operation failed with errors.
+*** ERROR[8822] The statement was not prepared.
+
 >>select * from t135_v1_user5;
 
 *** ERROR[4082] Object TRAFODION.T135SCH.T135_V1_USER5 does not exist or is inaccessible.

--- a/core/sql/regress/privs2/EXPECTED138
+++ b/core/sql/regress/privs2/EXPECTED138
@@ -67,7 +67,8 @@ SB_PERSISTENT_SAMPLES
 
 *** ERROR[4082] Object TRAFODION.T138SCH.USER1_T1 does not exist or is inaccessible.
 
---- SQL operation failed with errors.
+*** ERROR[8822] The statement was not prepared.
+
 >>
 >>create table user1_t2 (c1 int, c2 int);
 
@@ -90,7 +91,8 @@ SB_PERSISTENT_SAMPLES
 
 *** ERROR[4082] Object TRAFODION.T138SCH.USER1_T2 does not exist or is inaccessible.
 
---- SQL operation failed with errors.
+*** ERROR[8822] The statement was not prepared.
+
 >>
 >>exit;
 

--- a/core/sql/regress/seabase/EXPECTED022
+++ b/core/sql/regress/seabase/EXPECTED022
@@ -801,7 +801,8 @@ a2    ?               ?
 
 *** ERROR[4082] Object TRAFODION.SCH.T022HBM1 does not exist or is inaccessible.
 
---- SQL operation failed with errors.
+*** ERROR[8822] The statement was not prepared.
+
 >>create external table t022hbm1 ("cf".a varchar(4) not null,
 +>            b int)
 +>        primary key (a)

--- a/core/sql/regress/seabase/EXPECTED026
+++ b/core/sql/regress/seabase/EXPECTED026
@@ -37,7 +37,8 @@
 
 *** ERROR[4082] Object TRAFODION.SCH026.T026T1 does not exist or is inaccessible.
 
---- SQL operation failed with errors.
+*** ERROR[8822] The statement was not prepared.
+
 >>drop table t026t1;
 
 *** ERROR[4254] Object TRAFODION.SCH026.T026T1 has invalid state and cannot be accessed. Use cleanup command to drop it.
@@ -105,12 +106,14 @@
 
 *** ERROR[4082] Object TRAFODION.SCH026.T026T0 does not exist or is inaccessible.
 
---- SQL operation failed with errors.
+*** ERROR[8822] The statement was not prepared.
+
 >>invoke t026t1;
 
 *** ERROR[4082] Object TRAFODION.SCH026.T026T1 does not exist or is inaccessible.
 
---- SQL operation failed with errors.
+*** ERROR[8822] The statement was not prepared.
+
 >>
 >>set parserflags 131072;
 

--- a/core/sql/runtimestats/ssmpipc.cpp
+++ b/core/sql/runtimestats/ssmpipc.cpp
@@ -72,7 +72,7 @@ ExSsmpManager::~ExSsmpManager()
   }
 }
 
-IpcServer *ExSsmpManager::getSsmpServer(char *nodeName, short cpuNum,
+IpcServer *ExSsmpManager::getSsmpServer(NAHeap *heap, char *nodeName, short cpuNum,
                                         ComDiagsArea *&diagsArea)
 {
    char ssmpProcessName[50];
@@ -101,6 +101,8 @@ IpcServer *ExSsmpManager::getSsmpServer(char *nodeName, short cpuNum,
         // We need to keep 2 entries free - To send QueryFinishedMessage and to get the response for query started message
        if (cbGCTS->numReceiveCallbacksPending()+2 >= cbGCTS->getNowaitDepth())
        {
+          if (diagsArea == NULL)
+             diagsArea = ComDiagsArea::allocate(heap);
           *diagsArea << DgSqlCode(-2026)
             << DgString0(tmpProcessName)
             << DgInt0(GetCliGlobals()->myCpu())

--- a/core/sql/runtimestats/ssmpipc.h
+++ b/core/sql/runtimestats/ssmpipc.h
@@ -58,7 +58,7 @@ class ExSsmpManager
 public:
   ExSsmpManager(IpcEnvironment *env);
   ~ExSsmpManager();
-  IpcServer *getSsmpServer(char *nodeName, short cpuNum, ComDiagsArea *&diagsArea);
+  IpcServer *getSsmpServer(NAHeap *heap, char *nodeName, short cpuNum, ComDiagsArea *&diagsArea);
   IpcEnvironment *getIpcEnvironment() { return env_; }
   void removeSsmpServer(char *nodeName, short cpuNum);
   void cleanupDeletedSsmpServers();

--- a/core/sql/sqlci/Param.cpp
+++ b/core/sql/sqlci/Param.cpp
@@ -50,6 +50,8 @@
 #include "NLSConversion.h"
 #include "nawstring.h"
 
+extern NAHeap sqlci_Heap;
+
 short convDoItMxcs(char * source,
 		   Lng32 sourceLen,
 		   short sourceType,
@@ -242,7 +244,7 @@ short Param::convertValue(SqlciEnv * sqlci_env, short targetType,
 			  Lng32 targetPrecision,
 			  Lng32 targetScale,
                           Lng32 vcIndLen,
-   			  ComDiagsArea* diags) {
+   			  ComDiagsArea *&diags) {
 
   // get rid of the old converted value
   if (converted_value) {
@@ -418,7 +420,7 @@ short Param::convertValue(SqlciEnv * sqlci_env, short targetType,
 		  targetScale,
 		  VCLen,
 		  VCLenSize,
-		  0,
+		  &sqlci_Heap,
 		  &diags);
     
     if ( ok != ex_expr::EXPR_OK)
@@ -454,7 +456,7 @@ short Param::convertValue(SqlciEnv * sqlci_env, short targetType,
 					   targetScale,
 					   VCLen,
 					   VCLenSize,
-					   0,
+					   &sqlci_Heap,
 					   &diags,
                                            CONV_UNKNOWN,
                                            NULL,

--- a/core/sql/sqlci/Param.h
+++ b/core/sql/sqlci/Param.h
@@ -108,7 +108,7 @@ public:
   short convertValue(SqlciEnv *, short targetType, Lng32 &targetLength,
 		     Lng32 targetPrecision, Lng32 targetScale, 
                      Lng32 vcIndLen,
-                     ComDiagsArea* diags = 0);
+                     ComDiagsArea*&diags);
   void setName(const char * name_);
 
   void setValue(const char*, CharInfo::CharSet cs = CharInfo::UnknownCharSet);

--- a/core/sql/sqlci/SqlciCmd.cpp
+++ b/core/sql/sqlci/SqlciCmd.cpp
@@ -991,7 +991,7 @@ short ParserFlags::process(SqlciEnv * sqlci_env)
     // Return - "not authorized" error 
     ComDiagsArea diags;
     diags << DgSqlCode(-1017);
-    handleLocalError(diags, sqlci_env);
+    handleLocalError(&diags, sqlci_env);
     return -1;
   }
 
@@ -1003,7 +1003,7 @@ short ParserFlags::process(SqlciEnv * sqlci_env)
       // Please use "RESET PARSERFLAGS <value>" to reset the flags.
       ComDiagsArea diags;
       diags << DgSqlCode(3190);
-      handleLocalError(diags, sqlci_env);
+      handleLocalError(&diags, sqlci_env);
     }
     retCode = SQL_EXEC_SetParserFlagsForExSqlComp_Internal2(param);
   }
@@ -1020,7 +1020,7 @@ short ParserFlags::process(SqlciEnv * sqlci_env)
     // You are not authorized to perform this operation.
     ComDiagsArea diags;
     diags << DgSqlCode(retCode);
-    handleLocalError(diags, sqlci_env);
+    handleLocalError(&diags, sqlci_env);
   }
   return 0;
 }

--- a/core/sql/sqlci/sqlcmd.h
+++ b/core/sql/sqlci/sqlcmd.h
@@ -57,9 +57,15 @@ extern void HandleCLIErrorInit();
 extern void HandleCLIError(Lng32 &err, SqlciEnv *sqlci_env, 
 			   NABoolean displayErr = TRUE,
 			   NABoolean * isEOD = NULL,
+                           Int32 prepcode = 0, NABoolean getWarningsWithEOF = FALSE);
+extern void HandleCLIError(SQLSTMT_ID *stmt, Lng32 &err, SqlciEnv *sqlci_env, 
+			   NABoolean displayErr = TRUE,
+			   NABoolean * isEOD = NULL,
                            Int32 prepcode = 0);
-void handleLocalError(ComDiagsArea &diags, SqlciEnv *sqlci_env);
 
+void handleLocalError(ComDiagsArea *diags, SqlciEnv *sqlci_env);
+Int64 getRowsAffected(SQLSTMT_ID *stmt);
+Int64 getDiagsCondCount(SQLSTMT_ID *stmt);
 // for unnamed parameters
 #define MAX_NUM_UNNAMED_PARAMS  128
 #define MAX_LEN_UNNAMED_PARAM 300

--- a/core/sql/sqlcomp/CmpDescribe.cpp
+++ b/core/sql/sqlcomp/CmpDescribe.cpp
@@ -824,8 +824,7 @@ short CmpDescribe(const char *query, const RelExpr *queryExpr,
       goto finally;  // we are done
     }
 
-  if (d->getFormat() >= Describe::CONTROL_FIRST_ &&
-      d->getFormat() <= Describe::CONTROL_LAST_)
+  if (d->getIsControl())
     {
       rc = CmpDescribeControl(d, outbuf, outbuflen, heap);
       goto finally;  // we are done
@@ -865,7 +864,7 @@ short CmpDescribe(const char *query, const RelExpr *queryExpr,
   // For now, schemaName of HIVE indicates a hive table.
   // Need to fix that at a later time when multiple hive schemas are supported.
   if (((d->getFormat() == Describe::INVOKE_) ||
-       (d->getFormat() == Describe::LONG_)) &&
+       (d->getFormat() == Describe::SHOWDDL_)) &&
       (d->getDescribedTableName().isHive()) &&
       (!d->getDescribedTableName().isSpecialTable()))
     {
@@ -886,7 +885,7 @@ short CmpDescribe(const char *query, const RelExpr *queryExpr,
 
   // check if this is an hbase/seabase table. If so, describe using info from NATable.
   if (((d->getFormat() == Describe::INVOKE_) ||
-       (d->getFormat() == Describe::LONG_)) &&
+       (d->getFormat() == Describe::SHOWDDL_)) &&
       ((d->getDescribedTableName().isHbase()) ||
        (d->getDescribedTableName().isSeabase())))
     {

--- a/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
@@ -175,14 +175,15 @@ short CmpSeabaseDDL::switchCompiler(Int32 cntxtType)
   return 0;
 }
 
+
 short CmpSeabaseDDL::switchBackCompiler()
 {
 
   Lng32 diagsMark = 0;
   if (cmpSwitched_)
   {
-     if (CmpCommon::diags() != NULL)
-        diagsMark = CmpCommon::diags()->mark(); 
+      GetCliGlobals()->currContext()->copyDiagsAreaToPrevCmpContext();
+      CmpCommon::diags()->clear();
   }
   // do restore here even though switching may not have happened, i.e.
   // when switchToCompiler() was not called by the embedded CI, see above.
@@ -190,8 +191,8 @@ short CmpSeabaseDDL::switchBackCompiler()
   
   if (cmpSwitched_)
     {
-      // ignore new (?) from restore call but restore old diags
-      CmpCommon::diags()->rewind(diagsMark, TRUE);
+      // Clear the diagnostics area of the current CmpContext
+      CmpCommon::diags()->clear();
       // switch back to the original commpiler, ignore return error
       SQL_EXEC_SWITCH_BACK_COMPILER();
 

--- a/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
@@ -177,13 +177,13 @@ short CmpSeabaseDDL::switchCompiler(Int32 cntxtType)
 
 short CmpSeabaseDDL::switchBackCompiler()
 {
-  ComDiagsArea * tempDiags = NULL;
+
+  Lng32 diagsMark = 0;
   if (cmpSwitched_)
-    {
-      tempDiags = ComDiagsArea::allocate(heap_);
-      tempDiags->mergeAfter(*CmpCommon::diags());
-    }
-  
+  {
+     if (CmpCommon::diags() != NULL)
+        diagsMark = CmpCommon::diags()->mark(); 
+  }
   // do restore here even though switching may not have happened, i.e.
   // when switchToCompiler() was not called by the embedded CI, see above.
   restoreAllControlsAndFlags();
@@ -191,11 +191,7 @@ short CmpSeabaseDDL::switchBackCompiler()
   if (cmpSwitched_)
     {
       // ignore new (?) from restore call but restore old diags
-      CmpCommon::diags()->clear();
-      CmpCommon::diags()->mergeAfter(*tempDiags);
-      tempDiags->clear();
-      tempDiags->deAllocate();
-  
+      CmpCommon::diags()->rewind(diagsMark, TRUE);
       // switch back to the original commpiler, ignore return error
       SQL_EXEC_SWITCH_BACK_COMPILER();
 

--- a/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
@@ -179,7 +179,6 @@ short CmpSeabaseDDL::switchCompiler(Int32 cntxtType)
 short CmpSeabaseDDL::switchBackCompiler()
 {
 
-  Lng32 diagsMark = 0;
   if (cmpSwitched_)
   {
       GetCliGlobals()->currContext()->copyDiagsAreaToPrevCmpContext();


### PR DESCRIPTION
 The ComDiagsArea is allocated in many places and from different heaps in Trafodion, making it difficult to  detect the source of the leak. Hence, a different approach is taken to fix this issue.
    
Currently, ComDiagsArea is allocated in many places unconditionally even when SQL statement completes execution without any error or warnings. Then it is deallocated. Changed this strategy and allocate ComDiagsArea only when there is an error or warning while compiling or executing the SQL statement.
    
This should help the product in two ways
    1) To reduce the path length.  The smaller query execution would benefit the most by chopping of few more microseconds.
    2) Reduce the memory growth due to leaked ComDiagsArea
