### PR TITLE
[TRAFODION-2949] Improve LOB Extract/Update Performance 

### DIFF
--- a/core/sql/comexe/ComTdbExeUtil.cpp
+++ b/core/sql/comexe/ComTdbExeUtil.cpp
@@ -2485,6 +2485,7 @@ ComTdbExeUtilLobUpdate::ComTdbExeUtilLobUpdate
      Int32 lobStorageType,
      char * lobHdfsServer,
      Lng32 lobHdfsPort,
+     char *lobLoc,
      ex_expr * input_expr,
      ULng32 input_rowlen,
      ex_cri_desc * work_cri_desc,
@@ -2505,16 +2506,17 @@ ComTdbExeUtilLobUpdate::ComTdbExeUtilLobUpdate
                    given_cri_desc, returned_cri_desc,
                    down, up, 
                    num_buffers, buffer_size),
-     handle_(handle),
-     handleLen_(handleLen),
-     fromType_((short)fromType),
-     bufAddr_(bufAddr),
-     updateSize_(updateSize),
-     lobStorageType_(lobStorageType),
-     lobHdfsServer_(lobHdfsServer),
-     lobHdfsPort_(lobHdfsPort),
-     totalBufSize_(0),
-     flags_(0)
+    handle_(handle),
+    handleLen_(handleLen),
+    fromType_((short)fromType),
+    bufAddr_(bufAddr),
+    updateSize_(updateSize),
+    lobStorageType_(lobStorageType),
+    lobHdfsServer_(lobHdfsServer),
+    lobHdfsPort_(lobHdfsPort),
+    lobLoc_(lobLoc),
+    totalBufSize_(0),
+    flags_(0)
 {
   setNodeType(ComTdb::ex_LOB_UPDATE_UTIL);
 }
@@ -2524,6 +2526,8 @@ Long ComTdbExeUtilLobUpdate::pack(void * space)
     handle_.pack(space);
   if (lobHdfsServer_)
     lobHdfsServer_.pack(space);
+  if (lobLoc_)
+    lobLoc_.pack(space);
   return ComTdbExeUtil::pack(space);
 }
 Lng32 ComTdbExeUtilLobUpdate::unpack(void * base, void * reallocator)
@@ -2531,6 +2535,8 @@ Lng32 ComTdbExeUtilLobUpdate::unpack(void * base, void * reallocator)
   if (handle_.unpack(base))
     return -1;
   if (lobHdfsServer_.unpack(base))
+    return -1;
+  if(lobLoc_.unpack(base))
     return -1;
  return ComTdbExeUtil::unpack(base, reallocator);
 }

--- a/core/sql/comexe/ComTdbExeUtil.h
+++ b/core/sql/comexe/ComTdbExeUtil.h
@@ -2972,6 +2972,7 @@ public:
      Int32 lobStorageType,
      char * lobHdfsServer,
      Lng32 lobHdfsPort,
+     char *loc,
      ex_expr * input_expr,
      ULng32 input_rowlen,
      ex_cri_desc * work_cri_desc,
@@ -2990,6 +2991,7 @@ public:
   Lng32 getHandleLen() { return handleLen_; }
   char * getLobHdfsServer() { return lobHdfsServer_; }
   Lng32 getLobHdfsPort() { return lobHdfsPort_; }
+  char * getLobLocation() { return lobLoc_;}
 
   UpdateFromType getFromType() { return (UpdateFromType)fromType_; }
  
@@ -3053,6 +3055,7 @@ private:
   Lng32 lobStorageType_;
   Lng32 lobHdfsPort_;
   NABasicPtr lobHdfsServer_;
+  NABasicPtr lobLoc_;
   Int64 lobMaxSize_;
   Int64 lobMaxChunkSize_;
   Int64 lobGCLimit_;

--- a/core/sql/executor/ExExeUtilLoad.cpp
+++ b/core/sql/executor/ExExeUtilLoad.cpp
@@ -3012,37 +3012,9 @@ short ExExeUtilLobExtractTcb::work()
 
             //Retrieve the lobLocation for this lobNum which will be used 
             //in the other steps_ which open and read lob data file.
