### PR TITLE
[TRAFODION-3005] Fix issues with keys on long columns

### DIFF
--- a/core/sql/sqlcomp/CmpSeabaseDDL.h
+++ b/core/sql/sqlcomp/CmpSeabaseDDL.h
@@ -129,10 +129,21 @@ class CmpDDLwithStatusInfo;
 
 #include "CmpSeabaseDDLmd.h"
 
-// The value HBase uses for checking key length is HConstants.MAX_ROW_LENGTH.
-// The rowID length limit in HBase is enforced in HBase modules Put.java and
-// Mutation.java. (The above was true as of HBase 1.0.0.)
-#define MAX_HBASE_ROWKEY_LEN 32767
+// The define below gives the maximum rowID length that we will permit
+// for Trafodion tables and indexes. The actual HBase limit is more 
+// complicated: For Puts, HBase compares the key length to 
+// HConstants.MAX_ROW_LENGTH (= Short.MAX_VALUE = 32767). It raises an
+// exception if the key length is greater than that. But there are also
+// some internal data structures that HBase uses (the WAL perhaps?) that
+// are keyed. Experiments show that a Trafodion key of length n causes
+// a hang if n + strlen(Trafodion object name) + 16 > 32767. The HBase
+// log in these cases shows an IllegalArgumentException Row > 32767 in
+// this case. So it seems best to limit Trafodion key lengths to something
+// sufficiently smaller than 32767 so we don't hit these hangs. A value
+// of 32000 seems safe, since the longest Trafodion table name will be
+// TRAFODION.something.something, with each of the somethings topping out
+// at 256 bytes.
+#define MAX_HBASE_ROWKEY_LEN 32000
 
 #define SEABASEDDL_INTERNAL_ERROR(text)                                   \
    *CmpCommon::diags() << DgSqlCode(-CAT_INTERNAL_EXCEPTION_ERROR) 	  \

--- a/core/sql/sqlcomp/CmpSeabaseDDLindex.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLindex.cpp
@@ -239,14 +239,6 @@ CmpSeabaseDDL::createIndexColAndKeyInfoArrays(
      keyInfoArray[i].hbaseColQual = new(CTXTHEAP) char[strlen(qualNumStr)+1];
      strcpy((char*)keyInfoArray[i].hbaseColQual, qualNumStr);
     }
-
-  if (keyLength > MAX_HBASE_ROWKEY_LEN )
-    {
-      *CmpCommon::diags() << DgSqlCode(-CAT_ROWKEY_LEN_TOO_LARGE)
-                              << DgInt0(keyLength)
-                              << DgInt1(MAX_HBASE_ROWKEY_LEN);
-      return -1;
-    }
   
   if ((syskeyOnly) &&
       (hasSyskey))
@@ -394,6 +386,14 @@ CmpSeabaseDDL::createIndexColAndKeyInfoArrays(
       
       j++;
       i++;
+    }
+
+  if (keyLength > MAX_HBASE_ROWKEY_LEN )
+    {
+      *CmpCommon::diags() << DgSqlCode(-CAT_ROWKEY_LEN_TOO_LARGE)
+                              << DgInt0(keyLength)
+                              << DgInt1(MAX_HBASE_ROWKEY_LEN);
+      return -1;
     }
 
   return 0;


### PR DESCRIPTION
This is a follow-on to JIRA TRAFODION-2977 (pull request https://github.com/apache/trafodion/pull/1473).

I made two changes here.

1. In the previous pull request, I added a check to the CREATE INDEX logic to make sure the key length is not too long. I put that check too early in the logic. I have now moved that check to the proper place.

2. It turns out that HBase uses rowIDs + possibly the HBase object name + some other info to make entries into another HBase structure internally, and imposes a 32767 key length limit on that. Unfortunately when we exceed the length limit on that internal structure, the HBase application (Trafodion in our case) experiences a hang. To avoid these hangs, we will further restrict maximum key length in Trafodion to 32000. The code change contains a detailed explanation of how this number was arrived at.