### PR TITLE
[TRAFODION-3021] union, intersect, except should be cacheable

### DIFF
--- a/core/sql/optimizer/RelExpr.cpp
+++ b/core/sql/optimizer/RelExpr.cpp
@@ -6688,7 +6688,7 @@ void Join::rewriteNotInPredicate( ValueIdSet & origVidSet, ValueIdSet & newVidSe
 Intersect::Intersect(RelExpr *leftChild,
 	     RelExpr *rightChild)
 : RelExpr(REL_INTERSECT, leftChild, rightChild)
-{ setNonCacheable(); }
+{ }
 
 Intersect::~Intersect() {}
 
@@ -6705,7 +6705,7 @@ const NAString Intersect::getText() const
 Except::Except(RelExpr *leftChild,
              RelExpr *rightChild)
 : RelExpr(REL_EXCEPT, leftChild, rightChild)
-{ setNonCacheable(); }
+{ }
 
 Except::~Except() {}
 

--- a/core/sql/optimizer/RelSet.h
+++ b/core/sql/optimizer/RelSet.h
@@ -176,7 +176,7 @@ public:
 	OperatorTypeEnum otype = REL_UNION,
 	CollHeap *outHeap = CmpCommon::statementHeap(),
     NABoolean sysGenerated = FALSE,
-    NABoolean mayBeCacheable = FALSE
+    NABoolean mayBeCacheable = TRUE
   );
 
   // copy ctor

--- a/core/sql/regress/core/EXPECTED005.SB
+++ b/core/sql/regress/core/EXPECTED005.SB
@@ -1492,7 +1492,7 @@ S   OPERATOR              LC  RC  TAB_NAME
 CONTEXT   NUM_LOOKUPS  NUM_CACHE_HITS  NUM_ENTRIES  MAX_CACHE_SIZE
 --------  -----------  --------------  -----------  --------------
 
-NONE              171             140           16        20971520
+NONE              173             142           16        20971520
 
 --- 1 row(s) selected.
 >>
@@ -1567,7 +1567,7 @@ NONE              171             140           16        20971520
 NUM_LOOKUPS  NUM_CACHE_HITS  NUM_ENTRIES  MAX_CACHE_SIZE
 -----------  --------------  -----------  --------------
 
-        176             141            0        20971520
+        178             143            0        20971520
 
 --- 1 row(s) selected.
 >>


### PR DESCRIPTION
Make UNION, INTERSECT, EXCEPT cacheable.