-            short *lobNumList = new (getHeap()) short[1];
-	    short *lobTypList = new (getHeap()) short[1];
-	    char  **lobLocList = new (getHeap()) char*[1];
-             char  **lobColNameList = new (getHeap()) char*[1];
-	    lobLocList[0] = new (getHeap()) char[1024];
-	    lobColNameList[0] = new (getHeap()) char[256];
-
-	    Lng32 numLobs = lobNum;
-	    Lng32 cliRC = SQL_EXEC_LOBddlInterface
-	      (
-	       schName,
-	       schNameLen,
-	       uid,
-	       numLobs,
-	       LOB_CLI_SELECT_UNIQUE,
-	       lobNumList,
-	       lobTypList,
-	       lobLocList,lobColNameList,lobTdb().getLobHdfsServer(),
-               lobTdb().getLobHdfsPort(),0,FALSE);
-	    if (cliRC < 0)
-	      {
-		getDiagsArea()->mergeAfter(diags);
-
-		step_ = HANDLE_ERROR_;
-		break;
-	      }
-
-	    strcpy(lobLoc_, lobLocList[0]);
-            NADELETEBASIC(lobColNameList[0],getHeap());
-            NADELETEBASIC(lobNumList,getHeap());
-            NADELETEBASIC(lobTypList,getHeap());
+           
+	    strcpy(lobLoc_, lobTdb().getStringParam2());
+           
             if (lobTdb().getToType() == ComTdbExeUtilLobExtract::RETRIEVE_HDFSFILENAME_)
 	      step_ = EXTRACT_HDFSFILENAME_;
             else if (lobTdb().getToType() == ComTdbExeUtilLobExtract::RETRIEVE_OFFSET_)
@@ -3653,38 +3625,9 @@ short ExExeUtilLobUpdateTcb::work()
 	    lobName_ = ExpLOBoper::ExpGetLOBname(uid, lobNum, lobNameBuf_, 1000);
 
 	    lobDataLen_ = lobTdb().totalBufSize_; 
-            short *lobNumList = new (getHeap()) short[1];
-	    short *lobTypList = new (getHeap()) short[1];
-	    char  **lobLocList = new (getHeap()) char*[1];
-            char  **lobColNameList = new (getHeap()) char*[1];
-	    lobLocList[0] = new (getHeap()) char[1024];
-	    lobColNameList[0] = new (getHeap()) char[256];
-          
-	    Lng32 numLobs = lobNum;
-	    Lng32 cliRC = SQL_EXEC_LOBddlInterface
-	      (
-	       schName,
-	       schNameLen,
-	       uid,
-	       numLobs,
-	       LOB_CLI_SELECT_UNIQUE,
-	       lobNumList,
-	       lobTypList,
-	       lobLocList,lobColNameList,lobTdb().getLobHdfsServer(),
-               lobTdb().getLobHdfsPort(),0,FALSE);
-	    if (cliRC < 0)
-	      {
-		getDiagsArea()->mergeAfter(diags);
-
-		step_ = HANDLE_ERROR_;
-		break;
-	      }
-
-	    strcpy(lobLoc_, lobLocList[0]);
-            NADELETEBASIC(lobLocList[0],getHeap());
-            NADELETEBASIC(lobColNameList[0],getHeap());
-            NADELETEBASIC(lobNumList,getHeap());
-            NADELETEBASIC(lobTypList,getHeap());
+           
+            strcpy(lobLoc_, lobTdb().getLobLocation());
+	    
             char outLobHandle[LOB_HANDLE_LEN];
             Int32 outHandleLen;
             Int64 requestTag = 0;
@@ -3748,38 +3691,8 @@ short ExExeUtilLobUpdateTcb::work()
 	    lobName_ = ExpLOBoper::ExpGetLOBname(uid, lobNum, lobNameBuf_, 1000);
 
 	    lobDataLen_ = lobTdb().totalBufSize_; 
