### PR TITLE
[TRAFODION-2953] initial implementation of small table in one Hbase Region

### DIFF
--- a/core/sql/comexe/ComTdb.h
+++ b/core/sql/comexe/ComTdb.h
@@ -821,6 +821,7 @@ class ComTdbVirtTableTableInfo  : public ComTdbVirtTableBase
   const char * allColFams;
   Int64 objectFlags;  // flags from OBJECTS table
   Int64 tablesFlags;  // flags from TABLES table
+  const char * superTable;
 };
 
 class ComTdbVirtTableColumnInfo : public ComTdbVirtTableBase

--- a/core/sql/common/ComSmallDefs.h
+++ b/core/sql/common/ComSmallDefs.h
@@ -685,7 +685,8 @@ enum ComTextType {COM_VIEW_TEXT = 0,
                   COM_STORED_DESC_TEXT = 7,
                   COM_VIEW_REF_COLS_TEXT = 8,
                   COM_OBJECT_COMMENT_TEXT = COM_TABLE_COMMENT_TEXT,
-                  COM_COLUMN_COMMENT_TEXT = 12
+                  COM_COLUMN_COMMENT_TEXT = 12 ,
+                  COM_SUPER_TABLE_TEXT = 13
 };
 
 enum ComColumnDirection { COM_UNKNOWN_DIRECTION

--- a/core/sql/common/OperTypeEnum.h
+++ b/core/sql/common/OperTypeEnum.h
@@ -1244,7 +1244,8 @@ enum OperatorTypeEnum {
                         // Unpublished attributes
                         ELM_FILE_ATTR_EXTENT_ELEM,
                         ELM_FILE_ATTR_MAXEXTENTS_ELEM,
-                        ELM_FILE_ATTR_UID_ELEM
+                        ELM_FILE_ATTR_UID_ELEM,
+                        ELM_FILE_ATTR_SUPER_TABLE_ELEM
                       };
 
 #endif // OPERTYPEENUM_H

--- a/core/sql/generator/GenRelScan.cpp
+++ b/core/sql/generator/GenRelScan.cpp
@@ -2438,6 +2438,7 @@ short HbaseAccess::codeGen(Generator * generator)
 
   NABoolean isAlignedFormat = getTableDesc()->getNATable()->isAlignedFormat(getIndexDesc());
   NABoolean isHbaseMapFormat = getTableDesc()->getNATable()->isHbaseMapTable();
+  NABoolean isSmallTable =  getTableDesc()->getNATable()->isSmallTable();
 
   // If CIF is not OFF use aligned format, except when table is
   // not aligned and it has added columns. Support for added columns
@@ -2481,7 +2482,14 @@ short HbaseAccess::codeGen(Generator * generator)
     {
       if (getIndexDesc() && getIndexDesc()->getNAFileSet())
       {
-         tablename = space->AllocateAndCopyToAlignedSpace(GenGetQualifiedName(getIndexDesc()->getNAFileSet()->getFileSetName()), 0);
+         if(getTableDesc()->getNATable()->isSmallTable())
+         {
+           NAString st("");
+           st = getTableDesc()->getNATable()->superTable() ;
+           tablename = space->AllocateAndCopyToAlignedSpace(st, 0);
+         }
+         else
+           tablename = space->AllocateAndCopyToAlignedSpace(GenGetQualifiedName(getIndexDesc()->getNAFileSet()->getFileSetName()), 0);
          if (getIndexDesc()->isClusteringIndex())
          {
             //base table
@@ -2495,9 +2503,15 @@ short HbaseAccess::codeGen(Generator * generator)
     }
 
   if (! tablename) 
-     tablename =
+  {
+     if(getTableDesc()->getNATable()->isSmallTable())
+       tablename = 
+        space->AllocateAndCopyToAlignedSpace( NAString(getTableDesc()->getNATable()->superTable()), 0);
+     else
+       tablename =
         space->AllocateAndCopyToAlignedSpace(
                                            GenGetQualifiedName(getTableName()), 0);
+  }
 
   ValueIdList columnList;
   if ((getTableDesc()->getNATable()->isSeabaseTable()) &&
@@ -3410,7 +3424,11 @@ short HbaseAccessCoProcAggr::codeGen(Generator * generator)
     }
   else
     {
-      tablename = 
+      if (getTableDesc()->getNATable()->isSmallTable())
+        tablename = 
+        space->AllocateAndCopyToAlignedSpace( NAString(getTableDesc()->getNATable()->superTable()), 0);
+      else
+        tablename = 
         space->AllocateAndCopyToAlignedSpace(
              GenGetQualifiedName(getTableName()), 0);
     }

--- a/core/sql/generator/GenRelUpdate.cpp
+++ b/core/sql/generator/GenRelUpdate.cpp
@@ -1175,7 +1175,9 @@ short HbaseDelete::codeGen(Generator * generator)
       (getTableName().getQualifiedNameObj().isHbaseMappedName()))
     {
       if (getIndexDesc() && getIndexDesc()->getNAFileSet())
-	tablename = space->AllocateAndCopyToAlignedSpace(GenGetQualifiedName(getIndexDesc()->getNAFileSet()->getFileSetName().getObjectName()), 0);
+      {
+          tablename = space->AllocateAndCopyToAlignedSpace(GenGetQualifiedName(getIndexDesc()->getNAFileSet()->getFileSetName().getObjectName()), 0);
+      }
     }
   else
     {
@@ -1184,9 +1186,14 @@ short HbaseDelete::codeGen(Generator * generator)
     }
 
   if (! tablename)
-    tablename = 
-      space->AllocateAndCopyToAlignedSpace(
+  {
+      tablename = 
+        space->AllocateAndCopyToAlignedSpace(
 					   GenGetQualifiedName(getTableName()), 0);
+  }
+
+  if(getTableDesc()->getNATable()->isSmallTable())
+      strcpy(tablename, NAString(getTableDesc()->getNATable()->superTable()) );
 
   NAString serverNAS = ActiveSchemaDB()->getDefaults().getValue(HBASE_SERVER);
   NAString zkPortNAS = ActiveSchemaDB()->getDefaults().getValue(HBASE_ZOOKEEPER_PORT);
@@ -2138,18 +2145,25 @@ short HbaseUpdate::codeGen(Generator * generator)
       (getTableDesc()->getNATable()->isHbaseCellTable()))
     {
       if (getIndexDesc() && getIndexDesc()->getNAFileSet())
-	tablename = space->AllocateAndCopyToAlignedSpace(GenGetQualifiedName(getIndexDesc()->getNAFileSet()->getFileSetName().getObjectName()), 0);
+      {
+  	  tablename = space->AllocateAndCopyToAlignedSpace(GenGetQualifiedName(getIndexDesc()->getNAFileSet()->getFileSetName().getObjectName()), 0);
+      }
     }
   else
     {
       if (getIndexDesc() && getIndexDesc()->getNAFileSet())
-	tablename = space->AllocateAndCopyToAlignedSpace(GenGetQualifiedName(getIndexDesc()->getNAFileSet()->getFileSetName()), 0);
+	  tablename = space->AllocateAndCopyToAlignedSpace(GenGetQualifiedName(getIndexDesc()->getNAFileSet()->getFileSetName()), 0);
     }
 
   if (! tablename)
+  {
     tablename = 
       space->AllocateAndCopyToAlignedSpace(
 					   GenGetQualifiedName(getTableName()), 0);
+  }
+
+  if(getTableDesc()->getNATable()->isSmallTable())
+      strcpy(tablename, NAString(getTableDesc()->getNATable()->superTable()) );
 
   NAString serverNAS = ActiveSchemaDB()->getDefaults().getValue(HBASE_SERVER);
   NAString zkPortNAS = ActiveSchemaDB()->getDefaults().getValue(HBASE_ZOOKEEPER_PORT);
@@ -2164,7 +2178,6 @@ short HbaseUpdate::codeGen(Generator * generator)
     hbpa->setCacheBlocks(TRUE);
   // estrowsaccessed is 0 for now, so cache size will be set to minimum
   generator->setHBaseNumCacheRows(getEstRowsAccessed().getValue(), hbpa) ;
-
 
   // create hdfsscan_tdb
   ComTdbHbaseAccess *hbasescan_tdb = new(space) 
@@ -2768,13 +2781,16 @@ short HbaseInsert::codeGen(Generator *generator)
       (getTableDesc()->getNATable()->isHbaseCellTable()) ||
       (getTableName().getQualifiedNameObj().isHbaseMappedName()))
     {
-      tablename = space->AllocateAndCopyToAlignedSpace(GenGetQualifiedName(getIndexDesc()->getIndexName().getObjectName()), 0);
+        tablename = space->AllocateAndCopyToAlignedSpace(GenGetQualifiedName(getIndexDesc()->getIndexName().getObjectName()), 0);
     }
   else
     {
-      tablename = space->AllocateAndCopyToAlignedSpace(
+        tablename = space->AllocateAndCopyToAlignedSpace(
 						       GenGetQualifiedName(getIndexDesc()->getIndexName()), 0);
     }
+
+  if(getTableDesc()->getNATable()->isSmallTable())
+      strcpy(tablename, NAString(getTableDesc()->getNATable()->superTable()) );
 
   NAString serverNAS = ActiveSchemaDB()->getDefaults().getValue(HBASE_SERVER);
   NAString zkPortNAS = ActiveSchemaDB()->getDefaults().getValue(HBASE_ZOOKEEPER_PORT);

--- a/core/sql/generator/Generator.cpp
+++ b/core/sql/generator/Generator.cpp
@@ -2001,6 +2001,15 @@ TrafDesc * Generator::createVirtualTableDesc
         new GENHEAP(space) char[strlen(tableInfo->allColFams)+1];
       strcpy(table_desc->tableDesc()->all_col_fams, tableInfo->allColFams);
     }
+  if (tableInfo)
+   if (tableInfo->superTable != NULL) 
+    {
+      table_desc->tableDesc()->superTable_=
+        new GENHEAP(space) char[strlen(tableInfo->superTable)+1];
+      strcpy(table_desc->tableDesc()->superTable_, tableInfo->superTable);
+
+       table_desc->tableDesc()->setSuperTable(tableInfo->superTable);
+    }
 
   table_desc->tableDesc()->objectFlags = (tableInfo ? tableInfo->objectFlags : 0);
   table_desc->tableDesc()->tablesFlags = (tableInfo ? tableInfo->tablesFlags : 0);

--- a/core/sql/optimizer/BindRI.cpp
+++ b/core/sql/optimizer/BindRI.cpp
@@ -416,6 +416,8 @@ static NABoolean isHiddenColumn(const char *colname)
   int len = strlen(colname);
   if(strcmp(colname , "_SALT_") ==0) 
     return TRUE;
+  if(strcmp(colname , "_TBLNM_") ==0) 
+    return TRUE;
   //check for DIVISION column
   //pattern _DIVISION_%d_
   //must longer than 12

--- a/core/sql/optimizer/NATable.cpp
+++ b/core/sql/optimizer/NATable.cpp
@@ -5170,6 +5170,18 @@ NABoolean NATable::fetchObjectUIDForNativeTable(const CorrName& corrName,
    if (table_desc->tableDesc()->default_col_fam)
      defaultColFam_ = table_desc->tableDesc()->default_col_fam;
 
+   if (table_desc->tableDesc()->hasSuperTable() )
+   {
+     if( table_desc->tableDesc()->superTable_ != NULL)
+     {
+     superTable_ = new(heap_) char[strlen(table_desc->tableDesc()->superTable_) + 1];
+     strcpy(superTable_,table_desc->tableDesc()->superTable_);
+     setHasSuperTable(TRUE);
+     }
+     else
+       printf("LMDBG: Oops!\n");
+   }
+
    if (table_desc->tableDesc()->all_col_fams)
      {
        // Space delimited col families.

--- a/core/sql/optimizer/NATable.h
+++ b/core/sql/optimizer/NATable.h
@@ -609,7 +609,12 @@ public:
     else
        return getSQLMXAlignedTable();
   }
-
+  
+  NABoolean isSmallTable() const
+  {
+    return hasSuperTable();
+  }
+ 
   NABoolean isAlignedFormat(const IndexDesc *indexDesc) const
   {
     NABoolean isAlignedFormat;
@@ -781,6 +786,16 @@ public:
   NABoolean isInternalRegistered() const
   {  return (flags_ & IS_INTERNAL_REGISTERED) != 0; }
  
+  void setHasSuperTable( NABoolean value )
+  {
+    value ? flags_ |= HAS_SUPER_TABLE: flags_ &= ~HAS_SUPER_TABLE;
+  }
+
+  NABoolean hasSuperTable() const
+  { 
+    return (flags_ & HAS_SUPER_TABLE) != 0; 
+  }
+
   const CheckConstraintList &getCheckConstraints() const
                                                 { return checkConstraints_; }
   const AbstractRIConstraintList &getUniqueConstraints() const
@@ -919,6 +934,8 @@ public:
   static NAArray<HbaseStr>* getRegionsBeginKey(const char* extHBaseName);
 
   NAString &defaultColFam() { return defaultColFam_; }
+  char *superTable() const { 
+                   return superTable_; }
   NAList<NAString> &allColFams() { return allColFams_; }
 
 private:
@@ -1007,7 +1024,8 @@ private:
     HIVE_EXT_KEY_ATTRS        = 0x04000000,
     IS_IMPLICIT_EXTERNAL_TABLE= 0x08000000,
     IS_REGISTERED             = 0x10000000,
-    IS_INTERNAL_REGISTERED    = 0x20000000
+    IS_INTERNAL_REGISTERED    = 0x20000000,
+    HAS_SUPER_TABLE          = 0x40000000
   };
     
   UInt32 flags_;
@@ -1232,6 +1250,9 @@ private:
   NAColumnArray newColumns_;
 
   NAString defaultColFam_;
+
+  char *superTable_;
+
   NAList<NAString> allColFams_;
 }; // class NATable
 

--- a/core/sql/optimizer/PartFunc.h
+++ b/core/sql/optimizer/PartFunc.h
@@ -820,6 +820,10 @@ protected:
        const char * pivHiName,
        ItemExpr   * partNumExpr = NULL,
        NABoolean    useHash2Split = FALSE);
