### PR TITLE
[TRAFODION-3009] Streamline error handling in Executor utility commands

### DIFF
--- a/core/sql/cli/Context.cpp
+++ b/core/sql/cli/Context.cpp
@@ -4768,5 +4768,4 @@ void ContextCli::disconnectHdfsConnections()
           hdfsDisconnect(entry->hdfsHandle_);         
         }
     }
-  
 }

--- a/core/sql/executor/ExExeUtil.h
+++ b/core/sql/executor/ExExeUtil.h
@@ -280,6 +280,7 @@ class ExExeUtilTcb : public ex_tcb
 
   short holdAndSetCQD(const char * defaultName, const char * defaultValue,
                       ComDiagsArea * globalDiags = NULL);
+
   short restoreCQD(const char * defaultName, ComDiagsArea * globalDiags = NULL);
 
   short setCS(const char * csName, char * csValue,
@@ -290,8 +291,9 @@ class ExExeUtilTcb : public ex_tcb
   void restoreMaintainControlTableTimeout(char * catalog);
 
   static Lng32 holdAndSetCQD(const char * defaultName, const char * defaultValue,
-                            ExeCliInterface * cliInterface,
-                            ComDiagsArea * globalDiags = NULL);
+                         ExeCliInterface * cliInterface,
+                         ComDiagsArea * globalDiags = NULL);
+
   static Lng32 restoreCQD(const char * defaultName,
                          ExeCliInterface * cliInterface,
                          ComDiagsArea * globalDiags = NULL);

--- a/core/sql/executor/ExExeUtilCli.cpp
+++ b/core/sql/executor/ExExeUtilCli.cpp
@@ -2211,6 +2211,7 @@ Lng32 ExeCliInterface::holdAndSetCQD(const char * defaultName, const char * defa
   return 0;
 }
 
