### PR TITLE
[TRAFODION-3002] Fix UPDATE STATS for certain INTERVAL data types

### DIFF
--- a/core/sql/ustat/hs_globals.cpp
+++ b/core/sql/ustat/hs_globals.cpp
@@ -5052,7 +5052,7 @@ static void mapInternalSortTypes(HSColGroupStruct *groupList, NABoolean forHive 
           }
         else
           {
-            sprintf(sbuf, "%d", col.precision+2);
+            sprintf(sbuf, "%d,0", col.precision+2); // for seconds cast below
             typeName = getIntTypeForInterval(group, 60 * (Int64)pow(10, col.precision));
           }
         group->ISSelectExpn.append("cast(cast(")
@@ -5076,7 +5076,7 @@ static void mapInternalSortTypes(HSColGroupStruct *groupList, NABoolean forHive 
           }
         else
           {
-            sprintf(sbuf, "%d", col.precision+4);
+            sprintf(sbuf, "%d,0", col.precision+4); // for seconds cast below
             typeName = getIntTypeForInterval(group, 60 * 60 * (Int64)pow(10, col.precision));
           }
         group->ISSelectExpn.append("cast(cast(")
@@ -5100,7 +5100,7 @@ static void mapInternalSortTypes(HSColGroupStruct *groupList, NABoolean forHive 
           }
         else
           {
-            sprintf(sbuf, "%d", col.precision+5);
+            sprintf(sbuf, "%d,0", col.precision+5); // for seconds cast below
             typeName = getIntTypeForInterval(group, 24 * 60 * 60 * (Int64)pow(10, col.precision));
           }
         group->ISSelectExpn.append("cast(cast(")


### PR DESCRIPTION
Formerly, UPDATE STATS would fail with an internal error when processing an INTERVAL DAY(13) TO SECOND(0) column. It would also fail with a core when processing an INTERVAL DAY(8) TO SECOND(0) column. This has been fixed.