+public:
+  void createSmallTableKeyPredicates(
+       const char * tblName,ItemExpr   * partNumExpr = NULL
+       );
 
 private:
 
@@ -959,6 +963,9 @@ public:
   virtual PartitioningFunction* copy() const;
 
   virtual void createPartitioningKeyPredicates();
+  virtual SearchKey * createSearchKey(const IndexDesc *indexDesc,
+                                               ValueIdSet availInputs,
+                                               ValueIdSet additionalPreds) const;
 
   // Replace the pivs, partitioning key predicates and partitioning 
   // expression with those passed in.

--- a/core/sql/parser/ElemDDLFileAttr.h
+++ b/core/sql/parser/ElemDDLFileAttr.h
@@ -174,6 +174,48 @@ private:
   
 }; // class ElemDDLFileAttrRowFormat
 
+class ElemDDLFileAttrSuperTable: public ElemDDLFileAttr
+{
+
+public:
+
+  ElemDDLFileAttrSuperTable(NAString &tblNm)
+       : ElemDDLFileAttr(ELM_FILE_ATTR_SUPER_TABLE_ELEM),
+         superTable_(tblNm)
+  {
+  }
+
+  // virtual destructor
+  virtual ~ElemDDLFileAttrSuperTable()
+  {
+  };
+
+  // cast
+  virtual ElemDDLFileAttrSuperTable* castToElemDDLFileAttrSuperTable()
+  {
+    return this;
+  }
+
+  // accessors
+  NAString &getSuperTable()
+  {
+    return superTable_;
+  }
+
+  // method for building text
+  virtual NAString getSyntax() const
+  {
+   return "";
+  }
+
+private:
+
+  NAString superTable_;
+
+}; // class ElemDDLFileAttrSuperTable
+
+
+
 class ElemDDLFileAttrColFam : public ElemDDLFileAttr
 {
 

--- a/core/sql/parser/ElemDDLNode.cpp
+++ b/core/sql/parser/ElemDDLNode.cpp
@@ -429,6 +429,12 @@ ElemDDLNode::castToElemDDLFileAttrColFam()
   return NULL;
 }
 
