### PR TITLE
[TRAFODION-3003]Trafodion keepalive support

### DIFF
--- a/core/conn/odbc/src/odbc/Common/Global.h
+++ b/core/conn/odbc/src/odbc/Common/Global.h
@@ -139,9 +139,15 @@ class ODBCMXTraceMsg;
 #define DEFAULT_REFRESH_RATE_SECS		60
 #define DEFAULT_SRVR_IDLE_TIMEOUT		0
 #define DEFAULT_CONN_IDLE_TIMEOUT		0
+#define DEFAULT_KEEPALIVE               1     //OPEN KEEPALIVE
+#define DEFAULT_KEEPALIVE_TIMESEC       3600
+#define DEFAULT_KEEPALIVE_COUNT         3
+#define DEFAULT_KEEPALIVE_INTVL         20
 #define INFINITE_SRVR_IDLE_TIMEOUT		-1
 #define INFINITE_CONN_IDLE_TIMEOUT		-1
 #define STATE_TRANSITION_TIMEOUT_SECS	300
+
+#define CLIENT_KEEPALIVE_ATTR_TIMEOUT   3001
 
 #define JDBC_ATTR_CONN_IDLE_TIMEOUT		3000
 #define JDBC_DATASOURCE_CONN_IDLE_TIMEOUT -1L
@@ -935,7 +941,10 @@ typedef struct _SRVR_GLOBAL_Def
 		bzero(m_ProcName,sizeof(m_ProcName));
 		m_bNewConnection = false;
 		m_bNewService = false;
-
+               bzero(clientKeepaliveStatus, sizeof(clientKeepaliveStatus));
+               clientKeepaliveIdletime = 0;
+               clientKeepaliveIntervaltime = 0;
+               clientKeepaliveRetrycount = 0;
 		m_rule_wms_off = false;		// perf
 		m_rule_endstats_off = false;// perf
 
@@ -1053,6 +1062,10 @@ typedef struct _SRVR_GLOBAL_Def
 
 	tip_handle_t		tip_gateway;
 
+    char    clientKeepaliveStatus[64];
+    int     clientKeepaliveIdletime;
+    int     clientKeepaliveIntervaltime;
+    int     clientKeepaliveRetrycount;
 	char				*pxid_url;
 	IDL_long_long		local_xid;
 	UINT				xid_length;

--- a/core/conn/odbc/src/odbc/Common/Listener.h
+++ b/core/conn/odbc/src/odbc/Common/Listener.h
@@ -26,12 +26,19 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netdb.h>
-
+#include <netinet/tcp.h>
 enum CURR_TCPIP_OPER{
 	CURR_UNDEFINED,
 	CURR_OPEN,
 	CURR_PROCESS,
 	CURR_OTHER
+};
+
+typedef struct KEEPALIVE_OPT{
+    int isKeepalive;
+    int keepaliveIdle;
+    int keepaliveInterval;
+    int keepCount;
 };
 
 #define INITIALIZE_TRACE(TransportTrace) \

--- a/core/conn/odbc/src/odbc/nsksrvr/Interface/Listener_srvr.h
+++ b/core/conn/odbc/src/odbc/nsksrvr/Interface/Listener_srvr.h
@@ -47,8 +47,8 @@ public:
 	long getPort() { return m_port; };
 
 	void closeTCPIPSession(int fnum);
-
-
+    KEEPALIVE_OPT keepaliveOpt;
+    void TCP_SetKeepalive(int socketnum, char *keepaliveStatus, int idleTime, int intervalTime, int retryCount);
 protected:
 	long m_port;
 	CURR_TCPIP_OPER m_tcpip_operation;

--- a/core/conn/odbc/src/odbc/nsksrvr/Interface/linux/Listener_srvr_ps.cpp
+++ b/core/conn/odbc/src/odbc/nsksrvr/Interface/linux/Listener_srvr_ps.cpp
@@ -263,7 +263,11 @@ void* CNSKListenerSrvr::OpenTCPIPSession()
 //LCOV_EXCL_STOP
 	}
 