-            short *lobNumList = new (getHeap()) short[1];
-	    short *lobTypList = new (getHeap()) short[1];
-	    char  **lobLocList = new (getHeap()) char*[1];
-            char  **lobColNameList = new (getHeap()) char*[1];
-	    lobLocList[0] = new (getHeap()) char[1024];
-            lobColNameList[0] = new (getHeap()) char[256];
-	    
-	    Lng32 numLobs = lobNum;
-	    Lng32 cliRC = SQL_EXEC_LOBddlInterface
-	      (
-	       schName,
-	       schNameLen,
-	       uid,
-	       numLobs,
-	       LOB_CLI_SELECT_UNIQUE,
-	       lobNumList,
-	       lobTypList,
-	       lobLocList,lobColNameList,lobTdb().getLobHdfsServer(),
-               lobTdb().getLobHdfsPort(),0,FALSE);
-	    if (cliRC < 0)
-	      {
-		getDiagsArea()->mergeAfter(diags);
-
-		step_ = HANDLE_ERROR_;
-		break;
-	      }
-
-	    strcpy(lobLoc_, lobLocList[0]);
-            NADELETEBASIC(lobLocList[0],getHeap());
-            NADELETEBASIC(lobColNameList[0],getHeap());
-            NADELETEBASIC(lobNumList,getHeap());
-            NADELETEBASIC(lobTypList,getHeap());
+            strcpy(lobLoc_, lobTdb().getLobLocation());
+           
             char outLobHandle[LOB_HANDLE_LEN];
             Int32 outHandleLen;
             Int64 requestTag = 0;
@@ -3844,37 +3757,8 @@ short ExExeUtilLobUpdateTcb::work()
 	    lobName_ = ExpLOBoper::ExpGetLOBname(uid, lobNum, lobNameBuf_, 1000);
 
 	    lobDataLen_ = lobTdb().totalBufSize_; 
-            short *lobNumList = new (getHeap()) short[1];
-	    short *lobTypList = new (getHeap()) short[1];
-	    char  **lobLocList = new (getHeap()) char*[1];
-            char  **lobColNameList = new (getHeap()) char*[1];
-	    lobLocList[0] = new (getHeap()) char[1024];
-	    lobColNameList[0] = new (getHeap()) char[256];
-	    Lng32 numLobs = lobNum;
-	    Lng32 cliRC = SQL_EXEC_LOBddlInterface
-	      (
-	       schName,
-	       schNameLen,
-	       uid,
-	       numLobs,
-	       LOB_CLI_SELECT_UNIQUE,
-	       lobNumList,
-	       lobTypList,
-	       lobLocList,lobColNameList,lobTdb().getLobHdfsServer(),
-               lobTdb().getLobHdfsPort(),0,FALSE);
-	    if (cliRC < 0)
-	      {
-		getDiagsArea()->mergeAfter(diags);
-
-		step_ = HANDLE_ERROR_;
-		break;
-	      }
-
-	    strcpy(lobLoc_, lobLocList[0]);
-            NADELETEBASIC(lobLocList[0],getHeap());
-            NADELETEBASIC(lobColNameList[0],getHeap());
-            NADELETEBASIC(lobNumList,getHeap());
-            NADELETEBASIC(lobTypList,getHeap());
+            strcpy(lobLoc_, lobTdb().getLobLocation());
+           
            
             char outLobHandle[LOB_HANDLE_LEN];
             Int32 outHandleLen;

--- a/core/sql/generator/GenRelExeUtil.cpp
+++ b/core/sql/generator/GenRelExeUtil.cpp
@@ -4074,31 +4074,23 @@ short ExeUtilLobExtract::codeGen(Generator * generator)
       strcpy(handle, h.data());
     }
 
-  // when handle is null and extract is from a file that is specified, then the params are:
-  //  stringParam1: file name
-  //  stringParam2: file dir
-  //  stringParam3: other info (like port num for hadoop)
+  // Use stringParam1 to pass in target file .
   char * stringParam1 = NULL;
   if (NOT stringParam_.isNull())
     {
-    stringParam1 =  space->allocateAlignedSpace(stringParam_.length() + 1);
-    strcpy(stringParam1, stringParam_.data());
+      stringParam1 = space->allocateAlignedSpace(stringParam_.length() + 1);
+      strcpy(stringParam1, stringParam_.data());
     }
 
   char * stringParam2 = NULL;
