### PR TITLE
[TRAFODION-2249] Cannot use library management SPJs after an upgrade

### DIFF
--- a/core/sql/sqlcomp/CmpSeabaseDDLroutine.h
+++ b/core/sql/sqlcomp/CmpSeabaseDDLroutine.h
@@ -32,6 +32,9 @@
 //   perform initialize trafodion, upgrade library management
 // recommend that new procedures are added in alphabetic order
 
+// If adding a new library, be sure to update upgradeSeabaseLibmgr to
+// update jar/dll locations to the new version.
+
 // At this time there is no support to drop or change the signature of an
 // existing procedure.  Since customers may be using the procedures, it is
 // recommended that they not be dropped or changed - instead add new ones

--- a/install/python-installer/scripts/traf_start.py
+++ b/install/python-installer/scripts/traf_start.py
@@ -52,9 +52,17 @@ def run():
         if meta_current != "1":
             print 'Initialize trafodion, upgrade'
             run_cmd('echo "initialize trafodion, upgrade;" | sqlci > %s' % tmp_file)
+
+        # update system library procedures and functions
+        run_cmd('echo "initialize trafodion, upgrade library management;" | sqlci > %s' %tmp_file)
+        library_output = cmd_output('cat %s' % tmp_file)
+        if 'ERROR' in library_output:
+           err('Failed to initialize trafodion, upgrade library management:\n %s' % library_output)
+
     # other errors
     elif 'ERROR' in init_output:
         err('Failed to initialize trafodion:\n %s' % init_output)
+
 
     run_cmd('rm -rf %s' % tmp_file)
     if dbcfgs['ldap_security'] == 'Y':


### PR DESCRIPTION
Updated initialize trafodion, upgrade library management to modify the
jar/dll file locations for all system libraries to the new location.

Changed python installer to call ..., upgrade library management during
an upgrade operation