-
+    TCP_SetKeepalive(nSocketFnum,
+            srvrGlobal->clientKeepaliveStatus,
+            srvrGlobal->clientKeepaliveIdletime,
+            srvrGlobal->clientKeepaliveIntervaltime,
+            srvrGlobal->clientKeepaliveRetrycount);
 	pnode = GTransport.m_TCPIPSystemSrvr_list->ins_node(nSocketFnum);
 
 	if (pnode == NULL)
@@ -444,6 +448,7 @@ void * CNSKListenerSrvr::tcpip_listener(void *arg)
 	       {
 
                   GTransport.m_TCPIPSystemSrvr_list->del_node(pnode->m_nSocketFnum);
+                  SET_ERROR((long)0, NSK, TCPIP, UNKNOWN_API, E_SERVER,"tcpip_listener", O_SELECT, F_SELECT,errno, pnode->m_nSocketFnum);
 				  SRVR::BreakDialogue(NULL);
 	        }
                else

--- a/core/conn/odbc/src/odbc/nsksrvr/SrvrMain.cpp
+++ b/core/conn/odbc/src/odbc/nsksrvr/SrvrMain.cpp
@@ -95,7 +95,10 @@ long initSessMemSize;
 int portMapToSecs = -1;
 int portBindToSecs = -1;
 bool bPlanEnabled = false;
-
+char keepaliveStatus[256];
+int keepaliveIdletime;
+int keepaliveIntervaltime;
+int keepaliveRetrycount;
 void watcher(zhandle_t *zzh, int type, int state, const char *path, void *watcherCtx);
 bool verifyPortAvailable(const char * idForPort, int portNumber);
 BOOL getInitParamSrvr(int argc, char *argv[], SRVR_INIT_PARAM_Def &initParam, char* strName, char* strValue);
@@ -791,7 +794,14 @@ catch(SB_Fatal_Excep sbfe)
 //LCOV_EXCL_STOP
 		}
 	}
-
+    if( strlen(keepaliveStatus) > 0){
+        strncpy( srvrGlobal->clientKeepaliveStatus, keepaliveStatus, strlen(keepaliveStatus));
+        srvrGlobal->clientKeepaliveIntervaltime = keepaliveIntervaltime;
+        srvrGlobal->clientKeepaliveIdletime = keepaliveIdletime;
+        srvrGlobal->clientKeepaliveRetrycount = keepaliveRetrycount;
+    }else{
+        strncpy( srvrGlobal->clientKeepaliveStatus, "unenable", strlen("unenable"));
+    }
     // TCPADD and RZ are required parameters.
 	// The address is passed in with TCPADD parameter .
 	// The hostname is passed in with RZ parameter.
@@ -1427,7 +1437,74 @@ BOOL getInitParamSrvr(int argc, char *argv[], SRVR_INIT_PARAM_Def &initParam, ch
 				argEmpty = TRUE;
 				break;
 			}
-		}
+		}else
+        if (strcmp(arg, "-TCPKEEPALIVESTATUS") == 0){
+            if (++count < argc && argv[count][0] != '-')
+            {
+                if (strlen(argv[count]) < sizeof(keepaliveStatus) - 1)
+                {
+                    memset(keepaliveStatus, 0, sizeof(keepaliveStatus) - 1);
+                    strncpy(keepaliveStatus, argv[count], sizeof(keepaliveStatus) - 1);
+                }
+                else
+                {
+                    argWrong = TRUE;
+                }
+            }
+            else
+            {
+                argEmpty = TRUE;
+                break;
+            }
+        }else
+        if (strcmp(arg, "-TCPKEEPALIVEIDLETIME") == 0){
+            if (++count < argc )
+            {
+                if(strspn(argv[count], "0123456789")==strlen(argv[count])){
+                    keepaliveIdletime = atoi(argv[count]);
+                }else
+                {
+                    argWrong = TRUE;
+                }
+			}
+            else
+            {
+                argEmpty = TRUE;
+                break;
+            }
+        }else
+        if (strcmp(arg, "-TCPKEEPALIVEINTERVAL") == 0){
+            if (++count < argc )
+            {
+                if(strspn(argv[count], "0123456789")==strlen(argv[count])){
+                    keepaliveIntervaltime = atoi(argv[count]);
+                }else
+                {
+                    argWrong = TRUE;
+                }
+            }
+            else
+            {
+                argEmpty = TRUE;
+                break;
+            }
+        }else
+        if (strcmp(arg, "-TCPKEEPALIVERETRYCOUNT") == 0){
+            if (++count < argc )
+            {
+                if(strspn(argv[count], "0123456789")==strlen(argv[count])){
+                    keepaliveRetrycount = atoi(argv[count]);
+                }else
+                {
+                    argWrong = TRUE;
+                }
+            }
+            else
+            {
+                argEmpty = TRUE;
+                break;
+            }
+        }
 		count++;
 	}
 