-  if (NOT stringParam2_.isNull())
-    {
-    stringParam2 = space->allocateAlignedSpace(stringParam2_.length() + 1);
-    strcpy(stringParam2, stringParam2_.data());
-    }
-  else if (handle_ == NULL)
-    {
-      const char* f = ActiveSchemaDB()->getDefaults().
-	getValue(LOB_STORAGE_FILE_DIR);
+  //use StringParam2 to pass in LOB storage dir  
+   const char* f = ActiveSchemaDB()->getDefaults().
+    getValue(LOB_STORAGE_FILE_DIR);
 
-      stringParam2 = space->allocateAlignedSpace(strlen(f) + 1);
-      strcpy(stringParam2, f);
-    }
+   stringParam2 = space->allocateAlignedSpace(strlen(f) + 1);
+   strcpy(stringParam2, f);
+    
+  
 
   char * stringParam3 = NULL;
   if (NOT stringParam3_.isNull())
@@ -4145,19 +4137,15 @@ short ExeUtilLobExtract::codeGen(Generator * generator)
 				   &input_expr);
     }
 
-  Lng32 lst = 0;
-  if (handle_ == NULL)
-    {
-      // extract from a file
-      lst = (Lng32)(CmpCommon::getDefaultNumeric(LOB_STORAGE_TYPE));
-    }
-
+  Lng32 lst = 0; 
+  lst = (Lng32)(CmpCommon::getDefaultNumeric(LOB_STORAGE_TYPE));
   Lng32 hdfsPort = (Lng32)CmpCommon::getDefaultNumeric(LOB_HDFS_PORT);
-  const char* f = ActiveSchemaDB()->getDefaults().
+  const char* hs = ActiveSchemaDB()->getDefaults().
     getValue(LOB_HDFS_SERVER);
-  char * hdfsServer = space->allocateAlignedSpace(strlen(f) + 1);
-  strcpy(hdfsServer, f);
+  char * hdfsServer = space->allocateAlignedSpace(strlen(hs) + 1);
+  strcpy(hdfsServer, hs);
   
+
   ComTdbExeUtilLobExtract * exe_util_tdb = new(space) 
     ComTdbExeUtilLobExtract
     (
@@ -4347,11 +4335,15 @@ short ExeUtilLobUpdate::codeGen(Generator * generator)
 
 
   Lng32 hdfsPort = (Lng32)CmpCommon::getDefaultNumeric(LOB_HDFS_PORT);
-  const char* f = ActiveSchemaDB()->getDefaults().
+  const char* hs = ActiveSchemaDB()->getDefaults().
     getValue(LOB_HDFS_SERVER);
-  char * hdfsServer = space->allocateAlignedSpace(strlen(f) + 1);
-  strcpy(hdfsServer, f);
-  
+  char * hdfsServer = space->allocateAlignedSpace(strlen(hs) + 1);
+  strcpy(hdfsServer, hs);
+  const char* f = ActiveSchemaDB()->getDefaults().
+    getValue(LOB_STORAGE_FILE_DIR);
+
+  char *lobLoc = space->allocateAlignedSpace(strlen(f) + 1);
+  strcpy(lobLoc, f);
   ComTdbExeUtilLobUpdate * exe_util_lobupdate_tdb = new(space) 
     ComTdbExeUtilLobUpdate
     (
@@ -4366,6 +4358,7 @@ short ExeUtilLobUpdate::codeGen(Generator * generator)
      lst,
      hdfsServer,
      hdfsPort,
+     lobLoc,
      input_expr,
      inputRowLen,
      workCriDesc,


### PR DESCRIPTION
Removing unneeded CLI call to get lob location and instead using the  CQD value - LOB_STORAGE_FILE_DIR to get/save it in Tdb for use later at runtime.