### PR TITLE
[TRAFODION-3028] Support CONTROL QUERY SHAPE (CQS) for Hive insert

### DIFF
--- a/core/sql/common/ExprNode.cpp
+++ b/core/sql/common/ExprNode.cpp
@@ -737,6 +737,16 @@ NABoolean OperatorType::match(OperatorTypeEnum wildcard) const
 	      return FALSE;
 	    }
 
+        case REL_ANY_EXTRACT:
+	  switch (op_)
+	    {
+	    case REL_FAST_EXTRACT:
+	    case REL_HIVE_INSERT:
+	      return TRUE;
+	    default:
+	      return FALSE;
+	    }
+
 	case ANY_REL_OR_ITM_OP:
 	  ABORT("internal error in OperatorType::match()");
 
@@ -773,6 +783,7 @@ NABoolean OperatorType::isWildcard() const
     case REL_FORCE_ANY_SCAN:
     case REL_ANY_ROUTINE:
     case REL_ANY_SCALAR_UDF_ROUTINE:
+    case REL_ANY_EXTRACT:
       return TRUE;
 
     default:

--- a/core/sql/common/OperTypeEnum.h
+++ b/core/sql/common/OperTypeEnum.h
@@ -282,6 +282,7 @@ enum OperatorTypeEnum {
                         REL_FAST_EXTRACT,
 
                         REL_HIVE_INSERT,
+                        REL_ANY_EXTRACT,
                         REL_BULK_UNLOAD,
 
                         REL_COMMON_SUBEXPR_REF,

--- a/core/sql/generator/GenShape.cpp
+++ b/core/sql/generator/GenShape.cpp
@@ -124,6 +124,12 @@ short RelExpr::generateShape(CollHeap * c, char * buf, NAString * shapeStr)
      }
     break;
 
+   case REL_HIVE_INSERT:
+     {
+       sprintf(mybuf, "hive_insert(");
+     }
+    break;
+
    case REL_LEAF_TABLE_MAPPING_UDF:
    case REL_UNARY_TABLE_MAPPING_UDF:
    case REL_BINARY_TABLE_MAPPING_UDF:

--- a/core/sql/optimizer/ControlDB.cpp
+++ b/core/sql/optimizer/ControlDB.cpp
@@ -1790,6 +1790,16 @@ ExprNode *DecodeShapeSyntax(const NAString &fname,
       result = new (heap) MapValueIds(
 	   args->at(0)->castToRelExpr());
     }
+  else if (fname == "FAST_EXTRACT" ||
+           fname == "HIVE_INSERT")
+    {
+      if (badSingleArg(fname,args,diags))
+	return NULL;
+      result = new (heap) WildCardOp(
+	   REL_ANY_EXTRACT,
+	   0,
+	   args->at(0)->castToRelExpr());
+    }
   else if (fname == "SORT")
     {
       if (badSingleArg(fname,args,diags))

--- a/core/sql/optimizer/RelExpr.cpp
+++ b/core/sql/optimizer/RelExpr.cpp
@@ -2268,6 +2268,7 @@ Int32 WildCardOp::getArity() const
     case REL_ANY_GROUP:
     case REL_FORCE_EXCHANGE:
     case REL_ANY_UNARY_TABLE_MAPPING_UDF:
+    case REL_ANY_EXTRACT:
       return 1;
 
     case REL_ANY_BINARY_OP:
@@ -2345,6 +2346,8 @@ const NAString WildCardOp::getText() const
       return "REL_ANY_HASH_JOIN";
     case REL_ANY_MERGE_JOIN:
       return "REL_ANY_MERGE_JOIN";
+    case REL_ANY_EXTRACT:
+      return "REL_ANY_EXTRACT";
     case REL_FORCE_ANY_SCAN:
       return "REL_FORCE_ANY_SCAN";
     case REL_FORCE_EXCHANGE:

--- a/core/sql/parser/sqlparser.y
+++ b/core/sql/parser/sqlparser.y
@@ -21798,6 +21798,11 @@ query_shape_control : shape_identifier
 				    {
 				      $$ = new (PARSERHEAP()) WildCardOp(REL_ANY_LEAF_TABLE_MAPPING_UDF);
 				    }
+				  else if (*$1 == "FAST_EXTRACT" ||
+                                           *$1 == "HIVE_INSERT")
+				    {
+				      $$ = new (PARSERHEAP()) WildCardOp(REL_ANY_EXTRACT);
+				    }
 				  else if (*$1 == "FORWARD")
 				    {
 				      $$ = new (PARSERHEAP()) ScanForceWildCard();


### PR DESCRIPTION
Adding fast_extract() and hive_insert() CQS operator syntax to be able to force shapes of Hive insert statements.

Example:

control query shape hive_insert(cut);
explain insert into hive.hive.t values(1,1);

Note: I don't think this fix works for UNLOAD, since that seems to be
an "ExeUtil" statement that gets executed in two phases.