--- a/core/conn/odbc/src/odbc/nsksrvrcore/Makefile
+++ b/core/conn/odbc/src/odbc/nsksrvrcore/Makefile
@@ -64,7 +64,7 @@ OBJS  = $(OUTDIR)/CommonDiags.o \
         $(OUTDIR)/srvrothers.o \
         $(OUTDIR)/libmxocore_version.o
 
-INCLUDES = -I. -I../Common -I../EventMsgs -I../SrvrMsg -I../dependencies/include -I../dependencies/linux -I../Krypton/generated_incs  -I$(TRAF_HOME)/export/include/sql -I$(TRAF_HOME)/inc/tmf_tipapi  -I$(TRAF_HOME)/inc  -I$(TRAF_HOME)/export/include -I$(TRAF_HOME)/sql/nq_w/common -I../OssCfgCl/src -I../CmdCfgDll -I$(PROTOBUFS_INC) -I$(TRAF_HOME)/../sql/cli -I$(TRAF_HOME)/commonLogger -I$(TRAF_HOME)/../dbsecurity/cert/inc -I$(TRAF_HOME)/../dbsecurity/auth/inc -I$(LOG4CXX_INC_DIR) -I$(TRAF_HOME)/../mpi/src/include/intern
+INCLUDES = -I. -I ../nsksrvr/Interface/ -I../Common -I../EventMsgs -I../SrvrMsg -I../dependencies/include -I../dependencies/linux -I../Krypton/generated_incs  -I$(TRAF_HOME)/export/include/sql -I$(TRAF_HOME)/inc/tmf_tipapi  -I$(TRAF_HOME)/inc  -I$(TRAF_HOME)/export/include -I$(TRAF_HOME)/sql/nq_w/common -I../OssCfgCl/src -I../CmdCfgDll -I$(PROTOBUFS_INC) -I$(TRAF_HOME)/../sql/cli -I$(TRAF_HOME)/commonLogger -I$(TRAF_HOME)/../dbsecurity/cert/inc -I$(TRAF_HOME)/../dbsecurity/auth/inc -I$(LOG4CXX_INC_DIR) -I$(TRAF_HOME)/../mpi/src/include/intern
 
 DEFINES =  -DNA_LINUX -DSIZEOF_LONG_INT=4 -DUSE_NEW_PHANDLE -DSQ_GUARDIAN_CALL -D_M_DG -DINC_QPID_EVENT -w
 