+
 Lng32 ExeCliInterface::restoreCQD(const char * defaultName, ComDiagsArea *globalDiags)
 {
   Lng32 cliRC;
@@ -2243,6 +2244,7 @@ Lng32 ExeCliInterface::restoreCQD(const char * defaultName, ComDiagsArea *global
 Lng32 ExeCliInterface::getCQDval(const char * defaultName, 
 				 char * val,
 				 ComDiagsArea *globalDiags)
+
 {
   Lng32 cliRC;
 

--- a/core/sql/executor/ExExeUtilCli.h
+++ b/core/sql/executor/ExExeUtilCli.h
@@ -264,6 +264,7 @@ private:
   Lng32 GetRowsAffected(Int64 *rowsAffected);
 
   Lng32 holdAndSetCQD(const char * defaultName, const char * defaultValue, ComDiagsArea *globalDiags = NULL);
+
   Lng32 restoreCQD(const char * defaultName, ComDiagsArea *globalDiags = NULL);
 
   Lng32 getCQDval(const char * defaultName,

--- a/core/sql/executor/ExExeUtilCommon.cpp
+++ b/core/sql/executor/ExExeUtilCommon.cpp
@@ -1621,7 +1621,7 @@ Lng32 ExExeUtilTcb::extractParts
   if ((rc = extractedPartsObj_->extractParts(numParts, parts)) != 0 ||
       (numParts != 3))
     {
-      *getDiagsArea() << DgSqlCode(-CLI_INTERNAL_ERROR);
+      ExRaiseSqlError(getHeap(), &diagsArea_, -CLI_INTERNAL_ERROR);
       return -1;
     }
 

--- a/core/sql/executor/ExExeUtilExplain.cpp
+++ b/core/sql/executor/ExExeUtilExplain.cpp
@@ -399,8 +399,7 @@ short ExExeUtilDisplayExplainTcb::work()
 		// no rows found.
 		// Either no explain information was available or statement
 		// was not found.
-		ComDiagsArea * da = getDiagsArea();
-		ExRaiseSqlError(getMyHeap(), &da,
+		ExRaiseSqlError(getMyHeap(), &diagsArea_,
 				(((exeUtilTdb().getModuleName()) ||
 				  (exeUtilTdb().getStmtName())) ?
 				 (ExeErrorCode)CLI_STMT_NOT_EXISTS :
@@ -472,13 +471,11 @@ short ExExeUtilDisplayExplainTcb::work()
 	    if (rc != 0)	//means we got an EXE_EXPLAIN_BAD_DATA
 	      //or an error from getPtrAndLen()
 	      {
-		ComDiagsArea * da = getDiagsArea();
-		ExRaiseSqlError(getMyHeap(), &da,
+		ExRaiseSqlError(getMyHeap(), &diagsArea_,
 				(((exeUtilTdb().getModuleName()) ||
 				  (exeUtilTdb().getStmtName())) ?
 				 (ExeErrorCode)CLI_STMT_NOT_EXISTS :
 				 (ExeErrorCode)EXE_NO_EXPLAIN_INFO));
-
 		pstate.step_ = HANDLE_ERROR_;
 	      }
 	    else
@@ -3928,8 +3925,7 @@ short ExExeUtilDisplayExplainComplexTcb::work()
 		    // Return error.
 		    // Do not do 'DROP_AND_ERROR' as we don't want to drop
 		    // an existing table.
-		    ComDiagsArea * da = getDiagsArea();
-		    ExRaiseSqlError(getHeap(), &da,
+		    ExRaiseSqlError(getHeap(), &diagsArea_,
 				    EXE_NO_EXPLAIN_INFO, NULL);
 
 		    step_ = ERROR_;

--- a/core/sql/executor/ExExeUtilGet.cpp
+++ b/core/sql/executor/ExExeUtilGet.cpp
@@ -6116,11 +6116,11 @@ short ExExeUtilHiveMDaccessTcb::work()
                         (hcd ? hcd->type_ : hpd->type_),
                         (hcd ? hcd->name_ : hpd->name_),
                         hiveCat_, hiveSch_, htd->tblName_);
-		ExRaiseSqlError(getHeap(), &diagsArea_, CLI_GET_METADATA_INFO_ERROR,
+                ExRaiseSqlError(getHeap(), &diagsArea_, CLI_GET_METADATA_INFO_ERROR,
                       NULL, NULL, NULL,
                       strP);
-                step_ = ADVANCE_ROW_;
-                break;
+		step_ = ADVANCE_ROW_;
+		break;
 	      }
 	    
             infoCol->fsDatatype = fstype;

--- a/core/sql/executor/ExExeUtilLoad.cpp
+++ b/core/sql/executor/ExExeUtilLoad.cpp
@@ -2705,8 +2705,7 @@ short ExExeUtilLobExtractTcb::work()
 		      
 		      Lng32 intParam1 = 0;
 		      ExRaiseSqlError(getHeap(), &diagsArea_, 
-				      (ExeErrorCode)(8444), NULL, &intParam1, 
-				      &cliError, NULL, NULL);
+				      -8448, &intParam1, &cliError, NULL, NULL);
 		      step_ = HANDLE_ERROR_;
 		    }
 		}
@@ -2738,11 +2737,9 @@ short ExExeUtilLobExtractTcb::work()
 		  ex_queue_entry * up_entry = qparent_.up->getTailEntry();
 
 		  // invalid state, should not be reached.
-		  ComDiagsArea *diagsArea = up_entry->getDiagsArea();
 		  ExRaiseSqlError(getMyHeap(),
-				  &diagsArea,
+				  &diagsArea_,
 				  (ExeErrorCode)(EXE_INTERNAL_ERROR));
-                  setDiagsArea(diagsArea);
 		  step_ = CANCEL_;
 		}
 		break;
@@ -2895,12 +2892,9 @@ short ExExeUtilLobExtractTcb::work()
 	      else
 		{
 		  // invalid "toType"
-		  ex_queue_entry * up_entry = qparent_.up->getTailEntry();
-		  ComDiagsArea *diagsArea = up_entry->getDiagsArea();
 		  ExRaiseSqlError(getMyHeap(),
-				  &diagsArea,
+				  &diagsArea_,
 				  (ExeErrorCode)(EXE_INTERNAL_ERROR));
-                  setDiagsArea(diagsArea);
 		  step_ = CANCEL_;
 		
 		break;
@@ -3211,12 +3205,9 @@ short ExExeUtilLobExtractTcb::work()
 	    else
 	      {
 		// No other "toType" shoudl reach here - i.e TO_FILE_ or TO_STRING
-		ex_queue_entry * up_entry = qparent_.up->getTailEntry();
-		ComDiagsArea *diagsArea = up_entry->getDiagsArea();
 		ExRaiseSqlError(getMyHeap(),
-				&diagsArea,
+				&diagsArea_,
 				(ExeErrorCode)(EXE_INTERNAL_ERROR));
-                setDiagsArea(diagsArea);
 		step_ = CANCEL_;
 		
 		break;
@@ -3462,10 +3453,8 @@ short ExExeUtilLobUpdateTcb::work()
             else
 		{
 		  // invalid "fromType"
-		  ex_queue_entry * up_entry = qparent_.up->getTailEntry();
-		  ComDiagsArea * da = up_entry->getDiagsArea();
 		  ExRaiseSqlError(getMyHeap(),
-				  &da,
+				  &diagsArea_,
 				  (ExeErrorCode)(EXE_INTERNAL_ERROR));
 		  step_ = CANCEL_;
 		

--- a/core/sql/executor/HiveClient_JNI.h
+++ b/core/sql/executor/HiveClient_JNI.h
@@ -28,6 +28,7 @@
 #ifndef HIVE_CLIENT_H
 #define HIVE_CLIENT_H
 
+#include <list>
 #include "JavaObjectInterface.h"
 
 typedef enum {
@@ -40,6 +41,8 @@ typedef enum {
  ,HVC_ERROR_EXISTS_EXCEPTION
  ,HVC_ERROR_GET_HVT_PARAM
  ,HVC_ERROR_GET_HVT_EXCEPTION
+ ,HVC_ERROR_GET_HVP_PARAM
+ ,HVC_ERROR_GET_HVP_EXCEPTION
  ,HVC_ERROR_GET_REDEFTIME_PARAM
  ,HVC_ERROR_GET_REDEFTIME_EXCEPTION
  ,HVC_ERROR_GET_ALLSCH_EXCEPTION
@@ -53,7 +56,6 @@ typedef enum {
 class HiveClient_JNI : public JavaObjectInterface
 {
 public:
-  
   static HiveClient_JNI* getInstance();
   static void deleteInstance();
 
@@ -63,11 +65,13 @@ public:
   // Initialize JVM and all the JNI configuration.
   // Must be called.
   HVC_RetCode init();
-  
+
   HVC_RetCode close();
   static HVC_RetCode exists(const char* schName, const char* tabName);
   static HVC_RetCode getHiveTableStr(const char* schName, const char* tabName, 
                               Text& hiveTblStr);
+  static HVC_RetCode getHiveTableParameters(const char *schName, const char *tabName, 
+                              Text& hiveParamsStr);
   static HVC_RetCode getRedefTime(const char* schName, const char* tabName, 
                            Int64& redefTime);
   static HVC_RetCode getAllSchemas(NAHeap *heap, LIST(Text *)& schNames);
@@ -83,6 +87,7 @@ private:
   // Private Default constructor		
   HiveClient_JNI(NAHeap *heap)
   :  JavaObjectInterface(heap)
+  , isConnected_(FALSE)
   {}
 
 private:  
@@ -91,6 +96,7 @@ private:
    ,JM_CLOSE
    ,JM_EXISTS     
    ,JM_GET_HVT
+   ,JM_GET_HVP
    ,JM_GET_RDT
    ,JM_GET_ASH
    ,JM_GET_ATL
@@ -102,5 +108,6 @@ private:
   static bool javaMethodsInitialized_;
   // this mutex protects both JaveMethods_ and javaClass_ initialization
   static pthread_mutex_t javaMethodsInitMutex_;
+  bool isConnected_;
 };
 #endif

--- a/core/sql/exp/ExpHbaseInterface.cpp
+++ b/core/sql/exp/ExpHbaseInterface.cpp
@@ -1515,7 +1515,6 @@ NAArray<HbaseStr> * ExpHbaseInterface_JNI::getRegionStats(const HbaseStr& tblNam
   NAArray<HbaseStr>* regionStats = client_->getRegionStats((NAHeap *)heap_, tblName.val);
   if (regionStats == NULL)
     return NULL;
-
   return regionStats;
 }
 

--- a/core/sql/exp/ExpHbaseInterface.h
+++ b/core/sql/exp/ExpHbaseInterface.h
@@ -54,6 +54,7 @@
 
 #include "HBaseClient_JNI.h"
 #include "HiveClient_JNI.h"
+#include "HiveClient_JNI.h"
 
 #define INLINE_COLNAME_LEN 256
 

--- a/core/sql/sqlcomp/CmpSeabaseDDLauth.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLauth.cpp
@@ -2093,4 +2093,3 @@ CmpSeabaseDDLauth::AuthStatus authStatus = getAuthDetails(roleName,false);
     return true;
     
 }
-


### PR DESCRIPTION
ComDiagsArea is now allocated only when there are warnings or errors in
all the utility commands.

This requires all the executor utility commands to use a new version of
ExRaiseSqlError to populate diagnostics area.