+ElemDDLFileAttrSuperTable*
+ElemDDLNode::castToElemDDLFileAttrSuperTable()
+{
+  return NULL;
+}
+
 //++ MV
 ElemDDLFileAttrRangeLog *
 ElemDDLNode::castToElemDDLFileAttrRangeLog()

--- a/core/sql/parser/ElemDDLNode.h
+++ b/core/sql/parser/ElemDDLNode.h
@@ -106,6 +106,7 @@ class ElemDDLFileAttrMaxExtents;
 class ElemDDLFileAttrUID;
 class ElemDDLFileAttrRowFormat;
 class ElemDDLFileAttrColFam;
+class ElemDDLFileAttrSuperTable;
 class ElemDDLFileAttrNoLabelUpdate;
 class ElemDDLFileAttrOwner;
 //++ MV
@@ -432,6 +433,7 @@ public:
   virtual ElemDDLFileAttrUID		* castToElemDDLFileAttrUID();
   virtual ElemDDLFileAttrRowFormat	* castToElemDDLFileAttrRowFormat();
   virtual ElemDDLFileAttrColFam	* castToElemDDLFileAttrColFam();
+  virtual ElemDDLFileAttrSuperTable* castToElemDDLFileAttrSuperTable();
   virtual ElemDDLFileAttrNoLabelUpdate  * castToElemDDLFileAttrNoLabelUpdate();
   virtual ElemDDLFileAttrOwner          * castToElemDDLFileAttrOwner();
 

