### PR TITLE
[TRAFODION-2821] Trafodion core code base needs to be thread safe

### DIFF
--- a/core/sql/arkcmp/CmpContext.cpp
+++ b/core/sql/arkcmp/CmpContext.cpp
@@ -569,7 +569,7 @@ NABoolean CmpContext::execHiveSQL(const char* hiveSQL, ComDiagsArea *diags)
 
       if (!result && diags)
         *diags << DgSqlCode(-1214)
-               << DgString0(GetCliGlobals()->getJniErrorStrPtr())
+               << DgString0(GetCliGlobals()->getJniErrorStr())
                << DgString1(hiveSQL);
     }
 

--- a/core/sql/cli/Context.h
+++ b/core/sql/cli/Context.h
@@ -630,18 +630,6 @@ public:
     xactAborted = udrXactAborted_;
   }
 
-  inline void setJniErrorStr(NAString errorStr)
-  {  jniErrorStr_ = errorStr; }
-
-  inline void setJniErrorStr(const char *errorStr)
-  {  jniErrorStr_ = errorStr; }
-
-  inline NAString getJniErrorStr()
-  { return jniErrorStr_; }
-
-  inline const char* getJniErrorStrPtr()
-  { return (const char*)jniErrorStr_.data(); }
-
   inline CLISemaphore *getSemaphore()
   { 
      return cliSemaphore_;

--- a/core/sql/cli/Globals.cpp
+++ b/core/sql/cli/Globals.cpp
@@ -921,26 +921,6 @@ void CliGlobals::getUdrErrorFlags(NABoolean &sqlViolation,
                                   xactAborted);
 }
 
-void CliGlobals::setJniErrorStr(NAString errorStr)
-{
-   currContext()->setJniErrorStr(errorStr);
-}
-
-void CliGlobals::setJniErrorStr(const char *errorStr)
-{
-   currContext()->setJniErrorStr(errorStr);
-}
-
-NAString CliGlobals::getJniErrorStr()
-{
-  return currContext()->getJniErrorStr();
-}
-
-const char* CliGlobals::getJniErrorStrPtr()
-{
-  return currContext()->getJniErrorStrPtr();
-}
-
 void CliGlobals::updateTransMode(TransMode *transMode)
 {
   currContext()->getTransaction()->getTransMode()->

--- a/core/sql/cli/Globals.h
+++ b/core/sql/cli/Globals.h
@@ -70,6 +70,8 @@
 #include "ComExeTrace.h"
 #include "ComRtUtils.h"
 #include "ComSmallDefs.h"
+#include "JavaObjectInterface.h"
+
 class ContextCli;
 class Statement;  
 class ComDiagsArea; 
@@ -238,10 +240,9 @@ public:
   inline void setUncProcess() { isUncProcess_ = TRUE; }
   inline NABoolean isUncProcess() {return isUncProcess_;}
   NAHeap *getCurrContextHeap();
-  void setJniErrorStr(NAString errorStr); 
-  void setJniErrorStr(const char *errorStr); 
-  NAString getJniErrorStr();
-  const char* getJniErrorStrPtr();
+  void setJniErrorStr(NAString errorStr) { setSqlJniErrorStr(errorStr);  }
+  void setJniErrorStr(const char *errorStr)  { setSqlJniErrorStr(errorStr); }
+  const char* getJniErrorStr() { return getSqlJniErrorStr(); }
   void updateTransMode(TransMode *transMode);
 
 

--- a/core/sql/executor/ExExeUtilLoad.cpp
+++ b/core/sql/executor/ExExeUtilLoad.cpp
@@ -1259,7 +1259,7 @@ short ExExeUtilHBaseBulkLoadTcb::work()
                           &cliError, NULL,
                           " ",
                           getHbaseErrStr(retcode),
-                          (char *)currContext->getJniErrorStr().data());
+                          (char *)GetCliGlobals()->getJniErrorStr());
         step_ = LOAD_END_ERROR_;
         break;
       }
@@ -1962,7 +1962,7 @@ void ExExeUtilHBaseBulkUnLoadTcb::createHdfsFileError(Int32 hdfsClientRetCode)
   ComDiagsArea * diagsArea = NULL;
   char* errorMsg = HdfsClient::getErrorText((HDFS_Client_RetCode)hdfsClientRetCode);
   ExRaiseSqlError(getHeap(), &diagsArea, (ExeErrorCode)(8447), NULL,
-                  NULL, NULL, NULL, errorMsg, (char *)GetCliGlobals()->currContext()->getJniErrorStr().data());
+                  NULL, NULL, NULL, errorMsg, (char *)GetCliGlobals()->getJniErrorStr());
   ex_queue_entry *pentry_up = qparent_.up->getTailEntry();
   pentry_up->setDiagsArea(diagsArea);
 }

--- a/core/sql/executor/ExFastTransport.cpp
+++ b/core/sql/executor/ExFastTransport.cpp
@@ -1277,7 +1277,7 @@ void ExHdfsFastExtractTcb::createSequenceFileError(Int32 sfwRetCode)
                   (ExeErrorCode)(8447),
                   NULL, NULL, NULL, NULL,
                   errorMsg,
-                (char *)currContext->getJniErrorStr().data());
+                (char *)GetCliGlobals()->getJniErrorStr());
   //ex_queue_entry *pentry_down = qParent_.down->getHeadEntry();
   //pentry_down->setDiagsArea(diagsArea);
   updateWorkATPDiagsArea(diagsArea);
@@ -1294,7 +1294,7 @@ void ExHdfsFastExtractTcb::createHdfsClientFileError(Int32 hdfsClientRetCode)
                   (ExeErrorCode)(8447),
                   NULL, NULL, NULL, NULL,
                   errorMsg,
-                  (char *)currContext->getJniErrorStr().data());
+                  (char *)GetCliGlobals()->getJniErrorStr());
   updateWorkATPDiagsArea(diagsArea);
 }
 

--- a/core/sql/executor/ExHbaseAccess.cpp
+++ b/core/sql/executor/ExHbaseAccess.cpp
@@ -722,7 +722,7 @@ short ExHbaseAccessTcb::setupError(NAHeap *heap, ex_queue_pair &qparent, Lng32 r
 		      (str ? (char*)str : (char*)" "),
 		      getHbaseErrStr(retcode),
                       (str2 ? (char*)str2 : 
-                      (char *)currContext->getJniErrorStr().data())); 
+                      (char *)GetCliGlobals()->getJniErrorStr())); 
       pentry_down->setDiagsArea(diagsArea);
       return -1;
     }
@@ -752,7 +752,7 @@ short ExHbaseAccessTcb::setupError(Lng32 retcode, const char * str, const char *
 		      (str ? (char*)str : (char*)" "),
 		      getHbaseErrStr(retcode),
                       (str2 ? (char*)str2 : 
-                      (char *)currContext->getJniErrorStr().data())); 
+                      (char *)GetCliGlobals()->getJniErrorStr())); 
       pentry_down->setDiagsArea(diagsArea);
       return -1;
     }
@@ -3295,7 +3295,7 @@ logErrorReturn:
      loggingErrorDiags_ = ComDiagsArea::allocate(heap);
      *loggingErrorDiags_ << DgSqlCode(EXE_ERROR_WHILE_LOGGING)
                  << DgString0(loggingFileName_)
-                 << DgString1((char *)GetCliGlobals()->currContext()->getJniErrorStr().data());
+                 << DgString1((char *)GetCliGlobals()->getJniErrorStr());
   }
   return;
 }

--- a/core/sql/executor/ExHdfsScan.cpp
+++ b/core/sql/executor/ExHdfsScan.cpp
@@ -570,7 +570,7 @@ ExWorkProcRetcode ExHdfsScanTcb::work()
                             hdfsStats_, hdfsScanRetCode);
              if (hdfsScanRetCode != HDFS_SCAN_OK) {
                 setupError(EXE_ERROR_HDFS_SCAN, hdfsScanRetCode, "SETUP_HDFS_SCAN", 
-                              currContext->getJniErrorStr(), NULL);              
+                              GetCliGlobals()->getJniErrorStr(), NULL);              
                 step_ = HANDLE_ERROR_AND_DONE;
                 break;
              } 
@@ -594,7 +594,7 @@ ExWorkProcRetcode ExHdfsScanTcb::work()
              }
              else if (hdfsScanRetCode != HDFS_SCAN_OK) {
                 setupError(EXE_ERROR_HDFS_SCAN, hdfsScanRetCode, "SETUP_HDFS_SCAN", 
-                              currContext->getJniErrorStr(), NULL);              
+                              GetCliGlobals()->getJniErrorStr(), NULL);              
                 step_ = HANDLE_ERROR_AND_DONE;
                 break;
              } 
@@ -670,7 +670,7 @@ ExWorkProcRetcode ExHdfsScanTcb::work()
              hdfsScanRetCode = hdfsScan_->stop();
              if (hdfsScanRetCode != HDFS_SCAN_OK) {
                 setupError(EXE_ERROR_HDFS_SCAN, hdfsScanRetCode, "HdfsScan::stop", 
-                              currContext->getJniErrorStr(), NULL);              
+                              GetCliGlobals()->getJniErrorStr(), NULL);              
                 step_ = HANDLE_ERROR_AND_DONE;
              }    
              step_ = DONE;
@@ -2193,7 +2193,7 @@ logErrorReturn:
      loggingErrorDiags_ = ComDiagsArea::allocate(heap);
      *loggingErrorDiags_ << DgSqlCode(EXE_ERROR_WHILE_LOGGING)
                  << DgString0(loggingFileName_)
-                 << DgString1((char *)GetCliGlobals()->currContext()->getJniErrorStr().data());
+                 << DgString1((char *)GetCliGlobals()->getJniErrorStr());
   }
 }
 

--- a/core/sql/executor/HBaseClient_JNI.cpp
+++ b/core/sql/executor/HBaseClient_JNI.cpp
@@ -430,6 +430,7 @@ HBC_RetCode HBaseClient_JNI::releaseHTableClient(HTableClient_JNI* htc)
       jenv_->CallVoidMethod(javaObj_, JavaMethods_[JM_REL_HTC].methodID, j_htc);
       if (jenv_->ExceptionCheck()) {
          getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::releaseHTableClient()");
+         jenv_->PopLocalFrame(NULL);
          return HBC_ERROR_REL_HTC_EXCEPTION;
       }
   }
