### PR TITLE
[TRAFODION-2986] minor issues in adoc found during mvn site

### DIFF
--- a/docs/provisioning_guide/src/asciidoc/_chapters/ambari_install.adoc
+++ b/docs/provisioning_guide/src/asciidoc/_chapters/ambari_install.adoc
@@ -124,7 +124,7 @@ Upgrade the traf_ambari package and re-start ambari-server service.
 
  $ sudo ambari-server restart
 
-==== Upgrade Entire HDP Stack
+=== Upgrade Entire HDP Stack
 
 Ambari requires version upgrades to be an entire stack, not single components. If you want to
 include a trafodion upgrade in entire stack version upgrade, first upgrade the traf_ambari
@@ -134,7 +134,7 @@ Once that is done, proceed with the upgrade following Ambari instructions. Be su
 define the Trafodion-2.2 URL that points to a repo server with the new apache-trafodion_server
 package.
 
-==== Upgrade Only Trafodion
+=== Upgrade Only Trafodion
 
 In this case, Ambari will not upgrade a single component, so the apache-trafodion_server
 package must be installed on each node directly (via yum command). Once that is done, the

--- a/docs/provisioning_guide/src/asciidoc/_chapters/introduction.adoc
+++ b/docs/provisioning_guide/src/asciidoc/_chapters/introduction.adoc
@@ -265,12 +265,20 @@ and for the Distribution Manager. Therefore, we recommend that you secure the fi
 that matches the security policies of your organization.
 
 ==== Example: Quick start using a {project-name} Configuration File
-The {project-name} Installer supports a minimum configuration to quick start your installation in two steps.
+The {project-name} Installer supports a minimum configuration to quick start your installation in two steps:
+
 1. Copy {project-name} server binary file to your installer directory.
++
+*Example*
++
 ```
 cp /path/to/apache-trafodion_server-2.2.0-RH-x86_64.tar.gz python-installer/
 ```
+
 2. Modify configuration file `my_config`, add the Hadoop Distribution Manager URL in `mgr_url`.
++
+*Example*
++
 ```
 mgr_url = 192.168.0.1:8080
 ```


### PR DESCRIPTION
During the release 2.2, trying to update the documentation, found several minor typos and syntax errors
Doc fixing.