--- a/core/sql/parser/ParDDLFileAttrs.cpp
+++ b/core/sql/parser/ParDDLFileAttrs.cpp
@@ -2039,6 +2039,8 @@ ParDDLFileAttrsCreateTable::resetAllIsSpecDataMembers()
 
   isColFamSpec_                     = FALSE;
 
+  isSuperTableSpec_                     = FALSE;
+
   // [ NO ] AUDITCOMPRESS
   //   inherits from class ParDDLFileAttrsCreateIndex
 
@@ -2230,7 +2232,14 @@ ParDDLFileAttrsCreateTable::setFileAttr(ElemDDLFileAttr * pFileAttr)
     *SqlParser_Diags << DgSqlCode(-3097);
     break;
 
-
+  case ELM_FILE_ATTR_SUPER_TABLE_ELEM:
+    if (isSuperTableSpec_)
+      *SqlParser_Diags << DgSqlCode(-3082);
+    ComASSERT(pFileAttr->castToElemDDLFileAttrSuperTable() NEQ NULL);
+    superTable_ = pFileAttr->castToElemDDLFileAttrSuperTable()->getSuperTable();
+    isSuperTableSpec_ = TRUE;
+    
+    break;
   default :
     NAAbort("ParDDLFileAttrs.C", __LINE__, "internal logic error");
     break;

--- a/core/sql/parser/ParDDLFileAttrsCreateTable.h
+++ b/core/sql/parser/ParDDLFileAttrsCreateTable.h
@@ -158,6 +158,10 @@ public:
 
   inline NAString getColFam() const;
 
+  inline NABoolean isSuperTableSpecified() const;
+
+  NAString getSuperTable() const;
+
   //
   // mutators
   //
@@ -245,6 +249,10 @@ private:
   // COLUMN FAMILY
   NABoolean       isColFamSpec_;
   NAString colFam_;
+
+  // SMALL TABLE
+  NABoolean isSuperTableSpec_;
+  NAString superTable_;
 
 //-- MV
 
@@ -423,6 +431,17 @@ ParDDLFileAttrsCreateTable::getCompressionType() const
 }
 //-- MV
 //----------------------------------------------------------------------------
+
+inline NABoolean
+ParDDLFileAttrsCreateTable::isSuperTableSpecified() const
+{
+  return isSuperTableSpec_;
+}
+
+inline NAString ParDDLFileAttrsCreateTable::getSuperTable() const
+{
+  return superTable_;
+}
 
 // is the Col Family phrase specified?
 inline NABoolean

