### PR TITLE
[TRAFOODION-2949] Performance changes for LOB and increasing limit for larger varchars/…

### DIFF
--- a/core/sql/common/CharType.cpp
+++ b/core/sql/common/CharType.cpp
@@ -1477,7 +1477,7 @@ SQLlob::SQLlob(NAMemory *h,
 		)
   : NAType(h, (ev == NA_LOB_TYPE ? LiteralLOB : LiteralLOB)
 	    , ev
-	    , (externalFormat ? extFormatLen : 512)
+	    , extFormatLen
 	    , allowSQLnull
 	    , allowSQLnull ? SQL_NULL_HDR_SIZE : 0
 	    , TRUE

--- a/core/sql/common/CharType.h
+++ b/core/sql/common/CharType.h
@@ -735,16 +735,21 @@ public:
 
   SQLlob(NAMemory *h,
          NABuiltInTypeEnum  ev,
-	 Int64 lobLength, 
-	 LobsStorage lobStorage,
+	 Int64 lobLength=1024, 
+	 LobsStorage lobStorage=Lob_Invalid_Storage,
 	 NABoolean allowSQLnull	= TRUE,
 	 NABoolean inlineIfPossible = FALSE,
 	 NABoolean externalFormat = FALSE,
-	 Lng32 extFormatLen = 100);
+	 Lng32 extFormatLen=1024 );
  SQLlob(const SQLlob & aLob,NAMemory * heap)
-   :NAType(aLob,heap),
-    charSet_(CharInfo::UnknownCharSet)
-    {}
+   :NAType(aLob,heap)
+    {
+      lobLength_ = aLob.lobLength_;
+      lobStorage_ = aLob.lobStorage_;
+      externalFormat_ = aLob.externalFormat_;
+      extFormatLen_ = aLob.extFormatLen_;     
+      setCharSet(CharInfo::ISO88591);//lobhandle can only be in ISO format
+    }
   
  //is this type a blob/clob
  virtual NABoolean isLob() const {return TRUE;};
@@ -798,14 +803,14 @@ class SQLBlob : public SQLlob
 public: 
 
   SQLBlob(NAMemory *h,
-          Int64 blobLength, 
+          Int64 blobLength=1024, 
 	  LobsStorage lobStorage = Lob_Invalid_Storage,
 	  NABoolean allowSQLnull	= TRUE,
 	  NABoolean inlineIfPossible = FALSE,
 	  NABoolean externalFormat = FALSE,
 	  Lng32 extFormatLen = 1024);
  SQLBlob(const SQLBlob & aBlob,NAMemory * heap)
-   :SQLlob(aBlob,heap)
+      :SQLlob(aBlob,heap)
     {}
   virtual short getFSDatatype() const
   {return REC_BLOB;}
@@ -838,14 +843,14 @@ class SQLClob : public SQLlob
 public: 
 
   SQLClob(NAMemory *h,
-          Int64 blobLength, 
+          Int64 blobLength=1024, 
 	  LobsStorage lobStorage = Lob_Invalid_Storage,
 	  NABoolean allowSQLnull	= TRUE,
 	  NABoolean inlineIfPossible = FALSE,
 	  NABoolean externalFormat = FALSE,
 	  Lng32 extFormatLen = 1024);
  SQLClob(const SQLClob & aClob,NAMemory * heap)
-   :SQLlob(aClob,heap)
+      :SQLlob(aClob,heap)
     {}
   virtual short getFSDatatype() const
   {return REC_CLOB;}
@@ -864,6 +869,6 @@ public:
 private:
 
 }; // class SQLClob
-// sss #endif
+
 
 #endif /* CHARTYPE_H */

--- a/core/sql/exp/ExpLOBaccess.cpp
+++ b/core/sql/exp/ExpLOBaccess.cpp
@@ -304,15 +304,14 @@ Ex_Lob_Error ExLob::writeData(Int64 offset, char *data, Int32 size, Int64 &operL
       if (fInfo == NULL) {
          return LOB_DATA_FILE_NOT_FOUND_ERROR;
       }
+      if (fdData_)
+      {
+        hdfsCloseFile(fs_, fdData_);
+        fdData_=NULL;
+      }
+      openFlags_ =  O_WRONLY | O_APPEND; 
+      fdData_ = hdfsOpenFile(fs_, lobDataFile_.data(), openFlags_, 0, 0, 0);
     }