--- a/dcs/src/main/java/org/trafodion/dcs/Constants.java
+++ b/dcs/src/main/java/org/trafodion/dcs/Constants.java
@@ -92,7 +92,7 @@ public final class Constants {
     public static final String DCS_SERVER_USER_PROGRAM_COMMAND = "dcs.server.user.program.command";
 
     /** Default value for DCS server user program command */
-    public static final String DEFAULT_DCS_SERVER_USER_PROGRAM_COMMAND = "cd ${dcs.user.program.home};. ./sqenv.sh;mxosrvr -ZKHOST -RZ -ZKPNODE -CNGTO -ZKSTO -EADSCO -TCPADD -MAXHEAPPCT -STATISTICSINTERVAL -STATISTICSLIMIT -STATISTICSTYPE -STATISTICSENABLE -SQLPLAN -PORTMAPTOSECS -PORTBINDTOSECS";
+    public static final String DEFAULT_DCS_SERVER_USER_PROGRAM_COMMAND = "cd ${dcs.user.program.home};. ./sqenv.sh;mxosrvr -ZKHOST -RZ -ZKPNODE -CNGTO -ZKSTO -EADSCO -TCPADD -MAXHEAPPCT -STATISTICSINTERVAL -STATISTICSLIMIT -STATISTICSTYPE -STATISTICSENABLE -SQLPLAN -PORTMAPTOSECS -PORTBINDTOSECS -TCPKEEPALIVESTATUS -TCPKEEPALIVEIDLETIME -TCPKEEPALIVEINTERVAL -TCPKEEPALIVERETRYCOUNT";
 
     /** Configuration key for DCS server user program connecting timeout */
     public static final String DCS_SERVER_USER_PROGRAM_CONNECTING_TIMEOUT = "dcs.server.user.program.connecting.timeout";
@@ -112,6 +112,29 @@ public final class Constants {
     /** Default value for DCS server user program exit after disconnect */
     public static final int DEFAULT_DCS_SERVER_USER_PROGRAM_EXIT_AFTER_DISCONNECT = 0;
 
+    /** Configuration key for DCS server program mxosrvr keepalive STATUS*/
+    public static final String  DEFAULT_DCS_SERVER_PROGRAM_TCP_KEEPALIVE_STATUS= "dcs.server.user.program.tcp.keepalive.status";
+
+    /** Default value for DCS server program mxosrvr keepalive STATUS*/
+    public static final String DCS_SERVER_PROGRAM_KEEPALIVE_STATUS = "enable";
+
+    /** Configuration key for DCS server program mxosrvr keepalive IDLETIME*/
+    public static final String DEFAULT_DCS_SERVER_PROGRAM_TCP_KEEPALIVE_IDLETIME = "dcs.server.user.program.tcp.keepalive.idletime";
+
+    /** Default value for DCS server program mxosrvr keepalive IDLETIME*/
+    public static final int DCS_SERVER_PROGRAM_KEEPALIVE_IDLETIME = 300;
+
+    /** Configuration key for DCS server program mxosrvr keepalive INTERTIME */
+    public static final String DEFAULT_DCS_SERVER_PROGRAM_TCP_KEEPALIVE_INTERVALTIME = "dcs.server.user.program.tcp.keepalive.intervaltime";
+
+    /** Default value for DCS server program mxosrvr keepalive INTERTIME */
+    public static final int DCS_SERVER_PROGRAM_KEEPALIVE_INTERVALTIME = 5;
+
+    /** Configuration key for DCS server program mxosrvr keepalive RETRYCNT*/
+    public static final String DEFAULT_DCS_SERVER_PROGRAM_TCP_KEEPALIVE_RETRYCOUNT = "dcs.server.user.program.tcp.keepalive.retrycount";
+
+    /** Default value for DCS server program mxosrvr keepalive RETRYCNT*/
+    public static final int DCS_SERVER_PROGRAM_KEEPALIVE_RETRYCOUNT = 3;
     /**
      * Configuration key for DCS server user program exit when heap size becomes
      * too large

--- a/dcs/src/main/java/org/trafodion/dcs/server/ServerManager.java
+++ b/dcs/src/main/java/org/trafodion/dcs/server/ServerManager.java
@@ -83,6 +83,10 @@ public final class ServerManager implements Callable {
     private int maxRestartAttempts;
     private int retryIntervalMillis;
     private String nid = null;
+    private static String mxosrvrKeepaliveStatus;
+    private static int mxosrvrKeepaliveIdletime;
+    private static int mxosrvrKeepaliveIntervaltime;
+    private static int mxosrvrKeepaliveRetrycount;
 
     class RegisteredWatcher implements Watcher {
         CountDownLatch startSignal;
@@ -205,6 +209,14 @@ public final class ServerManager implements Callable {
                             "-PORTMAPTOSECS " + userProgPortMapToSecs + " ")
                     .replace("-PORTBINDTOSECS",
                             "-PORTBINDTOSECS " + userProgPortBindToSecs)
+                    .replace("-TCPKEEPALIVESTATUS",
+                            "-TCPKEEPALIVESTATUS " + mxosrvrKeepaliveStatus + " ")
+                    .replace("-TCPKEEPALIVEIDLETIME",
+                            "-TCPKEEPALIVEIDLETIME " + mxosrvrKeepaliveIdletime + " ")
+                    .replace("-TCPKEEPALIVEINTERVAL",
+                            "-TCPKEEPALIVEINTERVAL " + mxosrvrKeepaliveIntervaltime + " ")
+                    .replace("-TCPKEEPALIVERETRYCOUNT",
+                            "-TCPKEEPALIVERETRYCOUNT " + mxosrvrKeepaliveRetrycount + " ")
                     .replace("&lt;", "<").replace("&amp;", "&")
                     .replace("&gt;", ">");
             scriptContext.setCommand(command);
@@ -348,6 +360,18 @@ public final class ServerManager implements Callable {
         this.retryIntervalMillis = conf
                 .getInt(Constants.DCS_SERVER_USER_PROGRAM_RESTART_HANDLER_RETRY_INTERVAL_MILLIS,
                         Constants.DEFAULT_DCS_SERVER_USER_PROGRAM_RESTART_HANDLER_RETRY_INTERVAL_MILLIS);
+        this.mxosrvrKeepaliveStatus = conf.get(
+                Constants.DEFAULT_DCS_SERVER_PROGRAM_TCP_KEEPALIVE_STATUS,
+                Constants.DCS_SERVER_PROGRAM_KEEPALIVE_STATUS);
+        this.mxosrvrKeepaliveIdletime = conf.getInt(
+                Constants.DEFAULT_DCS_SERVER_PROGRAM_TCP_KEEPALIVE_IDLETIME,
+                Constants.DCS_SERVER_PROGRAM_KEEPALIVE_IDLETIME);
+        this.mxosrvrKeepaliveIntervaltime = conf.getInt(
+                Constants.DEFAULT_DCS_SERVER_PROGRAM_TCP_KEEPALIVE_INTERVALTIME,
+                Constants.DCS_SERVER_PROGRAM_KEEPALIVE_INTERVALTIME);
+        this.mxosrvrKeepaliveRetrycount = conf.getInt(
+                Constants.DEFAULT_DCS_SERVER_PROGRAM_TCP_KEEPALIVE_RETRYCOUNT,
+                Constants.DCS_SERVER_PROGRAM_KEEPALIVE_RETRYCOUNT);
         serverHandlers = new ServerHandler[this.childServers];
     }
 

--- a/dcs/src/main/resources/dcs-default.xml
+++ b/dcs/src/main/resources/dcs-default.xml
@@ -386,4 +386,33 @@
         Timeout minutes between first and max times (6 default) DCS Server startup MXOSRVR.
     </description>
   </property>
+  <property>
+    <name>dcs.server.user.program.tcp.keepalive.status</name>
+    <value>enable</value>
+    <description>
+        Used in  mxosrvr keepalive , parameter is ENABLE IDLETIME INTERTIME RETRYCNT.
+    </description>
+  </property>
+  <property>
+    <name>dcs.server.user.program.tcp.keepalive.idletime</name>
+    <value>300</value>
+    <description>
+        Used in  mxosrvr keepalive , parameter is ENABLE IDLETIME INTERTIME RETRYCNT.
+    </description>
+  </property>
+  <property>
+    <name>dcs.server.user.program.tcp.keepalive.intervaltime</name>
+    <value>5</value>
+    <description>
+        Used in  mxosrvr keepalive , parameter is ENABLE IDLETIME INTERTIME RETRYCNT.
+    </description>
+  </property>
+  <property>
+    <name>dcs.server.user.program.tcp.keepalive.retrycount</name>
+    <value>3</value>
+    <description>
+        Used in  mxosrvr keepalive , parameter is ENABLE IDLETIME INTERTIME RETRYCNT.
+    </description>
+  </property>
+
 </configuration>


### PR DESCRIPTION
Keepalive could be configured by modifying file src/main/java/org/trafodion/dcs/Constants.java

Modify variable DCS_SERVER_PROGRAM_TCP_KEEPALIVE_STATUS/IDLETIME/INTERVAL/RETRYCOUNT;

DCS_SERVER_PROGRAM_TCP_KEEPALIVE_STATUS has three value:enable,default,unenable;

Default value is enable,300,3,20(Only effective when value configured is set incorrectly)

The value will be read in when mxosrvr start. Mxosrvr will set the socket after getting a connection.