--- a/core/sql/parser/ParKeyWords.cpp
+++ b/core/sql/parser/ParKeyWords.cpp
@@ -1067,6 +1067,7 @@ ParKeyWord ParKeyWords::keyWords_[] = {
   ParKeyWord("SUFFIX",             TOK_SUFFIX,       NONRESTOKEN_),
   ParKeyWord("SUM",                TOK_SUM,         ANS_|RESWORD_|MPWORD_),
   ParKeyWord("SUMMARY",            TOK_SUMMARY,     NONRESTOKEN_),
+  ParKeyWord("SUPER",              TOK_SUPER,       NONRESTOKEN_),
   ParKeyWord("SUSPEND",            TOK_SUSPEND,     NONRESTOKEN_),
   ParKeyWord("SYNONYM",            TOK_SYNONYM,     POTANS_|RESWORD_),
   ParKeyWord("SYNONYMS",           TOK_SYNONYMS,    NONRESTOKEN_),

--- a/core/sql/parser/StmtDDLDrop.cpp
+++ b/core/sql/parser/StmtDDLDrop.cpp
@@ -755,6 +755,7 @@ StmtDDLDropTable::StmtDDLDropTable(const QualifiedName & tableQualName,
 	  isCleanupSpec_(FALSE),
 	  isValidateSpec_(FALSE),
 	  pLogFile_(NULL),
+	  smallTable_(FALSE),
 	  dropIfExists_(FALSE)
 {
 }
@@ -776,6 +777,7 @@ StmtDDLDropTable::StmtDDLDropTable(const QualifiedName & tableQualName,
 	  isCleanupSpec_(cleanupSpec),
 	  isValidateSpec_(validateSpec),
 	  pLogFile_(pLogFile),
+	  smallTable_(FALSE),
 	  dropIfExists_(FALSE)
 {
 }

--- a/core/sql/parser/StmtDDLDropTable.h
+++ b/core/sql/parser/StmtDDLDropTable.h
@@ -96,6 +96,8 @@ public:
 
   const NABoolean dropIfExists() const { return dropIfExists_; }
 
+  const NABoolean isSmallTable() const { return smallTable_; }
+
   // for binding
   ExprNode * bindNode(BindWA *bindWAPtr);
 
@@ -108,6 +110,8 @@ public:
   inline void setTableType(ExtendedQualName::SpecialTableType tableType); // ++ MV
 
   void setDropIfExists(NABoolean v) { dropIfExists_ = v; }
+
+  void setSmallTable(NABoolean v) { smallTable_= v; }
 
 private:
   // the tablename specified by user in the drop stmt.
@@ -127,6 +131,8 @@ private:
 
   // drop only if table exists. Otherwise just return.
   NABoolean dropIfExists_;
+
+  NABoolean smallTable_;
 }; // class StmtDDLDropTable
 
 // -----------------------------------------------------------------------

--- a/core/sql/parser/sqlparser.y
+++ b/core/sql/parser/sqlparser.y
@@ -1038,6 +1038,7 @@ static void enableMakeQuotedStringISO88591Mechanism()
 %token <tokval> TOK_SHAPE
 %token <tokval> TOK_SHARE               /* Tandem extension non-reserved word */
 %token <tokval> TOK_SHARED              /* Tandem extension non-reserved word */
+%token <tokval> TOK_SUPER
 %token <tokval> TOK_SUSPEND
 %token <tokval> TOK_SHOW
 %token <tokval> TOK_SHOWCONTROL         /* Tandem extension     reserved word */
@@ -2641,6 +2642,7 @@ static void enableMakeQuotedStringISO88591Mechanism()
 %type <pElemDDL>  		file_attribute_icompress_clause
 %type <pElemDDL>  		file_attribute_list
 %type <pElemDDL>                file_attribute_compression_clause
+%type <pElemDDL>                file_attribute_super_table_clause
 %type <pElemDDL>  		file_attribute_extent_clause
 %type <pElemDDL>  		file_attribute_maxextent_clause
 %type <pElemDDL>  		file_attribute_uid_clause
@@ -26719,6 +26721,7 @@ file_attribute :        file_attribute_allocate_clause
                       | file_attribute_no_label_update_clause
                       | file_attribute_owner_clause
                       | file_attribute_default_col_fam
+                      | file_attribute_super_table_clause
 
 /* type pElemDDL */           
 file_attribute_allocate_clause : TOK_ALLOCATE unsigned_smallint
@@ -27107,6 +27110,20 @@ file_attribute_row_format_clause : TOK_ALIGNED TOK_FORMAT
                                   $$ = new (PARSERHEAP()) ElemDDLFileAttrRowFormat
 				    (ElemDDLFileAttrRowFormat::eHBASE);
 				}
+
+/* type pElemDDL */
+file_attribute_super_table_clause : TOK_SUPER TOK_TABLE TOK_SYSTEM
+                                  {
+                                  NAString defaultSuperTable("TRAFODION._SUPER_.SYSTEM");
+                                  $$ = new (PARSERHEAP()) ElemDDLFileAttrSuperTable
+                                   (defaultSuperTable);
+                                  }
+                                |   TOK_SUPER TOK_TABLE QUOTED_STRING
+                                  {
+				YYERROR;
+                                  $$ = new (PARSERHEAP()) ElemDDLFileAttrSuperTable
+                                   (*$3);
+                                  }
 
 /* type pElemDDL */
 file_attribute_default_col_fam : TOK_DEFAULT TOK_COLUMN TOK_FAMILY QUOTED_STRING
@@ -34357,6 +34374,7 @@ nonreserved_func_word:  TOK_ABS
 			//                      | TOK_UPSERT
                       | TOK_UNIQUE_ID
                       | TOK_UUID
+                      | TOK_SUPER
 		      | TOK_USERNAMEINTTOEXT
                       | TOK_VARIANCE
                       | TOK_WEEK

--- a/core/sql/regress/seabase/EXPECTED035
+++ b/core/sql/regress/seabase/EXPECTED035
@@ -1,0 +1,128 @@
+>>
+>>drop table if exists t035t1 cascade;
+
+--- SQL operation complete.
+>>drop table if exists t035t2 cascade;
+
+--- SQL operation complete.
+>>
+>>create table t035t1 (a int, b int, c int, d int not null) attribute super table system;
+
+--- SQL operation complete.
+>>create table t035t2 (a int, b int, c int, d int not null) attribute super table system;
+
+--- SQL operation complete.
+>>insert into t035t1 values (1,2,3,4),(2,3,4,5),(3,3,3,3),(3,3,4,5),(1,3,3,3),
++>   (6,6,6,6);
+
+--- 6 row(s) inserted.
+>>insert into t035t2 values (1,2,3,4),(2,3,4,5),(3,3,3,3),(3,3,4,5),(1,3,3,3),
++>   (6,6,null,6);
+
+--- 6 row(s) inserted.
+>>
+>>
+>>select * from t035t1 order by 1,2,3,4;
+
+A            B            C            D          
+-----------  -----------  -----------  -----------
+
+          1            2            3            4
+          1            3            3            3
+          2            3            4            5
+          3            3            3            3
+          3            3            4            5
+          6            6            6            6
+
+--- 6 row(s) selected.
+>>select * from t035t1 where b = 2;
+
+A            B            C            D          
+-----------  -----------  -----------  -----------
+
+          1            2            3            4
+
+--- 1 row(s) selected.
+>>update t035t1 set c = 3 ;
+
+--- 6 row(s) updated.
+>>update t035t1 set c = 0 where b =3;
+
+--- 4 row(s) updated.
+>>select * from t035t1;
+
+A            B            C            D          
+-----------  -----------  -----------  -----------
+
+          1            2            3            4
+          2            3            0            5
+          3            3            0            3
+          3            3            0            5
+          1            3            0            3
+          6            6            3            6
+
+--- 6 row(s) selected.
+>>select * from t035t2;
+
+A            B            C            D          
+-----------  -----------  -----------  -----------
+
+          1            2            3            4
+          2            3            4            5
+          3            3            3            3
+          3            3            4            5
+          1            3            3            3
+          6            6            ?            6
+
+--- 6 row(s) selected.
+>>delete from t035t1 where a > 2;
+
+--- 3 row(s) deleted.
+>>select * from t035t1;
+
+A            B            C            D          
+-----------  -----------  -----------  -----------
+
+          1            2            3            4
+          2            3            0            5
+          1            3            0            3
+
+--- 3 row(s) selected.
+>>select * from t035t2;
+
+A            B            C            D          
+-----------  -----------  -----------  -----------
+
+          1            2            3            4
+          2            3            4            5
+          3            3            3            3
+          3            3            4            5
+          1            3            3            3
+          6            6            ?            6
+
+--- 6 row(s) selected.
+>>delete from t035t2;
+
+--- 6 row(s) deleted.
+>>select * from t035t2;
+
+--- 0 row(s) selected.
+>>select * from t035t1;
+
+A            B            C            D          
+-----------  -----------  -----------  -----------
+
+          1            2            3            4
+          2            3            0            5
+          1            3            0            3
+
+--- 3 row(s) selected.
+>>
+>>drop table t035t1;
+
+--- SQL operation complete.
+>>drop table t035t2;
+
+--- SQL operation complete.
+>>
+>>log;

--- a/core/sql/regress/seabase/TEST035
+++ b/core/sql/regress/seabase/TEST035
@@ -1,0 +1,54 @@
+-- @@@ START COPYRIGHT @@@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+-- @@@ END COPYRIGHT @@@
+--
+
+-- Tests for Small Table Feature
+
+log LOG035 clear;
+
+drop table if exists t035t1 cascade;
+drop table if exists t035t2 cascade;
+
+create table t035t1 (a int, b int, c int, d int not null) attribute super table system;
+create table t035t2 (a int, b int, c int, d int not null) attribute super table system;
+insert into t035t1 values (1,2,3,4),(2,3,4,5),(3,3,3,3),(3,3,4,5),(1,3,3,3),
+   (6,6,6,6);
+insert into t035t2 values (1,2,3,4),(2,3,4,5),(3,3,3,3),(3,3,4,5),(1,3,3,3),
+   (6,6,null,6);
+
+   
+select * from t035t1 order by 1,2,3,4;
+select * from t035t1 where b = 2;
+update t035t1 set c = 3 ;
+update t035t1 set c = 0 where b =3;
+select * from t035t1;
+select * from t035t2;
+delete from t035t1 where a > 2;
+select * from t035t1;
+select * from t035t2;
+delete from t035t2;
+select * from t035t2;
+select * from t035t1;
+
+drop table t035t1;
+drop table t035t2;
+
+log;

--- a/core/sql/regress/tools/sbdefs
+++ b/core/sql/regress/tools/sbdefs
@@ -22,7 +22,7 @@
 -- defs included during seabase regr run
 
 #ifdef SEABASE_REGRESS
-cqd mode_seabase 'ON';
+--cqd mode_seabase 'ON';
 cqd seabase_volatile_tables 'ON';
 cqd hbase_async_drop_table 'OFF';
 cqd hbase_serialization 'ON';

--- a/core/sql/sqlcat/TrafDDLdesc.h
+++ b/core/sql/sqlcat/TrafDDLdesc.h
@@ -964,7 +964,8 @@ public:
       VOLATILE          = 0x0040,
       IN_MEM_OBJ        = 0x0080,
       DROPPABLE         = 0x0100,
-      INSERT_ONLY       = 0x0200
+      INSERT_ONLY       = 0x0200,
+      HAS_SUPER_TABLE   = 0x0400
     };
 
   void setSystemTableCode(NABoolean v) 