-     hdfsCloseFile(fs_, fdData_);
-     fdData_=NULL;
-     openFlags_ = O_WRONLY | O_APPEND; 
-     fdData_ = hdfsOpenFile(fs_, lobDataFile_.data(), openFlags_, 0, 0, 0);
-     if (!fdData_) {
-       openFlags_ = -1;
-       return LOB_DATA_FILE_OPEN_ERROR;
-     }
 
      if ((operLen = hdfsWrite(fs_, fdData_, data, size)) == -1) {
        return LOB_DATA_WRITE_ERROR;
@@ -946,6 +945,10 @@ Ex_Lob_Error ExLob::writeDesc(Int64 &sourceLen, char *source, LobsSubOper subOpe
        LobInputOutputFileType srcFileType = fileType(source);
        if (srcFileType != HDFS_FILE)
          return  LOB_SOURCE_FILE_READ_ERROR;
+       //Check if external file exists
+       Int64 sourceEOD = 0;
+       if (statSourceFile(source, sourceEOD) != LOB_OPER_OK)
+         return  LOB_SOURCE_FILE_READ_ERROR;
       }
     // Calculate sourceLen for each subOper.
     if ((subOper == Lob_File))
@@ -1256,6 +1259,8 @@ Ex_Lob_Error ExLob::insertSelect(ExLob *srcLobPtr,
       // we have received the external data file name from the descriptor table
       // replace the contents of the lobDataFile with this name      
       str_cpy_all(extFileName, blackBox, blackBoxLen);
+      extFileName[blackBoxLen]= '\0';
+
       extFileNameLen = blackBoxLen;
       // Now insert this into the target lob descriptor
       
@@ -1822,8 +1827,8 @@ Ex_Lob_Error ExLob::allocateDesc(ULng32 size, Int64 &descNum, Int64 &dataOffset,
     hdfsFileInfo *fInfo = hdfsGetPathInfo(fs_, lobDataFile_.data());
     if (fInfo)
       dataOffset = fInfo->mSize;
-
-    if ((lobGCLimit != 0) && (dataOffset > lobGCLimit)) // 5 GB default
+    // if -1, don't do GC or if reached the limit do GC
+    if ((lobGCLimit != -1) && (dataOffset > lobGCLimit)) 
       {
         str_sprintf(logBuf,"Starting GC. Current Offset : %ld",dataOffset);
         lobDebugInfo(logBuf,0,__LINE__,lobTrace_);
@@ -1876,7 +1881,7 @@ Ex_Lob_Error ExLob::compactLobDataFile(ExLobInMemoryDescChunksEntry *dcArray,Int
   Ex_Lob_Error rc = LOB_OPER_OK;
   char logBuf[4096];
   lobDebugInfo("In ExLob::compactLobDataFile",0,__LINE__,lobTrace_);
-  Int64 maxMemChunk = 1024*1024*1024; //1GB limit for intermediate buffer for transfering data
+  Int64 maxMemChunk = 100*1024*1024; //100 MB limit for intermediate buffer for transfering data
 
   // make some temporary file names
   size_t len = lobDataFile_.length();

--- a/core/sql/exp/exp_attrs.cpp
+++ b/core/sql/exp/exp_attrs.cpp
@@ -316,15 +316,13 @@ void Attributes::displayContents(Space * space, Int32 operandNum,
   if ((getDatatype() == REC_BLOB) ||
       (getDatatype() == REC_CLOB))
     {
-      Int16 precision = getPrecision();
-      UInt16 scale = getScaleAsUI();
+     
       
-      Lng32 lobLen = (precision << 16);
-      lobLen += scale;
-      
-      Int64 ll = (Int64)lobLen;
+      Int64 ll = getLength();
+      if (isLengthInKB())
+        ll = ll*1024;
       //      Int64 ll = (Int64)getPrecision() * 1000 + (Int64)getScale();
-      str_sprintf(buf, "      LobLength = %ld Mb", ll);
+      str_sprintf(buf, "      LobLength = %ld bytes", ll);
       space->allocateAndCopyToAlignedSpace(buf, str_len(buf), sizeof(short));
     }
 

--- a/core/sql/exp/exp_attrs.h
+++ b/core/sql/exp/exp_attrs.h
@@ -378,6 +378,9 @@ public:
   NABoolean isForceFixed()     { return (flags_ & FORCE_FIXED_) != 0; }
   void setForceFixed()         { flags_ |= FORCE_FIXED_; }
 
+  NABoolean isLengthInKB()     { return (flags_ & LENGTH_IN_KB_) != 0; }
+  void setLengthInKB()         { flags_ |= LENGTH_IN_KB_; }
+
   // Bulk move flags
   void setBulkMoveable( NABoolean flag = TRUE ) { (flag ? flags_ |= BULK_MOVE_ : flags_ &= ~BULK_MOVE_); }
   NABoolean isBulkMoveable()       { return (flags_ & BULK_MOVE_) != 0; }
@@ -584,9 +587,10 @@ private:
 
     CASEINSENSITIVE_ = 0x0400,    // caseinsensitive char/varchar datatype
 
-    FORCE_FIXED_   = 0x0800       // Force this attribute to be treated as fixed
+    FORCE_FIXED_   = 0x0800,       // Force this attribute to be treated as fixed
                                   // in an aligned row.  Used by HashGroupby for
                                   // varchar aggregates
+    LENGTH_IN_KB_ =0x1000 // Indicates length is in KB 
 
   };
  

--- a/core/sql/generator/GenExpGenerator.cpp
+++ b/core/sql/generator/GenExpGenerator.cpp
@@ -359,13 +359,8 @@ Attributes * ExpGenerator::convertNATypeToAttributes
       
       else if (naType->getTypeQualifier() == NA_LOB_TYPE)
         {
+          
 	  SQLlob *lobType = (SQLlob *) naType;
-
-	  Lng32 lobLen = (Lng32)lobType->getLobLength();
-	  Int16 precision = (lobLen & 0xFFFF0000) >> 16;
-	  Int16 scale = lobLen & 0xFFFF;
-	  attr->setPrecision(precision);
-	  attr->setScale(scale);
           attr->setCharSet(lobType->getCharSet());
 	}
       

--- a/core/sql/generator/GenRelExeUtil.cpp
+++ b/core/sql/generator/GenRelExeUtil.cpp
@@ -4410,7 +4410,10 @@ short ExeUtilLobUpdate::codeGen(Generator * generator)
   exe_util_lobupdate_tdb->setTotalBufSize(CmpCommon::getDefaultNumeric(LOB_MAX_CHUNK_MEM_SIZE)*1024*1024);
   exe_util_lobupdate_tdb->setLobMaxSize( CmpCommon::getDefaultNumeric(LOB_MAX_SIZE) * 1024 * 1024);
   exe_util_lobupdate_tdb->setLobMaxChunkSize(CmpCommon::getDefaultNumeric(LOB_MAX_CHUNK_MEM_SIZE)*1024*1024);
-  exe_util_lobupdate_tdb->setLobGCLimit(CmpCommon::getDefaultNumeric(LOB_GC_LIMIT_SIZE)*1024*1024);
+  if ((CmpCommon::getDefaultNumeric(LOB_GC_LIMIT_SIZE) >=0))
+    exe_util_lobupdate_tdb->setLobGCLimit(CmpCommon::getDefaultNumeric(LOB_GC_LIMIT_SIZE)*1024*1024);
+  else
+    exe_util_lobupdate_tdb->setLobGCLimit(CmpCommon::getDefaultNumeric(LOB_GC_LIMIT_SIZE));
                                            
                                         
   generator->setCriDesc(givenDesc, Generator::DOWN);

--- a/core/sql/generator/GenRelJoin.cpp
+++ b/core/sql/generator/GenRelJoin.cpp
@@ -3482,9 +3482,11 @@ short NestedJoin::codeGen(Generator * generator)
 
   // Make sure that the LHS up queue can grow as large as the RHS down
   // queue.
-  if(tdb1->getMaxQueueSizeUp() < tdb2->getInitialQueueSizeDown()) {
-    tdb1->setMaxQueueSizeUp(tdb2->getInitialQueueSizeDown());
-  }
+  //We can't let upqueue of unpack to grow beyond what was calculated and set earlier in codeGen of the unpack operator
+  if (tdb1->getClassID() != ComTdb::ex_UNPACKROWS)
+    if(tdb1->getMaxQueueSizeUp() < tdb2->getInitialQueueSizeDown()) {
+      tdb1->setMaxQueueSizeUp(tdb2->getInitialQueueSizeDown());
+    }
 
   // If this NestedJoin itself is not on the RHS of a Flow/NestedJoin,
   // Then reset the largeQueueSize to 0.

--- a/core/sql/generator/Generator.h
+++ b/core/sql/generator/Generator.h
@@ -1580,6 +1580,7 @@ public:
   // Helpers for the special ONLJ queue sizing defaults.
   NABoolean const getMakeOnljLeftQueuesBig() 
                                     { return makeOnljLeftQueuesBig_; }
+  void setMakeOnljLeftQueuesBig(NABoolean x) {makeOnljLeftQueuesBig_ = x;}
   ULng32 const getOnljLeftUpQueue() { return onljLeftUpQueue_; }
   ULng32 const getOnljLeftDownQueue() {return onljLeftDownQueue_; }
 

--- a/core/sql/optimizer/BindItemExpr.cpp
+++ b/core/sql/optimizer/BindItemExpr.cpp
@@ -6103,20 +6103,22 @@ ItemExpr *Assign::bindNode(BindWA *bindWA)
 
               NAType * newType = NULL;
 
-              double lob_input_limit_for_batch = CmpCommon::getDefaultNumeric(LOB_INPUT_LIMIT_FOR_BATCH);
+              double lob_input_limit_for_batch = CmpCommon::getDefaultNumeric(LOB_INPUT_LIMIT_FOR_BATCH)*1024;
                   double lob_size = lobType.getLobLength();
               if (fs_datatype == REC_CLOB) {
-                  newType = new (bindWA->wHeap()) SQLClob(bindWA->wHeap(), (CmpCommon::getDefaultNumeric(LOB_MAX_SIZE) * 1024 * 1024),
+                newType = new (bindWA->wHeap()) SQLClob(bindWA->wHeap(), lob_input_limit_for_batch < lob_size ? lob_input_limit_for_batch : lob_size,
                          lobType.getLobStorage(),
-                         TRUE, FALSE, TRUE,
+                         TRUE, FALSE, FALSE,
                          lob_input_limit_for_batch < lob_size ? lob_input_limit_for_batch : lob_size);
               }
               else {
-              newType = new (bindWA->wHeap()) SQLBlob(bindWA->wHeap(), (CmpCommon::getDefaultNumeric(LOB_MAX_SIZE)*1024*1024),
+                newType = new (bindWA->wHeap()) SQLBlob(bindWA->wHeap(),lob_input_limit_for_batch < lob_size ? lob_input_limit_for_batch : lob_size ,
                                              lobType.getLobStorage(), 
-                                             TRUE, FALSE, TRUE, 
+                                             TRUE, FALSE, FALSE, 
                                              lob_input_limit_for_batch < lob_size ? lob_input_limit_for_batch : lob_size);
               }
+             
+              CMPASSERT(lob_input_limit_for_batch < INT_MAX);
               vid1.coerceType(*newType, NA_LOB_TYPE); 
               if (bindWA->getCurrentScope()->context()->inUpdate())
                 {

--- a/core/sql/optimizer/ItemFunc.h
+++ b/core/sql/optimizer/ItemFunc.h
@@ -2869,9 +2869,9 @@ public:
    obj_(obj),
    lobNum_(-1),
    lobStorageType_(Lob_Invalid_Storage),
-   lobMaxSize_((Int64)CmpCommon::getDefaultNumeric(LOB_MAX_SIZE) * 1024 * 1024),
-     lobMaxChunkMemSize_(CmpCommon::getDefaultNumeric(LOB_MAX_CHUNK_MEM_SIZE)),
-     lobGCLimit_(CmpCommon::getDefaultNumeric(LOB_GC_LIMIT_SIZE)),
+     lobMaxSize_((Int64)CmpCommon::getDefaultNumeric(LOB_MAX_SIZE)*1024*1024),
+     lobMaxChunkMemSize_((Int64)CmpCommon::getDefaultNumeric(LOB_MAX_CHUNK_MEM_SIZE)*1024*1024),
+     lobGCLimit_((Int64) CmpCommon::getDefaultNumeric(LOB_GC_LIMIT_SIZE)*1024*1024),
      hdfsPort_((Lng32)CmpCommon::getDefaultNumeric(LOB_HDFS_PORT)),
      hdfsServer_( CmpCommon::getDefaultString(LOB_HDFS_SERVER))
    {
@@ -2911,8 +2911,14 @@ public:
   LobsStorage &lobStorageType() { return lobStorageType_; }
   NAString &lobStorageLocation() { return lobStorageLocation_; }
   Int64 getLobMaxSize() {return lobMaxSize_; }
-  Int64 getLobMaxChunkMemSize() { return lobMaxChunkMemSize_*1024*1024;}
-  Int64 getLobGCLimit() { return lobGCLimit_*1024*1024;}
+  Int64 getLobMaxChunkMemSize() { return lobMaxChunkMemSize_;}
+  Int64 getLobGCLimit() 
+  { 
+    if (lobGCLimit_>0) 
+      return (Int64)lobGCLimit_;
+    else
+      return -1;
+  }
   Int32 getLobHdfsPort() { return hdfsPort_;}
   NAString &getLobHdfsServer(){return hdfsServer_;}
  protected:
@@ -2922,8 +2928,8 @@ public:
   LobsStorage lobStorageType_;
   NAString lobStorageLocation_;
   Int64 lobMaxSize_; // In byte units
-  Int32 lobMaxChunkMemSize_; //In MB Units
-  Int32 lobGCLimit_ ;//In MB Units
+  Int64 lobMaxChunkMemSize_; //In MB Units
+  Int64 lobGCLimit_ ;//In MB Units
   Int32 hdfsPort_;
   NAString hdfsServer_;
   
@@ -2943,7 +2949,7 @@ class LOBinsert : public LOBoper
     objectUID_(-1),
     append_(isAppend),
     lobAsVarchar_(treatLobAsVarchar),
-    lobSize_(0),
+     lobSize_((Int64)CmpCommon::getDefaultNumeric(LOB_MAX_SIZE)*1024*1024),
     fsType_(REC_BLOB)
     {};
   
@@ -2968,7 +2974,7 @@ class LOBinsert : public LOBoper
 
   //  Lng32 & lobNum() { return lobNum_; }
 
-  Lng32 & lobSize() { return lobSize_; }
+  Int64 & lobSize() { return lobSize_; }
 
   Lng32 & lobFsType() { return fsType_; }
   NABoolean lobAsVarchar() const { return lobAsVarchar_;}
@@ -2984,7 +2990,7 @@ class LOBinsert : public LOBoper
   // column this blob is being inserted into.
   //  Lng32 lobNum_;
 
-  Lng32 lobSize_;
+  Int64 lobSize_;
 
   Lng32 fsType_;
 
@@ -3048,7 +3054,7 @@ class LOBupdate : public LOBoper
             NABoolean treatLobAsVarchar =FALSE)
     : LOBoper(ITM_LOBUPDATE, val1Ptr, val2Ptr,val3Ptr,fromObj),
       objectUID_(-1),
-      lobSize_(0),
+      lobSize_((Int64)CmpCommon::getDefaultNumeric(LOB_MAX_SIZE)*1024*1024),
       append_(isAppend),
       lobAsVarchar_(treatLobAsVarchar)
     {};
@@ -3070,7 +3076,7 @@ class LOBupdate : public LOBoper
   Int64 & updatedTableObjectUID() { return objectUID_; }
   
   NAString &updatedTableSchemaName() { return schName_; }
-  Lng32 & lobSize() { return lobSize_; }
+  Int64 & lobSize() { return lobSize_; }
   NABoolean lobAsVarchar() const { return lobAsVarchar_;}
  private:
   // ---------------------------------------------------------------//
@@ -3083,7 +3089,7 @@ class LOBupdate : public LOBoper
 
 
   NABoolean append_;
-  Lng32 lobSize_;
+  Int64 lobSize_;
   NABoolean lobAsVarchar_;//This means this lob insert will get it's input data 
                           // in varchar format
 }; // class LOBupdate
@@ -3092,7 +3098,7 @@ class LOBconvert : public LOBoper
 {
  public:
   
- LOBconvert(ItemExpr *val1Ptr, ObjectType toObj,  Lng32 tgtSize = 32000) 
+ LOBconvert(ItemExpr *val1Ptr, ObjectType toObj,  Lng32 tgtSize= CmpCommon::getDefaultNumeric(LOB_OUTPUT_SIZE) ) 
    : LOBoper(ITM_LOBCONVERT, val1Ptr, NULL,NULL,toObj),
     tgtSize_(tgtSize)     
     {};

--- a/core/sql/optimizer/ObjectNames.cpp
+++ b/core/sql/optimizer/ObjectNames.cpp
@@ -710,7 +710,7 @@ NABoolean QualifiedName::isHbaseCellOrRow() const
 
 NABoolean QualifiedName::isLOBDesc() const
 {
-  if (getObjectName().index(LOB_DESC_HANDLE_PREFIX) == 0)
+  if ((getObjectName().index(LOB_DESC_HANDLE_PREFIX) == 0) || (getObjectName().index(LOB_DESC_CHUNK_PREFIX) ==0))
     return TRUE;
       
   else

--- a/core/sql/optimizer/SynthType.cpp
+++ b/core/sql/optimizer/SynthType.cpp
@@ -6680,7 +6680,7 @@ const NAType *LOBoper::synthesizeType()
 {
   // Return blob or clob type
   
-  NAType *result = new HEAP SQLBlob(HEAP, 1000);
+  NAType *result = new HEAP SQLBlob(HEAP, ((Int64) CmpCommon::getDefaultNumeric(LOB_MAX_SIZE)*1024*1024));
 
   if (child(0))
     {
@@ -6689,12 +6689,12 @@ const NAType *LOBoper::synthesizeType()
       
       if (typ1.getFSDatatype() == REC_BLOB)
 	{
-	  result = new HEAP SQLBlob(HEAP, 1000, Lob_Local_File,
+	  result = new HEAP SQLBlob(HEAP, ((Int64) CmpCommon::getDefaultNumeric(LOB_MAX_SIZE)*1024*1024), Lob_Invalid_Storage,
 				    typ1.supportsSQLnull());
 	}
       else if (typ1.getFSDatatype() == REC_CLOB)
 	{
-	  result = new HEAP SQLClob(HEAP, 1000, Lob_Invalid_Storage,
+	  result = new HEAP SQLClob(HEAP, ((Int64) CmpCommon::getDefaultNumeric(LOB_MAX_SIZE)*1024*1024), Lob_Invalid_Storage,
 				    typ1.supportsSQLnull());
 	}
     } 
@@ -6923,7 +6923,7 @@ const NAType *LOBconvertHandle::synthesizeType()
 	  return NULL;
 	}
       
-      result = new HEAP SQLBlob(HEAP, 1000, Lob_Invalid_Storage, typ1.supportsSQLnull(), FALSE, 
+     result = new HEAP SQLBlob(HEAP, ((Int64) CmpCommon::getDefaultNumeric(LOB_MAX_SIZE)*1024*1024), Lob_Invalid_Storage, typ1.supportsSQLnull(), FALSE, 
 					FALSE);
       return result;
     }

--- a/core/sql/parser/sqlparser.y
+++ b/core/sql/parser/sqlparser.y
@@ -11647,7 +11647,7 @@ blob_optional_left_len_right: '(' NUMERIC_LITERAL_EXACT_NO_SCALE optional_lob_un
 
 	  if (CmpCommon::getDefault(TRAF_BLOB_AS_VARCHAR) == DF_ON)
 	    {
-	      $$ = (Int64)100000;
+	      $$ = (Int64)CmpCommon::getDefault(TRAF_MAX_CHARACTER_COL_LENGTH );
 	    }
 	  else
 	    {
@@ -11683,7 +11683,7 @@ clob_optional_left_len_right: '(' NUMERIC_LITERAL_EXACT_NO_SCALE optional_lob_un
 
 	  if (CmpCommon::getDefault(TRAF_CLOB_AS_VARCHAR) == DF_ON)
 	    {
-	      $$ = (Int64)100000;
+	      $$ = (Int64)CmpCommon::getDefault(TRAF_MAX_CHARACTER_COL_LENGTH );
 	    }
 	  else
 	    {

--- a/core/sql/qmscommon/QRLogger.cpp
+++ b/core/sql/qmscommon/QRLogger.cpp
@@ -266,7 +266,7 @@ const char*  QRLogger::getMyProcessInfo()
   XPROCESSHANDLE_DECOMPOSE_(&myphandle, &mycpu, &mypin, &mynodenumber,NULL,100, NULL, myprocname,100, &myproclength);
   myprocname[myproclength] = '\0';
 
-  snprintf(procInfo, 300, "Node Number: %d, CPU: %d, PIN: %d, Process Name: %s", mynodenumber,mycpu, mypin, myprocname);
+  snprintf(procInfo, 300, "Node Number: %d, CPU: %d, PIN: %d, Process Name: %s", mycpu,mycpu, mypin, myprocname);
 
   processInfo_ = procInfo;
   return processInfo_.data();

--- a/core/sql/sqlcomp/CmpMain.cpp
+++ b/core/sql/sqlcomp/CmpMain.cpp
@@ -725,9 +725,13 @@ CmpMain::ReturnStatus CmpMain::sqlcomp(QueryText& input,            //IN
 
     //if using special tables e.g. using index as base table
     //select * from table (index_table T018ibc);
-    //then refresh metadata cache
+    //then refresh metadata cache.  Make an exception for internal exeutil
+    // statements that use this parserflag. It causes too many long compiles 
+    // and affects performance - for eg LOB access which uses ghost tables and 
+    // has the SPECIALTABLETYPE flag set..  
     if(Get_SqlParser_Flags(ALLOW_SPECIALTABLETYPE) &&
-       CmpCommon::context()->schemaDB_->getNATableDB()->cachingMetaData())
+       CmpCommon::context()->schemaDB_->getNATableDB()->cachingMetaData() &&
+       !Get_SqlParser_Flags(INTERNAL_QUERY_FROM_EXEUTIL) )
       CmpCommon::context()->schemaDB_->getNATableDB()->refreshCacheInThisStatement();
 
     MonitorMemoryUsage_Enter("Parser");


### PR DESCRIPTION
…bobs to use with batch input.
For LOB internal descriptor files, there was a check in compiler that prevented caching of NA Table . Removed that restriction for LOB descriptor tables  which affected evey DML into a table with a LOB column. 
Fix to allow larger varchar/lob data to be input with batch input.
1.  	First check for rowset size is in pre codegen phase. This was added during POC since we were getting 4 GB of rowset data all at once.
CQD MEMORY_LIMIT_ROWSET_IN_MB  was added and  set to 500MB.   The data + rowset size needed to fit into this space. I have changed it to be 1GB by defaults now.

2.	Then we check how big the up  queuesize should be to handle this rowset .  
CQD EXE_MEMORY_FOR_UNPACK_ROWS_IN_MB  is set to 100MB for this.  In this case we dynamically adjust the queue size to accommodate larger rows.  Eg is we have 100 rows of  2 MB each, we will limit upqueue size to 50 and allow 50 entries in upqueue. 

I have changed the default value for this CQD to be 1GB to match (1.)

3.	At runtime, the problem is that after passing these 2 checks, we try to allocate double the size of the up queue size for the full row length .  

Assume we calculate in step(2)  the upqueue size is N,  then we allocate rowlength*N*2   at runtime. This clearly exceeds what we have estimated at compiletime. 
This change includes a change in compiler to estimate the memory correctly. 


So with these we can handle upto 16MB of long varchar/LOB data for batch input data a little better.   But driver will still need to ensure that the rowset buffer will fit into the 1GB limit otherwise an error will be returned at compiletime. So for batch input for large rows , we need to  limit number of rows in the rowset. 

Also included a fix for TRAFODION-909