@@ -902,7 +903,6 @@ HBC_RetCode HBaseClient_JNI::registerTruncateOnAbort(const char* fileName, Int64
   if (jenv_->ExceptionCheck())
   {
     getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::drop()");
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::drop()", getLastError());
     jenv_->PopLocalFrame(NULL);
     return HBC_ERROR_DROP_EXCEPTION;
   }
@@ -3318,7 +3318,7 @@ HTC_RetCode HTableClient_JNI::setWriteBufferSize(Int64 size)
 
   if (jenv_->ExceptionCheck())
   {
-    logError(CAT_SQL_HBASE, "HTableClient_JNI::setWriteBufferSize()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HTableClient_JNI::setWriteBufferSize()");
     jenv_->PopLocalFrame(NULL);
     return HTC_ERROR_WRITEBUFFERSIZE_EXCEPTION;
   }
@@ -3955,6 +3955,13 @@ HVC_RetCode HiveClient_JNI::getAllTables(const char* schName,
     getExceptionDetails(__FILE__, __LINE__, "HiveClient_JNI::getAllTables()");
     jenv_->PopLocalFrame(NULL);
     return HVC_ERROR_GET_ALLTBL_EXCEPTION;
+  }
+
+  if (j_tblNames == NULL) 	
+  {	
+     GetCliGlobals()->setJniErrorStr(getErrorText(HVC_ERROR_EXISTS_EXCEPTION));
+     jenv_->PopLocalFrame(NULL);	
+     return HVC_ERROR_EXISTS_EXCEPTION;	
   }
 
   int numTables = convertStringObjectArrayToList(heap_, j_tblNames,

--- a/core/sql/executor/HBaseClient_JNI.cpp
+++ b/core/sql/executor/HBaseClient_JNI.cpp
@@ -336,9 +336,7 @@ HBC_RetCode HBaseClient_JNI::initConnection(const char* zkServers, const char* z
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::initConnection()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::initConnection()");
     jenv_->PopLocalFrame(NULL);
     return HBC_ERROR_INIT_EXCEPTION;
   }
@@ -393,9 +391,7 @@ HTableClient_JNI* HBaseClient_JNI::getHTableClient(NAHeap *heap, const char* tab
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::getHTableClient()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::getHTableClient()");
     NADELETE(htc, HTableClient_JNI, heap);
     jenv_->PopLocalFrame(NULL);
     return NULL;
@@ -403,10 +399,9 @@ HTableClient_JNI* HBaseClient_JNI::getHTableClient(NAHeap *heap, const char* tab
 
   if (j_htc == NULL) 
   {
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::getHTableClient()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::getHTableClient()");
     NADELETE(htc, HTableClient_JNI, heap);
     jenv_->PopLocalFrame(NULL);
-    return NULL;
   }
   htc->setJavaObject(j_htc);
   if (htc->init() != HTC_OK)
@@ -434,10 +429,7 @@ HBC_RetCode HBaseClient_JNI::releaseHTableClient(HTableClient_JNI* htc)
       tsRecentJMFromJNI = JavaMethods_[JM_REL_HTC].jm_full_name;
       jenv_->CallVoidMethod(javaObj_, JavaMethods_[JM_REL_HTC].methodID, j_htc);
       if (jenv_->ExceptionCheck()) {
-         getExceptionDetails();
-         logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-         logError(CAT_SQL_HBASE, "HBaseClient_JNI::releaseHTableClient()", getLastError());
-         jenv_->PopLocalFrame(NULL);
+         getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::releaseHTableClient()");
          return HBC_ERROR_REL_HTC_EXCEPTION;
       }
   }
@@ -465,15 +457,7 @@ HBulkLoadClient_JNI* HBaseClient_JNI::getHBulkLoadClient(NAHeap *heap)
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::getHBulkLoadClient()", getLastError());
-    jenv_->PopLocalFrame(NULL);
-    return NULL;
-  }
-  if (j_hblc == NULL)
-  {
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::getHBulkLoadClient()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::getHBulkLoadClient()");
     jenv_->PopLocalFrame(NULL);
     return NULL;
   }
@@ -505,9 +489,7 @@ HBC_RetCode HBaseClient_JNI::releaseHBulkLoadClient(HBulkLoadClient_JNI* hblc)
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::releaseHBulkLOadClient()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::releaseHBulkLoadClient()");
     jenv_->PopLocalFrame(NULL);
     return HBC_ERROR_REL_HBLC_EXCEPTION;
   }
@@ -535,9 +517,7 @@ HBC_RetCode HBaseClient_JNI::create(const char* fileName, HBASE_NAMELIST& colFam
   jobjectArray j_fams = convertToStringObjectArray(colFamilies);
   if (j_fams == NULL)
   {
-     getExceptionDetails();
-     logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-     logError(CAT_SQL_HBASE, "HBaseClient_JNI::create()", getLastError());
+     GetCliGlobals()->setJniErrorStr(getErrorText(HBC_ERROR_CREATE_PARAM));
      jenv_->PopLocalFrame(NULL);
      return HBC_ERROR_CREATE_PARAM;
   }
@@ -549,9 +529,7 @@ HBC_RetCode HBaseClient_JNI::create(const char* fileName, HBASE_NAMELIST& colFam
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::create()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::create()");
     jenv_->PopLocalFrame(NULL);
     return HBC_ERROR_CREATE_EXCEPTION;
   }
@@ -592,9 +570,7 @@ HBC_RetCode HBaseClient_JNI::create(const char* fileName,
                    HBASE_MAX_OPTIONS);
   if (j_opts == NULL)
   {
-     getExceptionDetails();
-     logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-     logError(CAT_SQL_HBASE, "HBaseClient_JNI::create()", getLastError());
+     getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::create()");
      jenv_->PopLocalFrame(NULL);
      return HBC_ERROR_CREATE_PARAM;
   }
@@ -605,9 +581,7 @@ HBC_RetCode HBaseClient_JNI::create(const char* fileName,
      j_keys = convertToByteArrayObjectArray(splitValues, numSplits, keyLength);
      if (j_keys == NULL)
      {
-        getExceptionDetails();
-        logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-        logError(CAT_SQL_HBASE, "HBaseClient_JNI::create()", getLastError());
+        getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::create()");
         jenv_->PopLocalFrame(NULL);
         return HBC_ERROR_CREATE_PARAM;
      }
@@ -623,9 +597,7 @@ HBC_RetCode HBaseClient_JNI::create(const char* fileName,
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::create()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::create()");
     jenv_->PopLocalFrame(NULL);
     return HBC_ERROR_CREATE_EXCEPTION;
   }
@@ -660,11 +632,9 @@ HBC_RetCode HBaseClient_JNI::alter(const char* fileName,
   }
   jobjectArray j_opts = convertToStringObjectArray(createOptionsArray, 
                    HBASE_MAX_OPTIONS);
-  if (j_opts == NULL)
+  if (jenv_->ExceptionCheck())
   {
-     getExceptionDetails();
-     logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-     logError(CAT_SQL_HBASE, "HBaseClient_JNI::alter()", getLastError());
+     getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::alter()");
      jenv_->PopLocalFrame(NULL);
      return HBC_ERROR_ALTER_PARAM;
   }
@@ -677,9 +647,7 @@ HBC_RetCode HBaseClient_JNI::alter(const char* fileName,
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::alter()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::alter()");
     jenv_->PopLocalFrame(NULL);
     return HBC_ERROR_ALTER_EXCEPTION;
   }
@@ -933,8 +901,7 @@ HBC_RetCode HBaseClient_JNI::registerTruncateOnAbort(const char* fileName, Int64
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails(jenv_);
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::drop()");
     logError(CAT_SQL_HBASE, "HBaseClient_JNI::drop()", getLastError());
     jenv_->PopLocalFrame(NULL);
     return HBC_ERROR_DROP_EXCEPTION;
@@ -967,9 +934,7 @@ HBC_RetCode HBaseClient_JNI::truncate(const char* fileName, NABoolean preserveSp
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails(jenv_);
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::drop()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::truncate()");
     jenv_->PopLocalFrame(NULL);
     return HBC_ERROR_TRUNCATE_EXCEPTION;
   }
@@ -999,9 +964,7 @@ HBC_RetCode HBaseClient_JNI::drop(const char* fileName, JNIEnv* jenv, Int64 tran
 
   if (jenv->ExceptionCheck())
   {
-    getExceptionDetails(jenv);
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::drop()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::drop()");
     jenv_->PopLocalFrame(NULL);
     return HBC_ERROR_DROP_EXCEPTION;
   }
@@ -1043,9 +1006,7 @@ HBC_RetCode HBaseClient_JNI::dropAll(const char* pattern, bool async, Int64 tran
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails(jenv_);
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::dropAll()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::dropAll()");
     jenv_->PopLocalFrame(NULL);
     return HBC_ERROR_DROP_EXCEPTION;
   }
@@ -1078,9 +1039,7 @@ NAArray<HbaseStr>* HBaseClient_JNI::listAll(NAHeap *heap, const char* pattern)
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails(jenv_);
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::listAll()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::listAll()");
     jenv_->PopLocalFrame(NULL);
     return NULL;
   }
@@ -1112,9 +1071,7 @@ Int32 HBaseClient_JNI::getRegionStatsEntries()
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails(jenv_);
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::getRegionStatsEntries()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::getRegionStatsEntries()");
     jenv_->PopLocalFrame(NULL);
     return 0;
   }
@@ -1151,9 +1108,7 @@ NAArray<HbaseStr>* HBaseClient_JNI::getRegionStats(NAHeap *heap, const char* tbl
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails(jenv_);
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::getRegionStats()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::getRegionStats()");
     jenv_->PopLocalFrame(NULL);
     return NULL;
   }
@@ -1209,9 +1164,7 @@ HBC_RetCode HBaseClient_JNI::copy(const char* srcTblName,
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails(jenv_);
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::copy()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::copy()");
     jenv_->PopLocalFrame(NULL);
     return HBC_ERROR_DROP_EXCEPTION;
   }
@@ -1251,9 +1204,7 @@ HBC_RetCode HBaseClient_JNI::exists(const char* fileName, Int64 transID)
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::exists()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::exists()");
     jenv_->PopLocalFrame(NULL);
     return HBC_ERROR_EXISTS_EXCEPTION;
   }
@@ -1303,9 +1254,7 @@ HBC_RetCode HBaseClient_JNI::grant(const Text& user, const Text& tblName, const 
     j_actionCodes = convertToStringObjectArray(actions);
     if (j_actionCodes == NULL)
     {
-       getExceptionDetails();
-       logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-       logError(CAT_SQL_HBASE, "HBaseClient_JNI::grant()", getLastError());
+       getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::grant()");
        jenv_->PopLocalFrame(NULL);
        return HBC_ERROR_GRANT_PARAM;
     }
@@ -1316,9 +1265,7 @@ HBC_RetCode HBaseClient_JNI::grant(const Text& user, const Text& tblName, const 
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::grant()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::grant()");
     jenv_->PopLocalFrame(NULL);
     return HBC_ERROR_GRANT_EXCEPTION;
   }
@@ -1381,9 +1328,7 @@ HBC_RetCode HBaseClient_JNI::estimateRowCount(const char* tblName,
   breadCrumb = 4;
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::estimateRowCount()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::estimateRowCount()");
     jenv_->PopLocalFrame(NULL);
     return HBC_ERROR_ROWCOUNT_EST_EXCEPTION;
   }
@@ -1418,10 +1363,7 @@ HBC_RetCode HBaseClient_JNI::getLatestSnapshot(const char * tblName, char *& sna
   jstring jresult = (jstring)jenv_->CallObjectMethod(javaObj_, JavaMethods_[JM_GET_LATEST_SNP].methodID,js_tblName);
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::getLatestSnapshot()", 
-             getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::getLatestSnapshot()");
     jenv_->PopLocalFrame(NULL);
     return HBC_ERROR_GET_LATEST_SNP_EXCEPTION;
   }
@@ -1457,9 +1399,7 @@ HBC_RetCode HBaseClient_JNI::cleanSnpTmpLocation(const char * path)
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::cleanSnpTmpLocation()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::cleanupSnpTmpLocation()");
     jenv_->PopLocalFrame(NULL);
     return HBC_ERROR_CLEAN_SNP_TMP_LOC_EXCEPTION;
   }
@@ -1485,10 +1425,7 @@ HBC_RetCode HBaseClient_JNI::setArchivePermissions(const char * tbl)
   jboolean jresult = jenv_->CallBooleanMethod(javaObj_, JavaMethods_[JM_SET_ARC_PERMS].methodID,js_tbl);
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::setArchivePermissions()",
-             getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::setArchivePermissions()");
     jenv_->PopLocalFrame(NULL);
     return HBC_ERROR_SET_ARC_PERMS_EXCEPTION;
   }
@@ -1509,10 +1446,7 @@ HBC_RetCode HBaseClient_JNI::getBlockCacheFraction(float& frac)
   
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::getBlockCacheFraction()", 
-             getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::getBlockCacheFraction()");
     jenv_->PopLocalFrame(NULL);
     return HBC_ERROR_GET_CACHE_FRAC_EXCEPTION;
   }
@@ -1649,9 +1583,7 @@ HBLC_RetCode HBulkLoadClient_JNI::initHFileParams(
   }
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBulkLoadClient_JNI::initHFileParams() => before calling Java.", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBulkLoadClient_JNI::initHFileParams()");
     jenv_->PopLocalFrame(NULL);
     return HBLC_ERROR_CREATE_HFILE_EXCEPTION;
   }
@@ -1664,9 +1596,7 @@ HBLC_RetCode HBulkLoadClient_JNI::initHFileParams(
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBulkLoadClient_JNI::initHFileParams()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBulkLoadClient_JNI::initHFileParams()");
     jenv_->PopLocalFrame(NULL);
     return HBLC_ERROR_CREATE_HFILE_EXCEPTION;
   }
@@ -1718,9 +1648,7 @@ HBLC_RetCode HBulkLoadClient_JNI::addToHFile( short rowIDLen, HbaseStr &rowIDs,
   }
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBulkLoadClient_JNI::addToHFile()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBulkLoadClient_JNI::addToHFile()");
     jenv_->PopLocalFrame(NULL);
     return HBLC_ERROR_ADD_TO_HFILE_EXCEPTION;
   }
@@ -1747,9 +1675,7 @@ HBLC_RetCode HBulkLoadClient_JNI::closeHFile(
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBulkLoadClient_JNI::closeHFile()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBulkLoadClient_JNI::closeHFile()");
     jenv_->PopLocalFrame(NULL);
     return HBLC_ERROR_CLOSE_HFILE_EXCEPTION;
   }
@@ -1791,15 +1717,6 @@ HBLC_RetCode HBulkLoadClient_JNI::doBulkLoad(
      return HBLC_ERROR_DO_BULKLOAD_PARAM;
    }
 
-  if (jenv_->ExceptionCheck())
-  {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBulkLoadClient_JNI::doBulkLoad() => before calling Java.", getLastError());
-    jenv_->PopLocalFrame(NULL);
-    return HBLC_ERROR_DO_BULKLOAD_EXCEPTION;
-  }
-
   jboolean j_quasiSecure = quasiSecure;
 
   jboolean j_snapshot = snapshot;
@@ -1808,9 +1725,7 @@ HBLC_RetCode HBulkLoadClient_JNI::doBulkLoad(
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBulkLoadClient_JNI::doBulkLoad()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBulkLoadClient_JNI::doBulkLoad()");
     jenv_->PopLocalFrame(NULL);
     return HBLC_ERROR_DO_BULKLOAD_EXCEPTION;
   }
