### PR TITLE
[TRAFODION-3000] Fix binder issue with index maintenance on MERGE DELETE

### DIFF
--- a/core/sql/optimizer/Inlining.cpp
+++ b/core/sql/optimizer/Inlining.cpp
@@ -1888,7 +1888,7 @@ static RelExpr *createIMNode(BindWA *bindWA,
 			     NABoolean isIMInsert,
 			     NABoolean useInternalSyskey,
                              NABoolean isForUpdateOrMergeUpdate,
-                             NABoolean isForMerge, // mergeDelete OR mergeUpdate
+                             NABoolean mergeDeleteWithInsertOrMergeUpdate,
 			     NABoolean isEffUpsert)
 {
    
@@ -1906,7 +1906,8 @@ static RelExpr *createIMNode(BindWA *bindWA,
   // that correspond to the base table. Hence we introduce 
   // robustDelete below. This flag could also be called 
   // isIMOnAUniqueIndexForMerge
-  NABoolean robustDelete = (isForMerge && index->isUniqueIndex()) || (isEffUpsert && index->isUniqueIndex());
+  NABoolean robustDelete = (mergeDeleteWithInsertOrMergeUpdate && index->isUniqueIndex()) || 
+                           (isEffUpsert && index->isUniqueIndex());
 
   tableCorrName.setCorrName(isIMInsert ?  NEWCorr : OLDCorr);
   
@@ -2127,8 +2128,15 @@ RelExpr *GenericUpdate::createIMNodes(BindWA *bindWA,
   if (getOperatorType() == REL_UNARY_DELETE ||
       getOperatorType() == REL_UNARY_UPDATE ||
       isEffUpsert)
-    
-    indexDelete = indexOp = createIMNode(bindWA,
+    {
+      NABoolean mergeDeleteWithInsertOrMergeUpdate = isMerge();
+      if (mergeDeleteWithInsertOrMergeUpdate && 
+          (getOperatorType() == REL_UNARY_DELETE) && 
+          (!insertValues()))
+        // merge delete without an insert
+        mergeDeleteWithInsertOrMergeUpdate = FALSE;
+      
+      indexDelete = indexOp = createIMNode(bindWA,
 					 tableCorrName,
                                          indexCorrName,
 					 index,
@@ -2136,8 +2144,9 @@ RelExpr *GenericUpdate::createIMNodes(BindWA *bindWA,
 					 FALSE,
     			       		 useInternalSyskey,
                                          isForUpdateOrMergeUpdate,
-                                         isMerge(),
+                                         mergeDeleteWithInsertOrMergeUpdate,
 					 isEffUpsert);
+    }
 
   if ((getOperatorType() == REL_UNARY_UPDATE) || isEffUpsert){
     indexOp = new (bindWA->wHeap()) Union(indexDelete, indexInsert, 


### PR DESCRIPTION
The inlining code for index maintenance in one place was assuming a record descriptor (RETDesc) for new values existed for a MERGE DELETE statement lacking a "when not matched" clause. But no such record descriptor exists, since there are no values being updated or inserted. That place has been changed to use the old record descriptor.