### PR TITLE
[TRAFODION-3009] Streamline error handling in Executor utility commands

### DIFF
--- a/core/sql/executor/ExExeUtilCli.cpp
+++ b/core/sql/executor/ExExeUtilCli.cpp
@@ -1094,7 +1094,7 @@ Lng32 ExeCliInterface::executeImmediate(const char * stmtStr,
   Lng32 retcode = 0;
 
   ComDiagsArea * tempDiags = NULL;
-  if (globalDiags != NULL && *globalDiags != NULL)
+  if (globalDiags != NULL && *globalDiags != NULL && (*globalDiags)->getNumber() > 0)
   {
      tempDiags = ComDiagsArea::allocate(heap_);
      tempDiags->mergeAfter(**globalDiags);
@@ -1119,7 +1119,7 @@ ExecuteImmediateReturn:
     {
       // Allocate the diagnostics area if needed
       // and populate the diagnostics conditions
-      if (*globalDiags == NULL && retcode != 0) {
+      if (*globalDiags == NULL && retcode != 0 && retcode != 100) {
          *globalDiags = ComDiagsArea::allocate(getHeap());
          SQL_EXEC_MergeDiagnostics_Internal(**globalDiags);
       }

--- a/core/sql/executor/ExHdfsScan.cpp
+++ b/core/sql/executor/ExHdfsScan.cpp
@@ -255,6 +255,8 @@ ExHdfsScanTcb::~ExHdfsScanTcb()
 
 void ExHdfsScanTcb::freeResources()
 {
+  if (hdfsScan_ != NULL)
+     hdfsScan_->stop();
   if (loggingFileName_ != NULL) {
      NADELETEBASIC(loggingFileName_, getHeap());
      loggingFileName_ = NULL;

--- a/core/sql/executor/ExHdfsScan.h
+++ b/core/sql/executor/ExHdfsScan.h
@@ -376,7 +376,7 @@ protected:
   int prevRangeNum_;
   int extraBytesRead_;
   NABoolean recordSkip_;
-  char *errBuf_;
+  int numFiles_;
 };
 
 class ExOrcScanTcb  : public ExHdfsScanTcb

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -3033,7 +3033,7 @@ XDDkwd__(SUBQUERY_UNNESTING,			"ON"),
   // Use large queues on RHS of Flow/Nested Join when appropriate
   DDkwd__(USE_LARGE_QUEUES,                     "ON"),
 
-  DDkwd__(USE_LIBHDFS_SCAN,                     "ON"),
+  DDkwd__(USE_LIBHDFS_SCAN,                     "OFF"),
 
   DDkwd__(USE_MAINTAIN_CONTROL_TABLE,          "OFF"),
 

--- a/core/sql/src/main/java/org/trafodion/sql/HDFSClient.java
+++ b/core/sql/src/main/java/org/trafodion/sql/HDFSClient.java
@@ -470,7 +470,7 @@ public class HDFSClient
    {
       if (future_ != null) {
          try {
-           future_.get(200, TimeUnit.MILLISECONDS);
+           future_.get(30, TimeUnit.SECONDS);
          } catch(TimeoutException e) {
             logger_.error("Asynchronous Thread of HdfsScan is Cancelled (timeout), ", e);
             future_.cancel(true);


### PR DESCRIPTION
Changes to avoid allocation of ComDiagsArea in some more places unless it is
needed to pass errors or warnings.

[TRAFODION-2917] Refactor Trafodion implementation of hdfs scan for text formatted hive tables

Disabling USE_LIBHDFS_SCAN by default. The new implementation of Hdfs Scan is now used to
scan the text type hive files.

Hdfs Scan is now stopped gracefully when the hive scan is cancelled. This avoids the random
core seen with new implementation.