### PR TITLE
[TRAFODION-2205] invalid char at create schema when authorization nam…

### DIFF
--- a/core/sql/cli/Cli.cpp
+++ b/core/sql/cli/Cli.cpp
@@ -6182,10 +6182,10 @@ Lng32 SQLCLI_GetDatabaseUserName (
   ContextCli &currContext = *(cliGlobals->currContext());
   ComDiagsArea &diags = currContext.diags();
 
-  retcode = currContext.getDBUserNameFromID(user_id,
-                                            string_value,
-                                            max_string_len,
-                                            len_of_item);
+  retcode = currContext.getAuthNameFromID(user_id,
+                                          string_value,
+                                          max_string_len,
+                                         *len_of_item);
 
   return CliEpilogue(cliGlobals, NULL, retcode);
 }
@@ -6206,8 +6206,8 @@ Lng32 SQLCLI_GetDatabaseUserID (
   ContextCli &currContext = *(cliGlobals->currContext());
   ComDiagsArea &diags = currContext.diags();
 
-  retcode = currContext.getDBUserIDFromName(string_value,
-                                            numeric_value);
+  retcode = currContext.getAuthIDFromName(string_value,
+                                          *numeric_value);
 
   return CliEpilogue(cliGlobals, NULL, retcode);
 }

--- a/core/sql/cli/Context.h
+++ b/core/sql/cli/Context.h
@@ -125,12 +125,6 @@ public:
      char *authNameBuffer, // OUT
      Int32 maxBufLen,      // IN
      Int32 &requiredLen);   // OUT optional
-  RETCODE getDBUserNameFromID(Int32 userID,         // IN
-                              char *userNameBuffer, // OUT
-                              Int32 maxBufLen,      // IN
-                              Int32 *requiredLen);  // OUT
-  RETCODE getDBUserIDFromName(const char *userName, // IN
-                              Int32 *userID);       // OUT
 
   // Function to be used only in ESPs to establish user identity. This
   // call will update data members and will NOT verify the input

--- a/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
@@ -8426,7 +8426,7 @@ NABoolean CmpSeabaseDDL::insertPrivMgrInfo(const Int64 objUID,
   Int32 lActualLen = 0;
   Int16 status = ComUser::getAuthNameFromAuthID( (Int32) schemaOwnerID 
                                                , (char *)&username
-                                               , MAX_USERNAME_LEN
+                                               , MAX_USERNAME_LEN+1
                                                , lActualLen );
   if (status != FEOK)
   {
@@ -8448,7 +8448,7 @@ std::string creatorGrantee;
       Int32 lActualLen = 0;
       Int16 status = ComUser::getAuthNameFromAuthID( (Int32) objOwnerID 
                                                    , (char *)&username
-                                                   , MAX_USERNAME_LEN
+                                                   , MAX_USERNAME_LEN+1
                                                    , lActualLen );
       if (status != FEOK)
       {
@@ -8468,7 +8468,7 @@ std::string creatorGrantee;
       Int32 lActualLen = 0;
       Int16 status = ComUser::getAuthNameFromAuthID( (Int32) creatorID 
                                                    , (char *)&username
-                                                   , MAX_USERNAME_LEN
+                                                   , MAX_USERNAME_LEN+1
                                                    , lActualLen );
       if (status != FEOK)
       {

--- a/core/sql/sqlcomp/CmpSeabaseDDLschema.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLschema.cpp
@@ -419,7 +419,7 @@ Int64 schemaUID = getObjectTypeandOwner(&cliInterface,
 char username[MAX_USERNAME_LEN+1];
 Int32 lActualLen = 0;
 Int16 status = ComUser::getAuthNameFromAuthID(objectOwner,username, 
-                                              MAX_USERNAME_LEN,lActualLen);
+                                              MAX_USERNAME_LEN+1,lActualLen);
    if (status != FEOK)
    {
       *CmpCommon::diags() << DgSqlCode(-20235) // Error converting user ID.

--- a/core/sql/sqlcomp/PrivMgrPrivileges.cpp
+++ b/core/sql/sqlcomp/PrivMgrPrivileges.cpp
@@ -2851,7 +2851,7 @@ short retcode = 0;
     char authName[MAX_USERNAME_LEN+1];
     Int32 actualLen = 0;
     retcode = ComUser::getAuthNameFromAuthID(objectOwner,authName,
-                                             MAX_USERNAME_LEN,actualLen);
+                                             MAX_USERNAME_LEN+1,actualLen);
     if (retcode != FEOK)
     {
       *pDiags_ << DgSqlCode(-20235)


### PR DESCRIPTION
…e is long

There is code that converts the user ID to its username.  The buffer size
requested was not big enough to hold the return value.  In addition, the buffer
size check was returning an error but did not add an error to the ComDiags area;
therefore the returned error was ignored.
- Changed max len in calls to getAuthNameFromAuthID to the correct size.
- Set up the Diags area when buffer size is too small so the error is reported
  correctly.

Also removed redundant methods:
-  getDBUserNameFromID - calls getAuthNameFromID instead
-  getDBUserIDFromName - calls GetAuthIDFromName instead