### PR TITLE
[TRAFODION-3037] install_local_hadoop script out of date (APACHE)

### DIFF
--- a/core/sqf/sql/scripts/install_local_hadoop
+++ b/core/sqf/sql/scripts/install_local_hadoop
@@ -594,6 +594,7 @@ if [[ "$HBASE_DISTRO" = "HDP" ]]; then
     HADOOP_TAR=hadoop-2.7.1.2.3.2.0-2950.tar.gz
 fi
 if [[ "$HBASE_DISTRO" =~ "APACHE" ]]; then
+    HADOOP_MIRROR_URL=https://archive.apache.org/dist/hadoop/common/hadoop-2.6.0/
     HADOOP_TAR=hadoop-2.6.0.tar.gz
 fi
 
@@ -624,7 +625,7 @@ if [[ "$HBASE_DISTRO" = "HDP" ]]; then
     HBASE_TAR=hbase-${HBASE_DEP_VER_HDP}.tar.gz
 fi
 if [[ "$HBASE_DISTRO" =~ "APACHE" ]]; then
-    HBASE_MIRROR_URL=https://archive.apache.org/dist/hbase/hbase-${HBASE_DEP_VER_APACHE}
+    HBASE_MIRROR_URL=https://archive.apache.org/dist/hbase/${HBASE_DEP_VER_APACHE}
     HBASE_TAR=hbase-${HBASE_DEP_VER_APACHE}-bin.tar.gz
 fi
 


### PR DESCRIPTION
On a brandnew develop machine, if one set the HBASE_DISTRO=APACHE, install_local_hadoop cannot correctly download required tar files.
The download link changed.