@@ -1834,29 +1749,18 @@ HBLC_RetCode HBulkLoadClient_JNI::bulkLoadCleanup(
      return HBLC_ERROR_INIT_PARAM;
 
   jstring js_location = jenv_->NewStringUTF(location.c_str());
-   if (js_location == NULL)
-   {
+  if (js_location == NULL)
+  {
      GetCliGlobals()->setJniErrorStr(getErrorText(HBLC_ERROR_BULKLOAD_CLEANUP_PARAM));
      jenv_->PopLocalFrame(NULL);
      return HBLC_ERROR_BULKLOAD_CLEANUP_PARAM;
-   }
-
-
-  if (jenv_->ExceptionCheck())
-  {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBulkLoadClient_JNI::bulkLoadCleanup() => before calling Java.", getLastError());
-    jenv_->PopLocalFrame(NULL);
-    return HBLC_ERROR_BULKLOAD_CLEANUP_PARAM;
   }
+
   tsRecentJMFromJNI = JavaMethods_[JM_BULK_LOAD_CLEANUP].jm_full_name;
   jboolean jresult = jenv_->CallBooleanMethod(javaObj_, JavaMethods_[JM_BULK_LOAD_CLEANUP].methodID, js_location);
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBulkLoadClient_JNI::bulkLoadCleanup()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBulkLoadClient_JNI::bulkLoadCleanup()");
     jenv_->PopLocalFrame(NULL);
     return HBLC_ERROR_BULKLOAD_CLEANUP_PARAM;
   }
@@ -1912,9 +1816,7 @@ HBLC_RetCode HBulkLoadClient_JNI::bulkLoadCleanup(
    count = jcount;
    if (jenv_->ExceptionCheck())
    {
-     getExceptionDetails();
-     logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-     logError(CAT_SQL_HBASE, "HBaseClient_JNI::incrCounter()", getLastError());
+     getExceptionDetails(__FILE__, __LINE__, "HBulkLoadClient_JNI::incrCounter()");
      jenv_->PopLocalFrame(NULL);
      return HBC_ERROR_INCR_COUNTER_EXCEPTION;
    }
@@ -1947,9 +1849,7 @@ HBLC_RetCode HBulkLoadClient_JNI::bulkLoadCleanup(
 
    if (jenv_->ExceptionCheck())
    {
-     getExceptionDetails();
-     logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-     logError(CAT_SQL_HBASE, "HBaseClient_JNI::createCounterTable()", getLastError());
+     getExceptionDetails(__FILE__, __LINE__, "HBulkLoadClient_JNI::createCounterTable()");
      jenv_->PopLocalFrame(NULL);
      return HBC_ERROR_CREATE_COUNTER_EXCEPTION;
    }
@@ -2004,9 +1904,7 @@ HBC_RetCode HBaseClient_JNI::revoke(const Text& user, const Text& tblName, const
     j_actionCodes = convertToStringObjectArray(actions);
     if (j_actionCodes == NULL)
     {
-       getExceptionDetails();
-       logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-       logError(CAT_SQL_HBASE, "HBaseClient_JNI::revoke()", getLastError());
+       getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::revoke()");
        jenv_->PopLocalFrame(NULL);
        return HBC_ERROR_REVOKE_PARAM;
     }
@@ -2017,9 +1915,7 @@ HBC_RetCode HBaseClient_JNI::revoke(const Text& user, const Text& tblName, const
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::revoke()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::revoke()");
     jenv_->PopLocalFrame(NULL);
     return HBC_ERROR_REVOKE_EXCEPTION;
   }
@@ -2082,9 +1978,7 @@ HTableClient_JNI *HBaseClient_JNI::startGet(NAHeap *heap, const char* tableName,
   if (!cols.isEmpty()) {
      j_cols = convertToByteArrayObjectArray(cols);
      if (j_cols == NULL) {
-        getExceptionDetails();
-        logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-        logError(CAT_SQL_HBASE, "HBaseClient_JNI::startGet()", getLastError());
+        getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::startGet()");
         NADELETE(htc, HTableClient_JNI, heap);
         jenv_->PopLocalFrame(NULL);
         return NULL;
@@ -2111,9 +2005,7 @@ HTableClient_JNI *HBaseClient_JNI::startGet(NAHeap *heap, const char* tableName,
   }
 
   if (jenv_->ExceptionCheck()) {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseCient_JNI::startGet()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::startGet()");
     jenv_->PopLocalFrame(NULL);
     releaseHTableClient(htc);
     return NULL;
@@ -2160,9 +2052,7 @@ HTableClient_JNI *HBaseClient_JNI::startGets(NAHeap *heap, const char* tableName
   if (!cols.isEmpty()) {
      j_cols = convertToByteArrayObjectArray(cols);
      if (j_cols == NULL) {
-        getExceptionDetails();
-        logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-        logError(CAT_SQL_HBASE, "HBaseClient_JNI::startGets()", getLastError());
+        getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::startGets()");
         NADELETE(htc, HTableClient_JNI, heap);
         jenv_->PopLocalFrame(NULL);
         return NULL;
@@ -2177,9 +2067,7 @@ HTableClient_JNI *HBaseClient_JNI::startGets(NAHeap *heap, const char* tableName
   if (rowIDs != NULL) {
      j_rows = convertToByteArrayObjectArray(*rowIDs);
      if (j_rows == NULL) {
-        getExceptionDetails();
-        logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-        logError(CAT_SQL_HBASE, "HBaseClient_JNI::startGets()", getLastError());
+        getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::startGets()");
         NADELETE(htc, HTableClient_JNI, heap);
         jenv_->PopLocalFrame(NULL);
         return NULL;
@@ -2224,9 +2112,7 @@ HTableClient_JNI *HBaseClient_JNI::startGets(NAHeap *heap, const char* tableName
   }
 
   if (jenv_->ExceptionCheck()) {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseCient_JNI::startGets()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::startGets()");
     jenv_->PopLocalFrame(NULL);
     releaseHTableClient(htc);
     return NULL;
@@ -2280,9 +2166,7 @@ HBC_RetCode HBaseClient_JNI::getRegionsNodeName(const char* tblName,
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::getRegionsNodeName()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::getRegionsNodeName()");
     jenv_->PopLocalFrame(NULL);
     return HBC_ERROR_GET_HBTI_EXCEPTION;
   }
@@ -2324,9 +2208,7 @@ HBC_RetCode HBaseClient_JNI::getHbaseTableInfo(const char* tblName,
                                               js_tblName, jHtabInfo);
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::getHbaseTableInfo()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::getHbaseTableInfo()");
     jenv_->PopLocalFrame(NULL);
     return HBC_ERROR_GET_HBTI_EXCEPTION;
   }
@@ -2413,9 +2295,7 @@ HBC_RetCode HBaseClient_JNI::insertRow(NAHeap *heap, const char *tableName,
          hbs->incMaxHbaseIOTime(hbs->getHbaseTimer().stop());
   }
   if (jenv_->ExceptionCheck()) {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::insertRow()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::insertRow()");
     jenv_->PopLocalFrame(NULL);
     if (htc != NULL)
         NADELETE(htc, HTableClient_JNI, heap);
@@ -2503,9 +2383,7 @@ HBC_RetCode HBaseClient_JNI::insertRows(NAHeap *heap, const char *tableName,
          hbs->incMaxHbaseIOTime(hbs->getHbaseTimer().stop());
   }
   if (jenv_->ExceptionCheck()) {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::insertRows()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::insertRows()");
     jenv_->PopLocalFrame(NULL);
     if (htc != NULL)
         NADELETE(htc, HTableClient_JNI, heap);
@@ -2618,9 +2496,7 @@ HBC_RetCode HBaseClient_JNI::checkAndUpdateRow(NAHeap *heap, const char *tableNa
          hbs->incMaxHbaseIOTime(hbs->getHbaseTimer().stop());
   }
   if (jenv_->ExceptionCheck()) {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::checkAndUpdateRow()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::cheakAndUpdateRow()");
     if (htc != NULL)
         NADELETE(htc, HTableClient_JNI, heap);
     jenv_->PopLocalFrame(NULL);
@@ -2691,9 +2567,7 @@ HBC_RetCode HBaseClient_JNI::deleteRow(NAHeap *heap, const char *tableName,
   if (cols != NULL && !cols->isEmpty()) {
      j_cols = convertToByteArrayObjectArray(*cols);
      if (j_cols == NULL) {
-        getExceptionDetails();
-        logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-        logError(CAT_SQL_HBASE, "HBaseClient_JNI::deleteRow()", getLastError());
+        getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::deleteRow()");
         if (htc != NULL)
            NADELETE(htc, HTableClient_JNI, heap);
         jenv_->PopLocalFrame(NULL);
@@ -2719,9 +2593,7 @@ HBC_RetCode HBaseClient_JNI::deleteRow(NAHeap *heap, const char *tableName,
          hbs->incMaxHbaseIOTime(hbs->getHbaseTimer().stop());
   }
   if (jenv_->ExceptionCheck()) {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::deleteRow()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::deleteRow()");
     jenv_->PopLocalFrame(NULL);
     if (htc != NULL)
         NADELETE(htc, HTableClient_JNI, heap);
@@ -2804,9 +2676,7 @@ HBC_RetCode HBaseClient_JNI::deleteRows(NAHeap *heap, const char *tableName,
          hbs->incMaxHbaseIOTime(hbs->getHbaseTimer().stop());
   }
   if (jenv_->ExceptionCheck()) {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::deleteRows()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::deleteRows()");
     jenv_->PopLocalFrame(NULL);
     if (htc != NULL)
         NADELETE(htc, HTableClient_JNI, heap);
@@ -2908,9 +2778,7 @@ HBC_RetCode HBaseClient_JNI::checkAndDeleteRow(NAHeap *heap, const char *tableNa
          hbs->incMaxHbaseIOTime(hbs->getHbaseTimer().stop());
   }
   if (jenv_->ExceptionCheck()) {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::checkAndDeleteRow()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::checkAndDeleteRow()");
     jenv_->PopLocalFrame(NULL);
     if (htc != NULL)
         NADELETE(htc, HTableClient_JNI, heap);
@@ -2959,8 +2827,7 @@ NAArray<HbaseStr>* HBaseClient_JNI::getKeys(Int32 funcIndex, NAHeap *heap, const
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::getKeys()");
     jenv_->PopLocalFrame(NULL);
     return NULL;
   }
@@ -2999,9 +2866,7 @@ HBC_RetCode HBaseClient_JNI::createSnapshot( const NAString&  tableName, const N
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::createSnapshot()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::createSnapshot()");
     jenv_->PopLocalFrame(NULL);
     return HBC_ERROR_CREATE_SNAPSHOT_EXCEPTION;
   }
@@ -3037,9 +2902,7 @@ HBC_RetCode HBaseClient_JNI::verifySnapshot( const NAString&  tableName, const N
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::verifySnapshot()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::verifySnapshot()");
     jenv_->PopLocalFrame(NULL);
     return HBC_ERROR_VERIFY_SNAPSHOT_EXCEPTION;
   }
@@ -3070,9 +2933,7 @@ HBC_RetCode HBaseClient_JNI::deleteSnapshot( const NAString&  snapshotName)
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::deleteSnapshot()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HBaseClient_JNI::deleteSnapshot()");
     jenv_->PopLocalFrame(NULL);
     return HBC_ERROR_DELETE_SNAPSHOT_EXCEPTION;
   }
@@ -3187,8 +3048,6 @@ HTC_RetCode HTableClient_JNI::init()
       return (HTC_RetCode)JavaObjectInterface::init(className, javaClass_, JavaMethods_, (Int32)JM_LAST, javaMethodsInitialized_);
     }
     JavaMethods_ = new JavaMethodInit[JM_LAST];
-    JavaMethods_[JM_GET_ERROR  ].jm_name      = "getLastError";
-    JavaMethods_[JM_GET_ERROR  ].jm_signature = "()Ljava/lang/String;";
     JavaMethods_[JM_SCAN_OPEN  ].jm_name      = "startScan";
     JavaMethods_[JM_SCAN_OPEN  ].jm_signature = "(J[B[B[Ljava/lang/Object;JZZI[Ljava/lang/Object;[Ljava/lang/Object;[Ljava/lang/Object;FFZZILjava/lang/String;Ljava/lang/String;II)Z";
     JavaMethods_[JM_DELETE     ].jm_name      = "deleteRow";
@@ -3214,14 +3073,6 @@ HTC_RetCode HTableClient_JNI::init()
     pthread_mutex_unlock(&javaMethodsInitMutex_);
   }
   return rc;
-}
-
-//////////////////////////////////////////////////////////////////////////////
-// 
-//////////////////////////////////////////////////////////////////////////////
-NAString HTableClient_JNI::getLastJavaError()
-{
-  return JavaObjectInterface::getLastJavaError(JavaMethods_[JM_GET_ERROR].methodID);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -3273,9 +3124,7 @@ HTC_RetCode HTableClient_JNI::startScan(Int64 transID, const Text& startRowID,
     j_cols = convertToByteArrayObjectArray(cols);
     if (j_cols == NULL)
     {
-       getExceptionDetails();
-       logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-       logError(CAT_SQL_HBASE, "HTableClient_JNI::startScan()", getLastError());
+       getExceptionDetails(__FILE__, __LINE__, "HTableClient_JNI::startScan()");
        jenv_->PopLocalFrame(NULL);
        return HTC_ERROR_SCANOPEN_PARAM;
     }
@@ -3300,9 +3149,7 @@ HTC_RetCode HTableClient_JNI::startScan(Int64 transID, const Text& startRowID,
     j_colnamestofilter = convertToByteArrayObjectArray(*inColNamesToFilter);
     if (j_colnamestofilter == NULL)
     {
-       getExceptionDetails();
-       logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-       logError(CAT_SQL_HBASE, "HTableClient_JNI::startScan()", getLastError());
+       getExceptionDetails(__FILE__, __LINE__, "HTableClient_JNI::startScan()");
        jenv_->PopLocalFrame(NULL);
        return HTC_ERROR_SCANOPEN_PARAM;
     }
@@ -3314,9 +3161,7 @@ HTC_RetCode HTableClient_JNI::startScan(Int64 transID, const Text& startRowID,
      j_compareoplist = convertToByteArrayObjectArray(*inCompareOpList);
      if (j_compareoplist == NULL)
      {
-        getExceptionDetails();
-        logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-        logError(CAT_SQL_HBASE, "HTableClient_JNI::startScan()", getLastError());
+        getExceptionDetails(__FILE__, __LINE__, "HTableClient_JNI::startScan()");
         jenv_->PopLocalFrame(NULL);
         return HTC_ERROR_SCANOPEN_PARAM;
      }
@@ -3328,9 +3173,7 @@ HTC_RetCode HTableClient_JNI::startScan(Int64 transID, const Text& startRowID,
      j_colvaluestocompare = convertToByteArrayObjectArray(*inColValuesToCompare);
      if (j_colvaluestocompare == NULL)
      {
-        getExceptionDetails();
-        logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-        logError(CAT_SQL_HBASE, "HTableClient_JNI::startScan()", getLastError());
+        getExceptionDetails(__FILE__, __LINE__, "HTableClient_JNI::startScan()");
         jenv_->PopLocalFrame(NULL);
         return HTC_ERROR_SCANOPEN_PARAM;
      }
@@ -3379,9 +3222,7 @@ HTC_RetCode HTableClient_JNI::startScan(Int64 transID, const Text& startRowID,
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HTableClient_JNI::scanOpen()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HTableClient_JNI::scanOpen()");
     jenv_->PopLocalFrame(NULL);
     return HTC_ERROR_SCANOPEN_EXCEPTION;
   }
@@ -3420,9 +3261,7 @@ HTC_RetCode HTableClient_JNI::deleteRow(Int64 transID, HbaseStr &rowID, const LI
      j_cols = convertToByteArrayObjectArray(*cols);
      if (j_cols == NULL)
      {
-        getExceptionDetails();
-        logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-        logError(CAT_SQL_HBASE, "HTableClient_JNI::deleteRow()", getLastError());
+        getExceptionDetails(__FILE__, __LINE__, "HTableClient_JNI::deleteROw()");
         jenv_->PopLocalFrame(NULL);
         return HTC_ERROR_DELETEROW_PARAM;
      }
@@ -3444,9 +3283,7 @@ HTC_RetCode HTableClient_JNI::deleteRow(Int64 transID, HbaseStr &rowID, const LI
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HTableClient_JNI::deleteRow()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HTableClient_JNI::deleteROw()");
     jenv_->PopLocalFrame(NULL);
     return HTC_ERROR_DELETEROW_EXCEPTION;
   }
@@ -3481,8 +3318,6 @@ HTC_RetCode HTableClient_JNI::setWriteBufferSize(Int64 size)
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
     logError(CAT_SQL_HBASE, "HTableClient_JNI::setWriteBufferSize()", getLastError());
     jenv_->PopLocalFrame(NULL);
     return HTC_ERROR_WRITEBUFFERSIZE_EXCEPTION;
@@ -3514,9 +3349,7 @@ HTC_RetCode HTableClient_JNI::setWriteToWAL(bool WAL)
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HTableClient_JNI::setWriteToWAL()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HTableClient_JNI::setWriteToWAL)");
     jenv_->PopLocalFrame(NULL);
     return HTC_ERROR_WRITETOWAL_EXCEPTION;
   }
@@ -3552,9 +3385,7 @@ std::string* HTableClient_JNI::getHTableName()
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HTableClient_JNI::getHTableName()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HTableClient_JNI::getHTableName()");
     jenv_->PopLocalFrame(NULL);
     return NULL;
   }
@@ -3654,9 +3485,7 @@ HTC_RetCode HTableClient_JNI::coProcAggr(Int64 transID,
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HTableClient_JNI::coProcAggr()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HTableClient_JNI::coProcAggr()");
     jenv_->PopLocalFrame(NULL);
     return HTC_ERROR_COPROC_AGGR_EXCEPTION;
   }
@@ -3704,6 +3533,8 @@ static const char* const hvcErrorEnumStr[] =
  ,"Java exception in getAllSchemas()."
  ,"Preparing parameters for getAllTables()."
  ,"Java exception in getAllTables()."
+ ,"Preparing parameters for executeHiveSQL()."
+ ,"Java exception in executeHiveSQL()."
 };
 
 
@@ -3781,8 +3612,6 @@ HVC_RetCode HiveClient_JNI::init()
     
     JavaMethods_[JM_CTOR       ].jm_name      = "<init>";
     JavaMethods_[JM_CTOR       ].jm_signature = "()V";
-    JavaMethods_[JM_GET_ERROR  ].jm_name      = "getLastError";
-    JavaMethods_[JM_GET_ERROR  ].jm_signature = "()Ljava/lang/String;";
     JavaMethods_[JM_INIT       ].jm_name      = "init";
     JavaMethods_[JM_INIT       ].jm_signature = "(Ljava/lang/String;)Z";
     JavaMethods_[JM_CLOSE      ].jm_name      = "close";
@@ -3810,14 +3639,6 @@ HVC_RetCode HiveClient_JNI::init()
 //////////////////////////////////////////////////////////////////////////////
 // 
 //////////////////////////////////////////////////////////////////////////////
-NAString HiveClient_JNI::getLastJavaError()
-{
-  return JavaObjectInterface::getLastJavaError(JavaMethods_[JM_GET_ERROR].methodID);
-}
-
-//////////////////////////////////////////////////////////////////////////////
-// 
-//////////////////////////////////////////////////////////////////////////////
 HVC_RetCode HiveClient_JNI::initConnection(const char* metastoreURI)
 {
   QRLogger::log(CAT_SQL_HBASE, LL_DEBUG, "HiveClient_JNI::initConnection(%s) called.", metastoreURI);
@@ -3839,9 +3660,7 @@ HVC_RetCode HiveClient_JNI::initConnection(const char* metastoreURI)
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HiveClient_JNI::initConnection()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HiveClient_JNI::initConnection()");
     jenv_->PopLocalFrame(NULL);
     return HVC_ERROR_INIT_EXCEPTION;
   }
@@ -3873,9 +3692,7 @@ HVC_RetCode HiveClient_JNI::close()
   jboolean jresult = jenv_->CallBooleanMethod(javaObj_, JavaMethods_[JM_CLOSE].methodID);
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HiveClient_JNI::close()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HiveClient_JNI::close()");
     jenv_->PopLocalFrame(NULL);
     return HVC_ERROR_CLOSE_EXCEPTION;
   }
@@ -3921,9 +3738,7 @@ HVC_RetCode HiveClient_JNI::exists(const char* schName, const char* tabName)
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HiveClient_JNI::exists()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HiveClient_JNI::exists()");
     jenv_->PopLocalFrame(NULL);
     return HVC_ERROR_EXISTS_EXCEPTION;
   }
@@ -3970,9 +3785,7 @@ HVC_RetCode HiveClient_JNI::getHiveTableStr(const char* schName,
                                             js_schName, js_tabName);
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HiveClient_JNI::getHiveTableStr()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HiveClient_JNI::getHiveTableStr()");
     jenv_->PopLocalFrame(NULL);
     return HVC_ERROR_GET_HVT_EXCEPTION;
   }
@@ -4031,9 +3844,7 @@ HVC_RetCode HiveClient_JNI::getRedefTime(const char* schName,
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HiveClient_JNI::getRedefTime()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HiveClient_JNI::getRedefTime()");
     jenv_->PopLocalFrame(NULL);
     return HVC_ERROR_GET_REDEFTIME_EXCEPTION;
   }
@@ -4066,9 +3877,7 @@ HVC_RetCode HiveClient_JNI::getAllSchemas(LIST(Text *)& schNames)
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HiveClient_JNI::getAllSchemas()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HiveClient_JNI::getAllSchemas()");
     jenv_->PopLocalFrame(NULL);
     return HVC_ERROR_GET_ALLSCH_EXCEPTION;
   }
@@ -4099,7 +3908,7 @@ HVC_RetCode HiveClient_JNI::executeHiveSQL(const char* hiveSQL)
   {
     GetCliGlobals()->setJniErrorStr(getErrorText(HVC_ERROR_GET_ALLTBL_PARAM));
     jenv_->PopLocalFrame(NULL);
-    return HVC_ERROR_GET_ALLTBL_PARAM;
+    return HVC_ERROR_EXECUTE_HIVE_SQL_PARAM;
   }
   
   tsRecentJMFromJNI = JavaMethods_[JM_EXEC_HIVE_SQL].jm_full_name;
@@ -4107,11 +3916,9 @@ HVC_RetCode HiveClient_JNI::executeHiveSQL(const char* hiveSQL)
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HiveClient_JNI::executeHiveSQL()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HiveClient_JNI::executeHiveSQL()");
     jenv_->PopLocalFrame(NULL);
-    return HVC_ERROR_GET_ALLSCH_EXCEPTION;
+    return HVC_ERROR_EXECUTE_HIVE_SQL_EXCEPTION;
   }
 
   QRLogger::log(CAT_SQL_HBASE, LL_DEBUG, 
@@ -4143,21 +3950,9 @@ HVC_RetCode HiveClient_JNI::getAllTables(const char* schName,
     (jarray)jenv_->CallObjectMethod(javaObj_, JavaMethods_[JM_GET_ATL].methodID, 
                             js_schName);
 
-  if (j_tblNames == NULL) 
-    {
-      getExceptionDetails();
-
-      logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-      logError(CAT_SQL_HBASE, "HiveClient_JNI::getAllTables()", getLastError());
-      jenv_->PopLocalFrame(NULL);
-      return HVC_ERROR_EXISTS_EXCEPTION;
-    }
-
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HiveClient_JNI::getAllTables()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HiveClient_JNI::getAllTables()");
     jenv_->PopLocalFrame(NULL);
     return HVC_ERROR_GET_ALLTBL_EXCEPTION;
   }
@@ -4520,17 +4315,13 @@ HTC_RetCode HTableClient_JNI::prepareForNextCell(int idx)
     kvBufferObj = jenv_->GetObjectArrayElement(jKvFamArray_, idx);
     if (jenv_->ExceptionCheck())
     {
-      getExceptionDetails();
-      logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-      logError(CAT_SQL_HBASE, "HTableClient_JNI::prepareForNextCell()", getLastError());
+      getExceptionDetails(__FILE__, __LINE__, "HTableClient_JNI::prepareForNextCell()");
       return HTC_PREPARE_FOR_NEXTCELL_EXCEPTION;
     }
     jba_kvFamArray_ = (jbyteArray)jenv_->NewGlobalRef(kvBufferObj);
     if (jenv_->ExceptionCheck())
     {
-      getExceptionDetails();
-      logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-      logError(CAT_SQL_HBASE, "HTableClient_JNI::prepareForNextCell()", getLastError());
+      getExceptionDetails(__FILE__, __LINE__, "HTableClient_JNI::prepareForNextCell()");
       return HTC_PREPARE_FOR_NEXTCELL_EXCEPTION;
     }
     jenv_->DeleteLocalRef(kvBufferObj);
@@ -4543,17 +4334,13 @@ HTC_RetCode HTableClient_JNI::prepareForNextCell(int idx)
     kvBufferObj = jenv_->GetObjectArrayElement(jKvQualArray_, idx);
     if (jenv_->ExceptionCheck())
     {
-      getExceptionDetails();
-      logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-      logError(CAT_SQL_HBASE, "HTableClient_JNI::prepareForNextCell()", getLastError());
+      getExceptionDetails(__FILE__, __LINE__, "HTableClient_JNI::prepareForNextCell()");
       return HTC_PREPARE_FOR_NEXTCELL_EXCEPTION;
     }
     jba_kvQualArray_ = (jbyteArray)jenv_->NewGlobalRef(kvBufferObj);
     if (jenv_->ExceptionCheck())
     {
-      getExceptionDetails();
-      logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-      logError(CAT_SQL_HBASE, "HTableClient_JNI::prepareForNextCell()", getLastError());
+      getExceptionDetails(__FILE__, __LINE__, "HTableClient_JNI::prepareForNextCell()");
       return HTC_PREPARE_FOR_NEXTCELL_EXCEPTION;
     }
     jenv_->DeleteLocalRef(kvBufferObj);
@@ -4566,17 +4353,13 @@ HTC_RetCode HTableClient_JNI::prepareForNextCell(int idx)
     kvBufferObj = jenv_->GetObjectArrayElement(jKvBuffer_, idx);
     if (jenv_->ExceptionCheck())
     {
-      getExceptionDetails();
-      logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-      logError(CAT_SQL_HBASE, "HTableClient_JNI::prepareForNextCell()", getLastError());
+      getExceptionDetails(__FILE__, __LINE__, "HTableClient_JNI::prepareForNextCell()");
       return HTC_PREPARE_FOR_NEXTCELL_EXCEPTION;
     }
     jba_kvBuffer_ = (jbyteArray)jenv_->NewGlobalRef(kvBufferObj);
     if (jenv_->ExceptionCheck())
     {
-      getExceptionDetails();
-      logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-      logError(CAT_SQL_HBASE, "HTableClient_JNI::prepareForNextCell()", getLastError());
+      getExceptionDetails(__FILE__, __LINE__, "HTableClient_JNI::prepareForNextCell()");
       return HTC_PREPARE_FOR_NEXTCELL_EXCEPTION;
     }
     jenv_->DeleteLocalRef(kvBufferObj);
@@ -4744,9 +4527,7 @@ HTC_RetCode HTableClient_JNI::getRowID(HbaseStr &rowID)
        jba_rowID_ = (jbyteArray)jenv_->NewGlobalRef(rowIDObj);
        if (jenv_->ExceptionCheck())
        {
-          getExceptionDetails();
-          logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-          logError(CAT_SQL_HBASE, "HTableClient_JNI::getRowID()", getLastError());
+          getExceptionDetails(__FILE__, __LINE__, "HTableClient_JNI::getRowID()");
           return HTC_GET_ROWID_EXCEPTION;
        }
        jenv_->DeleteLocalRef(rowIDObj);
@@ -4780,21 +4561,12 @@ HTC_RetCode HTableClient_JNI::fetchRows()
 
    if (jenv_->ExceptionCheck())
    {
-      getExceptionDetails();
-      logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-      logError(CAT_SQL_HBASE, "HTableClient_JNI::fetchRows()", getLastError());
+      getExceptionDetails(__FILE__, __LINE__, "HTableClient_JNI::fetchRows()");
       jenv_->PopLocalFrame(NULL);
       return HTC_ERROR_FETCHROWS_EXCEPTION;
    }
 
    numRowsReturned_ = jRowsReturned;
-   if (numRowsReturned_ == -1)
-   {
-      logError(CAT_SQL_HBASE, "HTableClient_JNI::fetchRows()", getLastJavaError());
-      jenv_->PopLocalFrame(NULL);
-      return HTC_ERROR_FETCHROWS_EXCEPTION;
-   }
-   else
    if (numRowsReturned_ == 0) {
       jenv_->PopLocalFrame(NULL);
       return HTC_DONE;
@@ -4879,7 +4651,6 @@ HTC_RetCode HTableClient_JNI::completeAsyncOperation(Int32 timeout, NABoolean *r
   HTC_RetCode retcode;
 
   if (initJNIEnv() != JOI_OK) {
-     getExceptionDetails();
      if (hbs_)
         hbs_->incMaxHbaseIOTime(hbs_->getHbaseTimer().stop());
      return HTC_ERROR_COMPLETEASYNCOPERATION_EXCEPTION;
@@ -4887,9 +4658,7 @@ HTC_RetCode HTableClient_JNI::completeAsyncOperation(Int32 timeout, NABoolean *r
   jint jtimeout = timeout;
   jbooleanArray jresultArray =  jenv_->NewBooleanArray(resultArrayLen);
   if (jenv_->ExceptionCheck()) {
-      getExceptionDetails();
-      logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-      logError(CAT_SQL_HBASE, "HTableClient_JNI::completeAsyncOperation()", getLastError());
+      getExceptionDetails(__FILE__, __LINE__, "HTableClient_JNI::completeAsyncOperation()");
       jenv_->PopLocalFrame(NULL);
       if (hbs_)
          hbs_->incMaxHbaseIOTime(hbs_->getHbaseTimer().stop());
@@ -4899,9 +4668,7 @@ HTC_RetCode HTableClient_JNI::completeAsyncOperation(Int32 timeout, NABoolean *r
   jboolean jresult = jenv_->CallBooleanMethod(javaObj_, JavaMethods_[JM_COMPLETE_PUT].methodID,
                                jtimeout, jresultArray);
   if (jenv_->ExceptionCheck()) {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HTableClient_JNI::completeAsyncOperation()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HTableClient_JNI::completeAsyncOperation()");
     jenv_->PopLocalFrame(NULL);
     if (hbs_)
        hbs_->incMaxHbaseIOTime(hbs_->getHbaseTimer().stop());

--- a/core/sql/executor/HBaseClient_JNI.h
+++ b/core/sql/executor/HBaseClient_JNI.h
@@ -282,11 +282,8 @@ public:
   }
 
 private:
-  NAString getLastJavaError();
-
   enum JAVA_METHODS {
-    JM_GET_ERROR
-   ,JM_SCAN_OPEN 
+    JM_SCAN_OPEN 
    ,JM_DELETE    
    ,JM_COPROC_AGGR
    ,JM_GET_NAME
@@ -546,9 +543,6 @@ private:
   NAArray<HbaseStr>* getKeys(Int32 funcIndex, NAHeap *heap, const char *tableName, bool useTRex);
 
 private:
-  NAString  getLastJavaError();
-
-private:  
   enum JAVA_METHODS {
     JM_CTOR = 0
    ,JM_INIT
@@ -631,6 +625,8 @@ typedef enum {
  ,HVC_ERROR_GET_ALLSCH_EXCEPTION
  ,HVC_ERROR_GET_ALLTBL_PARAM
  ,HVC_ERROR_GET_ALLTBL_EXCEPTION
+ ,HVC_ERROR_EXECUTE_HIVE_SQL_PARAM
+ ,HVC_ERROR_EXECUTE_HIVE_SQL_EXCEPTION
  ,HVC_LAST
 } HVC_RetCode;
 
@@ -676,13 +672,9 @@ private:
   , isConnected_(FALSE)
   {}
 
-private:
-  NAString getLastJavaError();
-
 private:  
   enum JAVA_METHODS {
     JM_CTOR = 0
-   ,JM_GET_ERROR 
    ,JM_INIT
    ,JM_CLOSE
    ,JM_EXISTS     
@@ -761,9 +753,6 @@ public:
 
 
 private:
-  NAString getLastJavaError();
-
-
   enum JAVA_METHODS {
     JM_CTOR = 0
    ,JM_INIT_HFILE_PARAMS

--- a/core/sql/executor/HdfsClient_JNI.cpp
+++ b/core/sql/executor/HdfsClient_JNI.cpp
@@ -208,9 +208,7 @@ HDFS_Scan_RetCode HdfsScan::setScanRanges(ExHdfsScanTcb::HDFS_SCAN_BUF *hdfsScan
    }
 
    if (jenv_->ExceptionCheck()) {
-      getExceptionDetails();
-      logError(CAT_SQL_HDFS, __FILE__, __LINE__);
-      logError(CAT_SQL_HDFS, "HdfsScan::setScanRanges()", getLastError());
+      getExceptionDetails(__FILE__, __LINE__, "HdfsScan::setScanRanges()");
       jenv_->PopLocalFrame(NULL);
       return HDFS_SCAN_ERROR_SET_SCAN_RANGES_EXCEPTION;
    }
@@ -260,9 +258,7 @@ HDFS_Scan_RetCode HdfsScan::trafHdfsRead(int retArray[], short arrayLen)
    }
 
    if (jenv_->ExceptionCheck()) {
-      getExceptionDetails();
-      logError(CAT_SQL_HDFS, __FILE__, __LINE__);
-      logError(CAT_SQL_HDFS, "HdfsScan::setScanRanges()", getLastError());
+      getExceptionDetails(__FILE__, __LINE__, "HdfsScan::setScanRanges()");
       jenv_->PopLocalFrame(NULL);
       return HDFS_SCAN_ERROR_TRAF_HDFS_READ_EXCEPTION;
    }
@@ -292,9 +288,7 @@ HDFS_Scan_RetCode HdfsScan::stop()
    }
 
    if (jenv_->ExceptionCheck()) {
-      getExceptionDetails();
-      logError(CAT_SQL_HDFS, __FILE__, __LINE__);
-      logError(CAT_SQL_HDFS, "HdfsScan::stop()", getLastError());
+      getExceptionDetails(__FILE__, __LINE__, "HdfsScan::stop()");
       jenv_->PopLocalFrame(NULL);
       return HDFS_SCAN_ERROR_STOP_EXCEPTION;
    }
@@ -513,9 +507,7 @@ HDFS_Client_RetCode HdfsClient::hdfsCreate(const char* path, NABoolean overwrite
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HDFS, __FILE__, __LINE__);
-    logError(CAT_SQL_HDFS, "HdfsClient::hdfsCreate()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HdfsClient::hdfsCreate()");
     jenv_->PopLocalFrame(NULL);
     return HDFS_CLIENT_ERROR_HDFS_CREATE_EXCEPTION;
   }
@@ -557,9 +549,7 @@ HDFS_Client_RetCode HdfsClient::hdfsOpen(const char* path, NABoolean compress)
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HDFS, __FILE__, __LINE__);
-    logError(CAT_SQL_HDFS, "HdfsClient::hdfsOpen()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HdfsClient::hdfsOpen()");
     jenv_->PopLocalFrame(NULL);
     return HDFS_CLIENT_ERROR_HDFS_OPEN_EXCEPTION;
   }
@@ -608,9 +598,7 @@ Int32 HdfsClient::hdfsWrite(const char* data, Int64 len, HDFS_Client_RetCode &hd
   }
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HDFS, __FILE__, __LINE__);
-    logError(CAT_SQL_HDFS, "HdfsClient::hdfsWrite()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HdfsClient::hdfsWrite()");
     jenv_->PopLocalFrame(NULL);
     hdfsClientRetcode = HDFS_CLIENT_ERROR_HDFS_WRITE_EXCEPTION;
     return 0;
@@ -650,9 +638,7 @@ Int32 HdfsClient::hdfsRead(const char* data, Int64 len, HDFS_Client_RetCode &hdf
   }
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HDFS, __FILE__, __LINE__);
-    logError(CAT_SQL_HDFS, "HdfsClient::hdfsRead()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HdfsClient::hdfsRead()");
     jenv_->PopLocalFrame(NULL);
     hdfsClientRetcode = HDFS_CLIENT_ERROR_HDFS_READ_EXCEPTION;
     return 0;
@@ -681,9 +667,7 @@ HDFS_Client_RetCode HdfsClient::hdfsClose()
   }
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HDFS, __FILE__, __LINE__);
-    logError(CAT_SQL_HDFS, "HdfsClient::hdfsClose()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HdfsClient::hdfsClose()");
     jenv_->PopLocalFrame(NULL);
     return HDFS_CLIENT_ERROR_HDFS_CLOSE_EXCEPTION;
   }
@@ -719,9 +703,7 @@ HDFS_Client_RetCode HdfsClient::hdfsCleanUnloadPath( const NAString& uldPath)
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HDFS, __FILE__, __LINE__);
-    logError(CAT_SQL_HDFS, "HdfsClient::hdfsCleanUnloadPath()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HdfsClient::hdfsCleanUnloadPath()");
     jenv_->PopLocalFrame(NULL);
     return HDFS_CLIENT_ERROR_HDFS_CLEANUP_EXCEPTION;
   }
@@ -760,9 +742,7 @@ HDFS_Client_RetCode HdfsClient::hdfsMergeFiles( const NAString& srcPath,
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HDFS, __FILE__, __LINE__);
-    logError(CAT_SQL_HDFS, "HdfsClient::hdfsMergeFiles()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HdfsClient::hdfsMergeFiles()");
     jenv_->PopLocalFrame(NULL);
     return HDFS_CLIENT_ERROR_HDFS_MERGE_FILES_EXCEPTION;
   }
@@ -799,9 +779,7 @@ HDFS_Client_RetCode HdfsClient::hdfsDeletePath( const NAString& delPath)
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HDFS, __FILE__, __LINE__);
-    logError(CAT_SQL_HDFS, "HdfsClient::hdfsDeletePath()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HdfsClient::hdfsDeletePath()");
     jenv_->PopLocalFrame(NULL);
     return HDFS_CLIENT_ERROR_HDFS_DELETE_PATH_EXCEPTION;
   }
@@ -836,9 +814,7 @@ HDFS_Client_RetCode HdfsClient::hdfsListDirectory(const char *pathStr, HDFS_File
           js_pathStr, jniObj);
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HDFS, __FILE__, __LINE__);
-    logError(CAT_SQL_HDFS, "HdfsClient::hdfsListDirectory()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HdfsClient::hdfsListDirectory()");
     jenv_->PopLocalFrame(NULL);
     return HDFS_CLIENT_ERROR_HDFS_LIST_DIR_EXCEPTION;
   } 
@@ -868,9 +844,7 @@ HDFS_Client_RetCode HdfsClient::hdfsExists( const NAString& uldPath, NABoolean &
   exist = jresult;
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HDFS, __FILE__, __LINE__);
-    logError(CAT_SQL_HDFS, "HdfsClient::hdfsExists()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HdfsClient::hdfsExists()");
     jenv_->PopLocalFrame(NULL);
     return HDFS_CLIENT_ERROR_HDFS_EXISTS_EXCEPTION;
   } 
@@ -901,9 +875,7 @@ HDFS_Client_RetCode HdfsClient::getHiveTableMaxModificationTs( Int64& maxModific
   jenv_->DeleteLocalRef(js_tableDirPaths);
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails(jenv_);
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HDFSClientI::getHiveTableMaxModificationTs()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HdfsClient::getHiveTableMaxModificationTS()");
     jenv_->PopLocalFrame(NULL);
     return HDFS_CLIENT_ERROR_HIVE_TBL_MAX_MODIFICATION_TS_EXCEPTION;
   }
@@ -929,9 +901,7 @@ HDFS_Client_RetCode HdfsClient::getFsDefaultName(char* buf, int buf_len)
                               JavaMethods_[JM_GET_FS_DEFAULT_NAME].methodID);
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails(jenv_);
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HDFSClient_JNI::getFsDefaultName()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HdfsClient::getFsDefaultName()");
     jenv_->PopLocalFrame(NULL);
     return HDFS_CLIENT_ERROR_GET_FS_DEFAULT_NAME_EXCEPTION;
   }
@@ -969,9 +939,7 @@ HDFS_Client_RetCode HdfsClient::hdfsCreateDirectory(const NAString &dirName)
                               JavaMethods_[JM_HDFS_CREATE_DIRECTORY].methodID, js_dirName);
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails(jenv_);
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    logError(CAT_SQL_HBASE, "HDFSClient_JNI::hdfsCreateDirectory()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "HdfsClient::hdfsCreateDirectory()");
     jenv_->PopLocalFrame(NULL);
     return HDFS_CLIENT_ERROR_CREATE_DIRECTORY_EXCEPTION;
   }

--- a/core/sql/executor/JavaObjectInterface.cpp
+++ b/core/sql/executor/JavaObjectInterface.cpp
@@ -46,6 +46,7 @@ int JavaObjectInterface::debugTimeout_ = 0;
 
 __thread JNIEnv* jenv_ = NULL;
 __thread NAString *tsRecentJMFromJNI = NULL;
+__thread NAString *tsSqlJniErrorStr = NULL;
 jclass JavaObjectInterface::gThrowableClass = NULL;
 jclass JavaObjectInterface::gStackTraceClass = NULL;
 jmethodID JavaObjectInterface::gGetStackTraceMethodID = NULL;
@@ -53,6 +54,27 @@ jmethodID JavaObjectInterface::gThrowableToStringMethodID = NULL;
 jmethodID JavaObjectInterface::gStackFrameToStringMethodID = NULL;
 jmethodID JavaObjectInterface::gGetCauseMethodID = NULL;
 
+void setSqlJniErrorStr(NAString &errorMsg)
+{
+  if (tsSqlJniErrorStr != NULL)
+     delete tsSqlJniErrorStr;
+  tsSqlJniErrorStr = new NAString(errorMsg); 
+}
+
+void setSqlJniErrorStr(const char *errorMsg)
+{
+  if (tsSqlJniErrorStr != NULL)
+     delete tsSqlJniErrorStr;
+  tsSqlJniErrorStr = new NAString(errorMsg); 
+}
+
+const char *getSqlJniErrorStr()
+{
+   if (tsSqlJniErrorStr == NULL)
+      return "";
+   else
+      return tsSqlJniErrorStr->data();
+}
   
 static const char* const joiErrorEnumStr[] = 
 {
@@ -451,8 +473,9 @@ JOI_RetCode JavaObjectInterface::init(char *className,
        lJavaClass = jenv_->FindClass(className); 
        if (jenv_->ExceptionCheck()) 
        {
-          getExceptionDetails();
-          QRLogger::log(CAT_SQL_HDFS_JNI_TOP, LL_ERROR, "Exception in FindClass(%s).", className);
+          char errMsg[200];
+          snprintf(errMsg, sizeof(errMsg), "Exception in FindClass(%s)", className);
+          getExceptionDetails(__FILE__, __LINE__, errMsg);
           return JOI_ERROR_FINDCLASS;
        }
        if (lJavaClass == 0) 
@@ -476,13 +499,12 @@ JOI_RetCode JavaObjectInterface::init(char *className,
                                                      JavaMethods[i].jm_signature);
         if (JavaMethods[i].methodID == 0 || jenv_->ExceptionCheck())
         { 
-          getExceptionDetails();
+          getExceptionDetails(__FILE__, __LINE__, "GetMethodId()");
           JavaMethods[i].methodID = jenv_->GetStaticMethodID(javaClass, 
                                                      JavaMethods[i].jm_name, 
                                                      JavaMethods[i].jm_signature);
           if (JavaMethods[i].methodID == 0 || jenv_->ExceptionCheck()) {
-             getExceptionDetails();
-             QRLogger::log(CAT_SQL_HDFS_JNI_TOP, LL_ERROR, "Error in GetMethod(%s).", JavaMethods[i].jm_name);
+             getExceptionDetails(__FILE__, __LINE__, "GetMethodId()");
              return JOI_ERROR_GETMETHOD;
           }
         }      
@@ -496,8 +518,9 @@ JOI_RetCode JavaObjectInterface::init(char *className,
       jobject jObj = jenv_->NewObject(javaClass, JavaMethods[0].methodID);
       if (jObj == 0 || jenv_->ExceptionCheck())
       { 
-        getExceptionDetails();
-        QRLogger::log(CAT_SQL_HDFS_JNI_TOP, LL_ERROR, "Error in NewObject() for class %s.", className);
+        char errMsg[200];
+        snprintf(errMsg, sizeof(errMsg), "Error in NewObject() for class %s.", className);
+        getExceptionDetails(__FILE__, __LINE__, errMsg);
         return JOI_ERROR_NEWOBJ;
       }
       javaObj_ = jenv_->NewGlobalRef(jObj);
@@ -542,50 +565,46 @@ void JavaObjectInterface::logError(std::string &cat, const char* file, int line)
   QRLogger::log(cat, LL_ERROR, "Java exception in file %s, line %d.", file, line);
 }
 
-NABoolean  JavaObjectInterface::getExceptionDetails(JNIEnv *jenv)
+NABoolean  JavaObjectInterface::getExceptionDetails(const char *fileName, int lineNo,
+                       const char *methodName)  
 {
-   if (jenv == NULL)
-       jenv = jenv_;
+   JNIEnv *jenv = jenv_;
    CliGlobals *cliGlobals = GetCliGlobals();
-   NAString error_msg(cliGlobals->currContext()->exHeap());
-   if (jenv == NULL)
-   {
-      error_msg = "Internal Error - Unable to obtain jenv";
-      cli_globals->setJniErrorStr(error_msg);
-      return FALSE;
-   } 
+   NAString error_msg;
    if (gThrowableClass == NULL)
    {
       jenv->ExceptionDescribe();
       error_msg = "Internal Error - Unable to find Throwable class";
-      cli_globals->setJniErrorStr(error_msg);
+      setSqlJniErrorStr(error_msg); 
       return FALSE; 
    }
    jthrowable a_exception = jenv->ExceptionOccurred();
    if (a_exception == NULL)
    {
        error_msg = "No java exception was thrown";
-       cli_globals->setJniErrorStr(error_msg);
+       setSqlJniErrorStr(error_msg); 
        return FALSE;
    }
-   appendExceptionMessages(jenv, a_exception, error_msg);
-   cli_globals->setJniErrorStr(error_msg);
+   appendExceptionMessages(a_exception, error_msg);
+   setSqlJniErrorStr(error_msg); 
+   logError(CAT_SQL_EXE, fileName, lineNo); 
+   logError(CAT_SQL_EXE, methodName, error_msg); 
    jenv->ExceptionClear();
    return TRUE;
 }
 
-void JavaObjectInterface::appendExceptionMessages(JNIEnv *jenv, jthrowable a_exception, NAString &error_msg)
+void JavaObjectInterface::appendExceptionMessages(jthrowable a_exception, NAString &error_msg)
 {
     jstring msg_obj =
-       (jstring) jenv->CallObjectMethod(a_exception,
+       (jstring) jenv_->CallObjectMethod(a_exception,
                                          gThrowableToStringMethodID);
     const char *msg_str;
     if (msg_obj != NULL)
     {
-       msg_str = jenv->GetStringUTFChars(msg_obj, 0);
+       msg_str = jenv_->GetStringUTFChars(msg_obj, 0);
        error_msg += msg_str;
-       jenv->ReleaseStringUTFChars(msg_obj, msg_str);
-       jenv->DeleteLocalRef(msg_obj);
+       jenv_->ReleaseStringUTFChars(msg_obj, msg_str);
+       jenv_->DeleteLocalRef(msg_obj);
     }
     else
        msg_str = "Exception is thrown, but tostring is null";
@@ -593,56 +612,36 @@ void JavaObjectInterface::appendExceptionMessages(JNIEnv *jenv, jthrowable a_exc
 
     // Get the stack trace
     jobjectArray frames =
-        (jobjectArray) jenv->CallObjectMethod(
+        (jobjectArray) jenv_->CallObjectMethod(
                                         a_exception,
                                         gGetStackTraceMethodID);
     if (frames == NULL)
        return;
-    jsize frames_length = jenv->GetArrayLength(frames);
+    jsize frames_length = jenv_->GetArrayLength(frames);
 
     jsize i = 0;
     for (i = 0; i < frames_length; i++)
     {
-       jobject frame = jenv->GetObjectArrayElement(frames, i);
-       msg_obj = (jstring) jenv->CallObjectMethod(frame,
+       jobject frame = jenv_->GetObjectArrayElement(frames, i);
+       msg_obj = (jstring) jenv_->CallObjectMethod(frame,
                                             gStackFrameToStringMethodID);
        if (msg_obj != NULL)
        {
-          msg_str = jenv->GetStringUTFChars(msg_obj, 0);
+          msg_str = jenv_->GetStringUTFChars(msg_obj, 0);
           error_msg += "\n";
           error_msg += msg_str;
-          jenv->ReleaseStringUTFChars(msg_obj, msg_str);
-          jenv->DeleteLocalRef(msg_obj);
-          jenv->DeleteLocalRef(frame);
+          jenv_->ReleaseStringUTFChars(msg_obj, msg_str);
+          jenv_->DeleteLocalRef(msg_obj);
+          jenv_->DeleteLocalRef(frame);
        }
     }
-    jthrowable j_cause = (jthrowable)jenv->CallObjectMethod(a_exception, gGetCauseMethodID);
+    jthrowable j_cause = (jthrowable)jenv_->CallObjectMethod(a_exception, gGetCauseMethodID);
     if (j_cause != NULL) {
        error_msg += " Caused by \n";
-       appendExceptionMessages(jenv, j_cause, error_msg);
+       appendExceptionMessages(j_cause, error_msg);
     }
-    jenv->DeleteLocalRef(a_exception);
+    jenv_->DeleteLocalRef(a_exception);
 } 
-
-NAString JavaObjectInterface::getLastError()
-{
-  return cli_globals->getJniErrorStr();
-}
-
-NAString JavaObjectInterface::getLastJavaError(jmethodID methodID)
-{
-  if (javaObj_ == NULL)
-    return "";
-  jstring j_error = (jstring)jenv_->CallObjectMethod(javaObj_,
-               methodID);
-  if (j_error == NULL)
-      return "";
-  const char *error_str = jenv_->GetStringUTFChars(j_error, NULL);
-  cli_globals->setJniErrorStr(error_str);
-  jenv_->ReleaseStringUTFChars(j_error, error_str);
-  return cli_globals->getJniErrorStr();
-}
-
 
 JOI_RetCode JavaObjectInterface::initJNIEnv()
 {

--- a/core/sql/executor/JavaObjectInterface.h
+++ b/core/sql/executor/JavaObjectInterface.h
@@ -31,6 +31,7 @@
 #include <sys/syscall.h>
 #include "jni.h"
 #include "Platform.h"
+#include "NAString.h"
 
 class LmJavaOptions;
 
@@ -40,7 +41,11 @@ class LmJavaOptions;
 
 extern __thread JNIEnv *jenv_;
 extern __thread NAString *tsRecentJMFromJNI;
+extern __thread NAString *tsSqlJniErrorStr;
 
+void setSqlJniErrorStr(NAString &errorMsg);
+void setSqlJniErrorStr(const char *errorMsg);
+const char *getSqlJniErrorStr();
 
 // This structure defines the information needed for each java method used.
 struct JavaMethodInit {
@@ -74,8 +79,6 @@ class JavaObjectInterface
   : public ExGod
 #endif
 {
-public:
-  NAString getLastJavaError(jmethodID methodID);
 protected:
 
   // Default constructor - for creating a new JVM		
@@ -119,7 +122,8 @@ protected:
   // Get the error description.
   static char* getErrorText(JOI_RetCode errEnum);
  
-  static NAString getLastError();
+  static const char *getLastError() 
+    { return getSqlJniErrorStr(); }
 
   // Write the description of a Java error to the log file.
   static void logError(std::string &cat, const char* methodName, const char *result);
@@ -143,11 +147,10 @@ public:
   {
     return isInitialized_;
   }
-  // Pass in jenv if the thread where the object is created is different than
-  // the thread where exception occurred
-  static NABoolean getExceptionDetails(JNIEnv *jenv = NULL);  
+  static NABoolean getExceptionDetails(const char *fileName, int lineNo,
+                       const char *methodName);  
 
-  static void appendExceptionMessages(JNIEnv *jenv, jthrowable a_exception, NAString &error_msg);
+  static void appendExceptionMessages(jthrowable a_exception, NAString &error_msg);
   
   NAHeap *getHeap() { return heap_; }
 protected:

--- a/core/sql/executor/OrcFileReader.cpp
+++ b/core/sql/executor/OrcFileReader.cpp
@@ -166,8 +166,7 @@ OFR_RetCode OrcFileReader::open(const char* path)
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HDFS_ORC_FILE_READER, "OrcFileReader::open()", jresult);
+    getExceptionDetails(__FILE__, __LINE__, "OrcFileReader::open()");
     jenv_->PopLocalFrame(NULL);
     return OFR_ERROR_OPEN_EXCEPTION;
   }
@@ -191,9 +190,7 @@ OFR_RetCode OrcFileReader::getPosition(Int64& pos)
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HDFS_ORC_FILE_READER, __FILE__, __LINE__);
-    logError(CAT_SQL_HDFS_ORC_FILE_READER, "OrcFileReader::getPosition()", getLastError());
+    getExceptionDetails(__FILE__, __LINE__, "OrcFileReader::getPosition()");
     jenv_->PopLocalFrame(NULL);
     return OFR_ERROR_GETPOS_EXCEPTION;
   }
@@ -230,8 +227,7 @@ OFR_RetCode OrcFileReader::seeknSync(Int64 pos)
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HDFS_ORC_FILE_READER, __FILE__, __LINE__);
+    getExceptionDetails(__FILE__, __LINE__, "OrcFileReader::seeknSync()");
     jenv_->PopLocalFrame(NULL);
     return OFR_ERROR_SYNC_EXCEPTION;
   }
@@ -270,8 +266,7 @@ OFR_RetCode OrcFileReader::isEOF(bool& isEOF)
 
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HDFS_ORC_FILE_READER, __FILE__, __LINE__);
+    getExceptionDetails(__FILE__, __LINE__, "OrcFileReader::isEOF()");
     jenv_->PopLocalFrame(NULL);
     return OFR_ERROR_ISEOF_EXCEPTION;
   }
@@ -318,9 +313,7 @@ OFR_RetCode OrcFileReader::fetchNextRow(char * buffer, long& array_length, long&
 	jobject jresult = (jobject)jenv_->CallObjectMethod(javaObj_, JavaMethods_[JM_FETCHROW2].methodID);
     if (jenv_->ExceptionCheck()) 
     {
-      getExceptionDetails();
-      logError(CAT_SQL_HDFS_ORC_FILE_READER, __FILE__, __LINE__);
-      logError(CAT_SQL_HDFS_ORC_FILE_READER, "OrcFileReader::fetchNextRow()", getLastError());
+      getExceptionDetails(__FILE__, __LINE__, "OrcFileReader::fetchNextRow()");
       jenv_->PopLocalFrame(NULL);
       return OFR_ERROR_FETCHROW_EXCEPTION;
     }
@@ -399,8 +392,7 @@ OFR_RetCode OrcFileReader::close()
 
   if (jenv_->ExceptionCheck()) 
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HDFS_ORC_FILE_READER, __FILE__, __LINE__);
+    getExceptionDetails(__FILE__, __LINE__, "OrcFileReader::close()");
     jenv_->PopLocalFrame(NULL);
     return OFR_ERROR_CLOSE_EXCEPTION;
   }
@@ -432,8 +424,7 @@ OFR_RetCode OrcFileReader::getRowCount(Int64& count)
   
   if (jenv_->ExceptionCheck())
   {
-    getExceptionDetails();
-    logError(CAT_SQL_HDFS_ORC_FILE_READER, __FILE__, __LINE__);
+    getExceptionDetails(__FILE__, __LINE__, "OrcFileReader::getRowCount()");
     jenv_->PopLocalFrame(NULL);
     return OFR_ERROR_GETNUMROWS_EXCEPTION;
   }

--- a/core/sql/executor/SequenceFileReader.cpp
+++ b/core/sql/executor/SequenceFileReader.cpp
@@ -189,6 +189,13 @@ SFR_RetCode SequenceFileReader::open(const char* path)
   tsRecentJMFromJNI = JavaMethods_[JM_OPEN].jm_full_name;
   jstring jresult = (jstring)jenv_->CallObjectMethod(javaObj_, JavaMethods_[JM_OPEN].methodID, js_path);
 
+  if (jenv_->ExceptionCheck())
+  {
+    getExceptionDetails(__FILE__, __LINE__, "SequenceFileReader::open()");
+    jenv_->PopLocalFrame(NULL);
+    return SFR_ERROR_OPEN_EXCEPTION;
+  }
+
   if (jresult != NULL)
   {
     logError(CAT_SQL_HDFS_SEQ_FILE_READER, "SequenceFileReader::open()", jresult);
@@ -213,6 +220,13 @@ SFR_RetCode SequenceFileReader::getPosition(Int64& pos)
   tsRecentJMFromJNI = JavaMethods_[JM_GETPOS].jm_full_name;
   Int64 result = jenv_->CallLongMethod(javaObj_, JavaMethods_[JM_GETPOS].methodID);
 
+  if (jenv_->ExceptionCheck())
+  {
+    getExceptionDetails(__FILE__, __LINE__, "SequenceFileReader::getPosition()");
+    jenv_->PopLocalFrame(NULL);
+    return SFR_ERROR_GETPOS_EXCEPTION;
+  }
+
   if (result == -1) 
   {
     logError(CAT_SQL_HDFS_SEQ_FILE_READER, "SequenceFileReader::getPosition()", getLastError());
@@ -233,11 +247,18 @@ SFR_RetCode SequenceFileReader::seeknSync(Int64 pos)
   QRLogger::log(CAT_SQL_HDFS_SEQ_FILE_READER, LL_DEBUG, "SequenceFileReader::seeknSync(%ld) called.", pos);
 
   if (initJNIEnv() != JOI_OK)
-     return SFR_ERROR_GETPOS_EXCEPTION;
+     return SFR_ERROR_SYNC_EXCEPTION;
 
   // String seeknSync(long);
   tsRecentJMFromJNI = JavaMethods_[JM_SYNC].jm_full_name;
   jstring jresult = (jstring)jenv_->CallObjectMethod(javaObj_, JavaMethods_[JM_SYNC].methodID, pos);
+
+  if (jenv_->ExceptionCheck())
+  {
+    getExceptionDetails(__FILE__, __LINE__, "SequenceFileReader::seeknSync()");
+    jenv_->PopLocalFrame(NULL);
+    return SFR_ERROR_SYNC_EXCEPTION;
+  }
 
   if (jresult != NULL)
   {
@@ -263,6 +284,13 @@ SFR_RetCode SequenceFileReader::isEOF(bool& isEOF)
   tsRecentJMFromJNI = JavaMethods_[JM_ISEOF].jm_full_name;
   bool result = jenv_->CallBooleanMethod(javaObj_, JavaMethods_[JM_ISEOF].methodID);
 
+  if (jenv_->ExceptionCheck())
+  {
+    getExceptionDetails(__FILE__, __LINE__, "SequenceFileReader::seeknSync()");
+    jenv_->PopLocalFrame(NULL);
+    return SFR_ERROR_ISEOF_EXCEPTION;
+  }
+
   jenv_->PopLocalFrame(NULL);
   isEOF = result;
   return SFR_OK;
@@ -279,6 +307,12 @@ SFR_RetCode SequenceFileReader::fetchNextRow(Int64 stopOffset, char* buffer)
   // java.lang.String fetchNextRow(long stopOffset);
   tsRecentJMFromJNI = JavaMethods_[JM_FETCHROW2].jm_full_name;
   jstring jresult = (jstring)jenv_->CallObjectMethod(javaObj_, JavaMethods_[JM_FETCHROW2].methodID, stopOffset);
+  if (jenv_->ExceptionCheck())
+  {
+    getExceptionDetails(__FILE__, __LINE__, "SequenceFileReader::fetchNextRow()");
+    jenv_->PopLocalFrame(NULL);
+    return SFR_ERROR_FETCHROW_EXCEPTION;
+  }
   if (jresult==NULL && getLastError()) 
   {
     logError(CAT_SQL_HDFS_SEQ_FILE_READER, "SequenceFileReader::fetchNextRow()", getLastError());
@@ -312,6 +346,12 @@ SFR_RetCode SequenceFileReader::close()
   // String close();
   tsRecentJMFromJNI = JavaMethods_[JM_CLOSE].jm_full_name;
   jstring jresult = (jstring)jenv_->CallObjectMethod(javaObj_, JavaMethods_[JM_CLOSE].methodID);
+  if (jenv_->ExceptionCheck())
+  {
+    getExceptionDetails(__FILE__, __LINE__, "SequenceFileReader::close()");
+    jenv_->PopLocalFrame(NULL);
+    return SFR_ERROR_CLOSE_EXCEPTION;
+  }
 
   if (jresult!=NULL) 
   {
@@ -466,6 +506,13 @@ SFW_RetCode SequenceFileWriter::open(const char* path, SFW_CompType compression)
   tsRecentJMFromJNI = JavaMethods_[JM_OPEN].jm_full_name;
   jstring jresult = (jstring)jenv_->CallObjectMethod(javaObj_, JavaMethods_[JM_OPEN].methodID, js_path, compression);
 
+  if (jenv_->ExceptionCheck())
+  {
+    getExceptionDetails(__FILE__, __LINE__, "SequenceFileWriter::open()");
+    jenv_->PopLocalFrame(NULL);
+    return SFW_ERROR_OPEN_EXCEPTION;
+  }
+
   if (jresult != NULL)
   {
     logError(CAT_SQL_HDFS_SEQ_FILE_WRITER, "SequenceFileWriter::open()", jresult);
@@ -495,6 +542,12 @@ SFW_RetCode SequenceFileWriter::write(const char* data)
   // String write(java.lang.String);
   tsRecentJMFromJNI = JavaMethods_[JM_WRITE].jm_full_name;
   jstring jresult = (jstring)jenv_->CallObjectMethod(javaObj_, JavaMethods_[JM_WRITE].methodID, js_data);
+  if (jenv_->ExceptionCheck())
+  {
+    getExceptionDetails(__FILE__, __LINE__, "SequenceFileWriter::write()");
+    jenv_->PopLocalFrame(NULL);
+    return SFW_ERROR_WRITE_EXCEPTION;
+  }
 
   if (jresult != NULL)
   {
@@ -551,6 +604,12 @@ SFW_RetCode SequenceFileWriter::close()
   // String close();
   tsRecentJMFromJNI = JavaMethods_[JM_CLOSE].jm_full_name;
   jstring jresult = (jstring)jenv_->CallObjectMethod(javaObj_, JavaMethods_[JM_CLOSE].methodID);
+  if (jenv_->ExceptionCheck())
+  {
+    getExceptionDetails(__FILE__, __LINE__, "SequenceFileWriter::close()");
+    jenv_->PopLocalFrame(NULL);
+    return SFW_ERROR_CLOSE_EXCEPTION;
+  }
 
   if (jresult != NULL)
   {

--- a/core/sql/executor/ex_root.cpp
+++ b/core/sql/executor/ex_root.cpp
@@ -997,7 +997,7 @@ void ex_root_tcb::setupWarning(Lng32 retcode, const char * str,
     ExRaiseSqlWarning(getHeap(), &newDiags, (ExeErrorCode) (8448), NULL,
         &intParam1, &cliError, NULL, (str ? (char*) str : (char*) " "),
         getHbaseErrStr(retcode),
-        (str2 ? (char*) str2 : (char *) currContext->getJniErrorStr().data()));
+        (str2 ? (char*) str2 : (char *) GetCliGlobals()->getJniErrorStr()));
     diagsArea->mergeAfter(*newDiags);
   }
   ex_assert( 0, "invalid return code value");

--- a/core/sql/executor/hiveHook.cpp
+++ b/core/sql/executor/hiveHook.cpp
@@ -212,7 +212,7 @@ NABoolean HiveMetaData::recordError(Int32 errCode,
       if (client_)
         errCodeStr_ = client_->getErrorText((HVC_RetCode)errCode_);
       errMethodName_ = errMethodName;
-      errDetail_ = GetCliGlobals()->getJniErrorStrPtr();
+      errDetail_ = GetCliGlobals()->getJniErrorStr();
       return FALSE;
     }
   return TRUE;

--- a/core/sql/optimizer/NATable.cpp
+++ b/core/sql/optimizer/NATable.cpp
@@ -7878,7 +7878,7 @@ ExpHbaseInterface* NATable::getHBaseInterfaceRaw()
         << DgString0((char*)"ExpHbaseInterface::init()")
         << DgString1(getHbaseErrStr(-retcode))
         << DgInt0(-retcode)
-        << DgString2((char*)GetCliGlobals()->getJniErrorStr().data());
+        << DgString2((char*)GetCliGlobals()->getJniErrorStr());
       delete ehi;
       return NULL;
     }

--- a/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
@@ -1146,7 +1146,7 @@ ExpHbaseInterface* CmpSeabaseDDL::allocEHI(const char * server,
                           << DgString0((char*)"ExpHbaseInterface::init()")
                           << DgString1(getHbaseErrStr(-retcode))
                           << DgInt0(-retcode)
-                          << DgString2((char*)GetCliGlobals()->getJniErrorStr().data());
+                          << DgString2((char*)GetCliGlobals()->getJniErrorStr());
       }
 
       deallocEHI(ehi); 
@@ -1425,7 +1425,7 @@ short CmpSeabaseDDL::validateVersions(NADefaults *defs,
         *hbaseErrNum = retcode;
 
       if (hbaseErrStr)
-        *hbaseErrStr = (char*)GetCliGlobals()->getJniErrorStr().data();
+        *hbaseErrStr = (char*)GetCliGlobals()->getJniErrorStr();
 
       retcode = -1398;
       goto label_return;
@@ -1500,7 +1500,7 @@ short CmpSeabaseDDL::validateVersions(NADefaults *defs,
         *hbaseErrNum = retcode;
 
       if (hbaseErrStr)
-        *hbaseErrStr = (char*)GetCliGlobals()->getJniErrorStr().data();
+        *hbaseErrStr = (char*)GetCliGlobals()->getJniErrorStr();
 
       retcode = -1398;
       goto label_return;
@@ -2557,7 +2557,7 @@ short CmpSeabaseDDL::createHbaseTable(ExpHbaseInterface *ehi,
                           << DgString0((char*)"ExpHbaseInterface::exists()")
                           << DgString1(getHbaseErrStr(-retcode))
                           << DgInt0(-retcode)
-                          << DgString2((char*)GetCliGlobals()->getJniErrorStr().data());
+                          << DgString2((char*)GetCliGlobals()->getJniErrorStr());
       
       return -1;
     }
@@ -2615,7 +2615,7 @@ short CmpSeabaseDDL::createHbaseTable(ExpHbaseInterface *ehi,
                           << DgString0((char*)"ExpHbaseInterface::create()")
                           << DgString1(getHbaseErrStr(-retcode))
                           << DgInt0(-retcode)
-                          << DgString2((char*)GetCliGlobals()->getJniErrorStr().data());
+                          << DgString2((char*)GetCliGlobals()->getJniErrorStr());
       
       return -1;
     }
@@ -2695,7 +2695,7 @@ short CmpSeabaseDDL::alterHbaseTable(ExpHbaseInterface *ehi,
                               << DgString0((char*)"ExpHbaseInterface::alter()")
                               << DgString1(getHbaseErrStr(-retcode))
                               << DgInt0(-retcode)
-                              << DgString2((char*)GetCliGlobals()->getJniErrorStr().data());
+                              << DgString2((char*)GetCliGlobals()->getJniErrorStr());
           retcode = -1;
         } // if
     } // else
@@ -2723,7 +2723,7 @@ short CmpSeabaseDDL::dropHbaseTable(ExpHbaseInterface *ehi,
                               << DgString0((char*)"ExpHbaseInterface::drop()")
                               << DgString1(getHbaseErrStr(-retcode))
                               << DgInt0(-retcode)
-                              << DgString2((char*)GetCliGlobals()->getJniErrorStr().data());
+                              << DgString2((char*)GetCliGlobals()->getJniErrorStr());
           
           return -1;
         }
@@ -2735,7 +2735,7 @@ short CmpSeabaseDDL::dropHbaseTable(ExpHbaseInterface *ehi,
                           << DgString0((char*)"ExpHbaseInterface::exists()")
                           << DgString1(getHbaseErrStr(-retcode))
                           << DgInt0(-retcode)
-                          << DgString2((char*)GetCliGlobals()->getJniErrorStr().data());
+                          << DgString2((char*)GetCliGlobals()->getJniErrorStr());
       
       return -1;
     }
@@ -2758,7 +2758,7 @@ short CmpSeabaseDDL::copyHbaseTable(ExpHbaseInterface *ehi,
                               << DgString0((char*)"ExpHbaseInterface::copy()")
                               << DgString1(getHbaseErrStr(-retcode))
                               << DgInt0(-retcode)
-                              << DgString2((char*)GetCliGlobals()->getJniErrorStr().data());
+                              << DgString2((char*)GetCliGlobals()->getJniErrorStr());
           
           return -1;
         }
@@ -2770,7 +2770,7 @@ short CmpSeabaseDDL::copyHbaseTable(ExpHbaseInterface *ehi,
                           << DgString0((char*)"ExpHbaseInterface::copy()")
                           << DgString1(getHbaseErrStr(-retcode))
                           << DgInt0(-retcode)
-                          << DgString2((char*)GetCliGlobals()->getJniErrorStr().data());
+                          << DgString2((char*)GetCliGlobals()->getJniErrorStr());
       
       return -1;
     }
@@ -8127,7 +8127,7 @@ short CmpSeabaseDDL::dropSeabaseObjectsFromHbase(const char * pattern,
                           << DgString0((char*)"ExpHbaseInterface::dropAll()")
                           << DgString1(getHbaseErrStr(-retcode))
                           << DgInt0(-retcode)
-                          << DgString2((char*)GetCliGlobals()->getJniErrorStr().data());
+                          << DgString2((char*)GetCliGlobals()->getJniErrorStr());
 
       return retcode;
     }
@@ -8638,7 +8638,7 @@ short CmpSeabaseDDL::truncateHbaseTable(const NAString &catalogNamePart,
                           << DgString0((char*)"ExpHbaseInterface::truncate()")
                           << DgString1(getHbaseErrStr(-retcode))
                           << DgInt0(-retcode)
-                          << DgString2((char*)GetCliGlobals()->getJniErrorStr().data());
+                          << DgString2((char*)GetCliGlobals()->getJniErrorStr());
 
       processReturn();
       return -1;

--- a/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
@@ -4820,7 +4820,7 @@ void CmpSeabaseDDL::renameSeabaseTable(
                           << DgString0((char*)"ExpHbaseInterface::copy()")
                           << DgString1(getHbaseErrStr(-retcode))
                           << DgInt0(-retcode)
-                          << DgString2((char*)GetCliGlobals()->getJniErrorStr().data());
+                          << DgString2((char*)GetCliGlobals()->getJniErrorStr());
       
       processReturn();
       
@@ -6264,7 +6264,7 @@ short CmpSeabaseDDL::hbaseFormatTableDropColumn(
                             << DgString0((char*)"ExpHbaseInterface::deleteColumns()")
                             << DgString1(getHbaseErrStr(-cliRC))
                             << DgInt0(-cliRC)
-                            << DgString2((char*)GetCliGlobals()->getJniErrorStr().data());
+                            << DgString2((char*)GetCliGlobals()->getJniErrorStr());
         
         goto label_error;
       }
@@ -10152,7 +10152,7 @@ void CmpSeabaseDDL::hbaseGrantRevoke(
                                   DgString0((char*)"ExpHbaseInterface::revoke()"))
                               << DgString1(getHbaseErrStr(-retcode))
                               << DgInt0(-retcode)
-                              << DgString2((char*)GetCliGlobals()->getJniErrorStr().data());
+                              << DgString2((char*)GetCliGlobals()->getJniErrorStr());
 
           deallocEHI(ehi);
 
@@ -10169,7 +10169,7 @@ void CmpSeabaseDDL::hbaseGrantRevoke(
                           << DgString0((char*)"ExpHbaseInterface::close()")
                           << DgString1(getHbaseErrStr(-retcode))
                           << DgInt0(-retcode)
-                          << DgString2((char*)GetCliGlobals()->getJniErrorStr().data());
+                          << DgString2((char*)GetCliGlobals()->getJniErrorStr());
 
       deallocEHI(ehi);
 
@@ -12592,7 +12592,7 @@ TrafDesc * CmpSeabaseDDL::getSeabaseUserTableDesc(const NAString &catName,
             << DgString0((char*)"ExpHbaseInterface::getLatestSnapshot()")
             << DgString1(getHbaseErrStr(-retcode))
             << DgInt0(-retcode)
-            << DgString2((char*)GetCliGlobals()->getJniErrorStr().data());
+            << DgString2((char*)GetCliGlobals()->getJniErrorStr());
           delete ehi;
         }
     }

--- a/core/sql/src/main/java/org/trafodion/sql/HTableClient.java
+++ b/core/sql/src/main/java/org/trafodion/sql/HTableClient.java
@@ -114,7 +114,6 @@ public class HTableClient {
 	private ResultScanner scanner = null;
         private ScanHelper scanHelper = null;
 	Result[] getResultSet = null;
-	String lastError;
         RMInterface table = null;
         private boolean writeToWAL = false;
 	int numRowsCached = 1;
@@ -350,16 +349,6 @@ public class HTableClient {
 	    if (logger.isDebugEnabled()) logger.debug("Exit HTableClient::init, useTRex: " + this.useTRex + ", useTRexScanner: "
 	              + this.useTRexScanner + ", table object: " + table);
 	    return true;
-	}
-
-	public String getLastError() {
-		String ret = lastError;
-		lastError = null;
-		return ret;
-	}
-
-	void setLastError(String err) {
-		lastError = err;
 	}
 
 	String getTableName() {
@@ -1188,10 +1177,7 @@ public class HTableClient {
 		else
 		{
 			if (scanner == null) {
-				String err = "  fetchRows() called before scanOpen().";
-				logger.error(err);
-				setLastError(err);
-				return -1;
+                                throw new IOException("HTableClient.FetchRows() called before scanOpen().");
 			}
 			Result[] result = null;
 			if (preFetch)

--- a/core/sql/src/main/java/org/trafodion/sql/HiveClient.java
+++ b/core/sql/src/main/java/org/trafodion/sql/HiveClient.java
@@ -167,9 +167,8 @@ public class HiveClient {
     }
 
     public Object[] getAllTables(String schName) 
-        throws MetaException, Exception {
-        //System.out.println("schName = " + schName);
-
+        throws MetaException, TException {
+        try {
         Database db = hmsClient.getDatabase(schName);
         if (db == null)
             return null;
@@ -179,6 +178,9 @@ public class HiveClient {
            return tableList.toArray();
         else
            return null;
+        } catch (NoSuchObjectException e) {
+          return null;
+        }
     }
 
     // Because Hive changed the name of the class containing internal constants changed

--- a/core/sql/ustat/hs_cli.cpp
+++ b/core/sql/ustat/hs_cli.cpp
@@ -503,7 +503,7 @@ Lng32 HSClearCLIDiagnostics()
 // Obtain any JNI diagnostic text stored in the CLI
 const char * HSFuncGetJniErrorStr()
 {
-  return GetCliGlobals()->currContext()->getJniErrorStrPtr();
+  return GetCliGlobals()->getJniErrorStr();
 }
 
 // -----------------------------------------------------------------------


### PR DESCRIPTION
Java exceptions thrown while calling the java methods from JNI in
Trafodion are stored in the current context. However in a multi-threaded
ESP environment, these exceptions should be stored in thread specific
variable to enable error handling to be thread safe. Otherwise, the JNI
errors could be overwritten by the JNI errors from another thread.

Also streamlined JNI error handling by extending the getExceptionDetails()
method to log the errors also.

Incorporated error handling in SequenceFileReader JNI methods.