@@ -994,6 +995,19 @@ public:
   void setVolatileTable(NABoolean v) 
   {(v ? tableDescFlags |= VOLATILE : tableDescFlags &= ~VOLATILE); };
   NABoolean isVolatileTable() { return (tableDescFlags & VOLATILE) != 0; };
+
+  void setSuperTable(const char *v)
+  { 
+    if ( v = NULL )
+      tableDescFlags &= ~HAS_SUPER_TABLE;
+    else
+      tableDescFlags |= HAS_SUPER_TABLE;
+  }
+
+  NABoolean hasSuperTable() 
+  {
+    return (tableDescFlags & HAS_SUPER_TABLE) != 0  ; 
+  }
 
   void setInMemoryObject(NABoolean v) 
   {(v ? tableDescFlags |= IN_MEM_OBJ : tableDescFlags &= ~IN_MEM_OBJ); };
@@ -1068,6 +1082,8 @@ public:
   // for hbase's region keys
   DescStructPtr hbase_regionkey_desc;
   DescStructPtr sequence_generator_desc;
+
+  char * superTable_;
 
   char filler[32];
 };

--- a/core/sql/sqlcomp/CmpSeabaseDDL.h
+++ b/core/sql/sqlcomp/CmpSeabaseDDL.h
@@ -294,6 +294,13 @@ class CmpSeabaseDDL
                               ComObjectType & objectType,
                               Int32 & objectOwner);
                               
