### PR TITLE
[TRAFODION-2977] Fix issues with maximum key length detection

### DIFF
--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -140,7 +140,7 @@
 1138 ZZZZZ 99999 ADVANCED CRTCL DIALOUT --- unused ---
 1139 ZZZZZ 99999 BEGINNER MAJOR DBADMIN System-generated column $0~ColumnName of base table $1~TableName cannot appear in the search condition of a check constraint definition.
 1140 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Row-length $0~int0 exceeds the maximum allowed row-length of $1~int1 for table $2~TableName.
-1141 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Key length $0-int0 exceeds the maximum allowed key length of $1~int1
+1141 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Key length $0~int0 exceeds the maximum allowed key length of $1~int1.
 1142 0A000 99999 BEGINNER MAJOR DBADMIN --- unused ---
 1143 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Validation for constraint $0~ConstraintName failed; incompatible data exists in referencing base table $1~TableName and referenced base table $2~String0.  To display the data that violates the constraint, please use the following DML statement: $3~String1
 1144 ZZZZZ 99999 BEGINNER MAJOR DBADMIN A quoted string was expected in first key clause for column $0~ColumnName on table $1~TableName, but the value detected is ($2~String0).

--- a/core/sql/generator/GenRelUpdate.cpp
+++ b/core/sql/generator/GenRelUpdate.cpp
@@ -2945,6 +2945,8 @@ short HbaseInsert::codeGen(Generator *generator)
 	// without code change
 	if (loadFlushSizeinRows >= USHRT_MAX/2)
 	  loadFlushSizeinRows = ((USHRT_MAX/2)-1);
+	else if (loadFlushSizeinRows < 1)  // make sure we don't fall to zero on really long rows
+	  loadFlushSizeinRows = 1;
 	hbasescan_tdb->setTrafLoadFlushSize(loadFlushSizeinRows);
 
         // For sample file, set the sample location in HDFS and the sampling rate.

--- a/core/sql/sqlcomp/CmpSeabaseDDL.h
+++ b/core/sql/sqlcomp/CmpSeabaseDDL.h
@@ -129,6 +129,11 @@ class CmpDDLwithStatusInfo;
 
 #include "CmpSeabaseDDLmd.h"
 
+// The value HBase uses for checking key length is HConstants.MAX_ROW_LENGTH.
+// The rowID length limit in HBase is enforced in HBase modules Put.java and
+// Mutation.java. (The above was true as of HBase 1.0.0.)
+#define MAX_HBASE_ROWKEY_LEN 32767
+
 #define SEABASEDDL_INTERNAL_ERROR(text)                                   \
    *CmpCommon::diags() << DgSqlCode(-CAT_INTERNAL_EXCEPTION_ERROR) 	  \
                        << DgString0(__FILE__)   		   	  \

--- a/core/sql/sqlcomp/CmpSeabaseDDLindex.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLindex.cpp
@@ -239,6 +239,14 @@ CmpSeabaseDDL::createIndexColAndKeyInfoArrays(
      keyInfoArray[i].hbaseColQual = new(CTXTHEAP) char[strlen(qualNumStr)+1];
      strcpy((char*)keyInfoArray[i].hbaseColQual, qualNumStr);
     }
+
+  if (keyLength > MAX_HBASE_ROWKEY_LEN )
+    {
+      *CmpCommon::diags() << DgSqlCode(-CAT_ROWKEY_LEN_TOO_LARGE)
+                              << DgInt0(keyLength)
+                              << DgInt1(MAX_HBASE_ROWKEY_LEN);
+      return -1;
+    }
   
   if ((syskeyOnly) &&
       (hasSyskey))

--- a/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
@@ -57,7 +57,6 @@
 
 #include "TrafDDLdesc.h"
 
-#define MAX_HBASE_ROWKEY_LEN 32768
 
 // defined in CmpDescribe.cpp
 extern short CmpDescribeSeabaseTable ( 


### PR DESCRIPTION
This set of changes fixes several minor bugs:

1. The key length limit that Trafodion imposes differed from the HBase limit. They are now the same.

2. CREATE INDEX logic lacked a check on key length. This has now been added.

3. There was a typo in the message text for message 1141 preventing the computed key length from being displayed. This has been fixed.

4. There was a bug in the generator where, if CREATE INDEX were allowed to have a long key, we generated plans to populate that index that would overrun their buffers, causing ESPs to core. This has been fixed; we now guarantee that buffers are long enough for at least one row.