### PR TITLE
[TRAFODION-3022] Add web site link to Apache Current Events

### DIFF
--- a/docs/src/site/site.xml
+++ b/docs/src/site/site.xml
@@ -40,6 +40,14 @@
     </name>
     <href>index.html</href>
   </bannerLeft>
+  <bannerRight>
+    <name>
+       <![CDATA[
+       <img src="https://www.apache.org/events/current-event-125x125.png" alt="Apache Events" width="125">
+       ]]>
+    </name>
+    <href>https://www.apache.org/events/current-event.html</href>
+  </bannerRight>
 
   <custom>
     <reflowSkin>


### PR DESCRIPTION
This adds the ApacheCon (or whatever ASF current event is next) icon on the top-right of the web pages, opposite of the Dragon logo.

Icon can be previewed here: https://www.apache.org/events/current-event-125x125.png 