+  short getSuperTableText(ExeCliInterface *cliInterface,
+                    const char * catName,
+                    const char * schName,
+                    const char * objName,
+                    const char * inObjType,
+                    NAString& superTable) ;
+
   short getSaltText(ExeCliInterface *cliInterface,
                     const char * catName,
                     const char * schName,

--- a/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
@@ -3174,6 +3174,8 @@ short CmpSeabaseDDL::getColInfo(ElemDDLColDef * colNode,
               colFlags |= SEABASE_COLUMN_IS_DIVISION;
             else if (colName == ElemDDLSaltOptionsClause::getSaltSysColName())
               colFlags |= SEABASE_COLUMN_IS_SALT;
+           else if (colName == "_TBLNM_")
+              colFlags |= SEABASE_COLUMN_IS_TBLNM;
             else
               CMPASSERT(0);
           }
@@ -4138,6 +4140,79 @@ short CmpSeabaseDDL::getAllUsingViews(ExeCliInterface *cliInterface,
 }
 
 /* 
+Get the super table name
+Returns 0 for object does not have super table
+Returns 1 for object has super table returned in superTable
+Returns -1 for error, which for now is ignored as we have an alternate code path.
+ */
+
+short CmpSeabaseDDL::getSuperTableText(
+                                   ExeCliInterface *cliInterface,
+                                   const char * catName,
+                                   const char * schName,
+                                   const char * objName,
+                                   const char * inObjType,
+                                   NAString& superTable)
+{
+  Lng32 cliRC = 0;
+
+  NAString quotedSchName;
+  ToQuotedString(quotedSchName, NAString(schName), FALSE);
+  NAString quotedObjName;
+  ToQuotedString(quotedObjName, NAString(objName), FALSE);
+  Int64 objUID;
+  Lng32 colNum;
+  NAString defaultValue;
+
+  char buf[4000];
+  char *data;
+  Lng32 len;
+
+  // determine object UID 
+  str_sprintf(buf, "select object_uid  from %s.\"%s\".%s o where o.catalog_name = '%s' and o.schema_name = '%s' and o.object_name = '%s'  and o.object_type = '%s'  ",
+              getSystemCatalog(), SEABASE_MD_SCHEMA, SEABASE_OBJECTS,
+              catName, quotedSchName.data(), quotedObjName.data(),
+              inObjType
+              );
+
+  Queue * sQueue = NULL;
+  cliRC = cliInterface->fetchAllRows(sQueue, buf, 0, FALSE, FALSE, TRUE);
+  if (cliRC < 0)
+    {
+      cliInterface->retrieveSQLDiagnostics(CmpCommon::diags());
+      return -1;
+    }
+ 
+  // did not find row
+  if (sQueue->numEntries() == 0)
+    return 0;
+
+  sQueue->position();
+  OutputInfo * vi = (OutputInfo*)sQueue->getNext(); 
+  objUID = *(Int64 *)vi->get(0);
+
+  // this should be the normal case, salt text is stored in the TEXT table,
+  // not the default value
+  cliRC = getTextFromMD(cliInterface,
+                        objUID,
+                        COM_SUPER_TABLE_TEXT,
+                        0,
+                        superTable);
+  if (cliRC < 0)
+    {
+      cliInterface->retrieveSQLDiagnostics(CmpCommon::diags());
+      return -1;
+    }
+
+  if (superTable.isNull())
+    superTable= defaultValue;
+
+  CMPASSERT(!superTable.isNull());
+
+  return 1;
+}
+
+/* 
 Get the salt column text for a given table or index.
 Returns 0 for object does not have salt column
 Returns 1 for object has salt column and it is being returned in saltText
@@ -5047,6 +5122,15 @@ short CmpSeabaseDDL::updateSeabaseMDTable(
         {
           NAString nas(hbaseCreateOptions);
           if (updateTextTable(cliInterface, objUID, COM_HBASE_OPTIONS_TEXT, 0, nas))
+            {
+              return -1;
+            }
+        }
+
+      if (CmpSeabaseDDL::isMDflagsSet(tablesFlags, MD_TABLES_SUPER_TABLE_ATTRS))
+        {
+          NAString nas(tableInfo->superTable); 
+          if (updateTextTable(cliInterface, objUID, COM_SUPER_TABLE_TEXT , 0, nas))
             {
               return -1;
             }
@@ -6975,6 +7059,13 @@ short CmpSeabaseDDL::dropSeabaseObject(ExpHbaseInterface * ehi,
 
   ExeCliInterface cliInterface(STMTHEAP, 0, NULL,
    CmpCommon::context()->sqlSession()->getParentQid() );
+  
+  NAString superTable;
+  short hasSuperTable = getSuperTableText(&cliInterface, 
+                             tableName.getCatalogNamePartAsAnsiString().data(),
+                             tableName.getSchemaNamePartAsAnsiString().data(),
+                             tableName.getObjectNamePartAsAnsiString().data(),
+                             COM_BASE_TABLE_OBJECT_LIT,superTable);
 
   if (dropFromMD)
     {
@@ -7044,13 +7135,24 @@ short CmpSeabaseDDL::dropSeabaseObject(ExpHbaseInterface * ehi,
               return -1;
             }
         }
-      
+      if (hasSuperTable == 1) // this table is embedded in super table, so do a delete first
+        {
+          char buf[4000];
+          Lng32 cliRC = 0;
+          str_sprintf(buf, "DELETE FROM %s.%s.%s;", catalogNamePart.data(), schemaNamePart.data(),objectNamePart.data() );
+          cliRC = cliInterface.executeImmediate(buf);
+          if (cliRC < 0)
+          {
+            cliInterface.retrieveSQLDiagnostics(CmpCommon::diags());
+            return -1;
+          }
+        } 
       if (deleteFromSeabaseMDTable(&cliInterface, 
                                    catalogNamePart, schemaNamePart, objectNamePart, objType ))
         return -1;
     }
 
-  if (dropFromHbase)
+  if (dropFromHbase && hasSuperTable!=1)
     {
       if (objType != COM_VIEW_OBJECT)
         {
@@ -7294,6 +7396,22 @@ void CmpSeabaseDDL::initSeabaseMD(NABoolean ddlXns, NABoolean minimal)
     {
       ehi->truncate(tddlTable, TRUE, TRUE);
     }
+  // create default system super table
+  HbaseStr sysSuperTable;
+  const NAString sysSTNAS("TRAFODION._SUPER_.SYSTEM");
+  sysSuperTable.val = (char *)sysSTNAS.data();
+  sysSuperTable.len = sysSTNAS.length();
+
+  if (ehi->exists(sysSuperTable) == 0 ) //not exists
+  {
+    if (createHbaseTable(ehi, &sysSuperTable, SEABASE_DEFAULT_COL_FAMILY, NULL,
+                         0, 0, NULL,
+                         FALSE, ddlXns) == -1)
+    {
+      deallocEHI(ehi); 
+      return;
+    }
+  }
 
   // create hbase physical objects
   for (Lng32 i = 0; i < numTables; i++)

--- a/core/sql/sqlcomp/CmpSeabaseDDLmd.h
+++ b/core/sql/sqlcomp/CmpSeabaseDDLmd.h
@@ -126,7 +126,8 @@ enum SeabaseColumnsFlags {
   SEABASE_COLUMN_IS_SALT       = 0x0000000000000001, // don't rely on this quite yet,
                                                      // since some older tables
                                                      // don't have this flag set
-  SEABASE_COLUMN_IS_DIVISION   = 0x0000000000000002
+  SEABASE_COLUMN_IS_DIVISION   = 0x0000000000000002,
+  SEABASE_COLUMN_IS_TBLNM      = 0x0000000000000004
 };
 
 static const QString seabaseDefaultsDDL[] =
@@ -375,7 +376,8 @@ enum SeabaseTablesFlags
     MD_TABLES_RESERVED1            = 0x0001,
     MD_TABLES_RESERVED2            = 0x0002,
     MD_TABLES_HIVE_EXT_COL_ATTRS   = 0x0004,
-    MD_TABLES_HIVE_EXT_KEY_ATTRS   = 0x0008
+    MD_TABLES_HIVE_EXT_KEY_ATTRS   = 0x0008,
+    MD_TABLES_SUPER_TABLE_ATTRS    = 0x0040
   };
 
 static const QString seabaseTableConstraintsDDL[] =


### PR DESCRIPTION
This is the very first code drop for TRAFODION-2953, the major purpose is to get feedback to see if the design is OK and shall we continue with this effort or not.
Please check https://issues.apache.org/jira/browse/TRAFODION-2953, I attached a design document there.

This PR contains initial prototype of the design. It still has a major code-refactor to do, but I would like to hear from community first, before I spend more time on it, in case there are something fundamentally wrong.

The major code-refactor I mentioned above is for this prototype code is to add a new PartitionFunction, instead of modifying the SinglePartitionPartitioningFunction directly. I will inherit a new SinglePartitionWithSmallTablePartitioningFunction from SinglePartitionPartitioningFunction next.

One can check the TEST035 to get a demo of how it works.

There are many other tasks following this initial code drop. For example, index/alter/create-super-table etc.

The major idea to support this is to add a new SYSTEM column _TBLNM_, so in a single Region, rows belong to different tables can be distinguished. When doing IUDS, always add predicate _TBLNM_ = 'theNameOfTheTable' to filter out the correct rows. 

Please help to review and let me know your comments, many thanks. 

The requirement is strong. In some use cases, there must be many small tables.

