### PR TITLE
[TRAFODION-3016] Windows ODBC do not support output with zh-cn.utf8

### DIFF
--- a/win-odbc64/odbcclient/drvr35/cdatasource.h
+++ b/win-odbc64/odbcclient/drvr35/cdatasource.h
@@ -44,6 +44,7 @@ public:
 	short readDSValues(char *DSName, char* TransError);
 	void CDataSource::updateDSValues(short DSNType, CONNECT_FIELD_ITEMS *connectFieldItems,
 								 CONNECT_KEYWORD_TREE *keywordTree);
+    void setDSCharSet(DWORD charset){ m_DSCharSet = charset; };
 private:
 	short		m_DSLocation;						
 	char		m_DSName[MAX_SQL_IDENTIFIER_LEN + 1];

--- a/win-odbc64/odbcclient/drvr35/cstmt.cpp
+++ b/win-odbc64/odbcclient/drvr35/cstmt.cpp
@@ -1063,7 +1063,20 @@ SQLRETURN CStmt::SendSQLCommand(BOOL SkipProcess, SQLCHAR *StatementText,
             else
                 m_StmtType = TYPE_UNKNOWN;
         }
-
+        else if (strcmp(token, "SET") == 0)
+        {
+            token = strtok(NULL, delimiters);
+            if (token != NULL && strcmp(token, "NAMES") == 0)
+            {
+                token = strtok(NULL, delimiters);
+                if (token != NULL && strcmp(token, "'UTF8'") == 0)
+                {
+                    m_ConnectHandle->m_DSValue.setDSCharSet(1);
+                    return SQL_SUCCESS;
+                }
+            }
+            m_StmtType = TYPE_UNKNOWN;
+        }
         else
         {
             /*


### PR DESCRIPTION
The Chinese encode of windows is GBK.
So driver will convert the Chinese characters to GB2312.
But when UTF-8 is needed, it is not supported.
And "SET NAMES 'UTF8'" is used by mysql and PostgreSQL also.