### PR TITLE
[TRAFODION-3043] Add missing binder check for DATE_PART function

### DIFF
--- a/core/sql/common/DTICommonType.cpp
+++ b/core/sql/common/DTICommonType.cpp
@@ -61,6 +61,18 @@ const char* DatetimeIntervalCommonType::getFieldName(rec_datetime_field field)
     return "SECOND";
   case REC_DATE_FRACTION_MP:
     return "FRACTION";
+  case REC_DATE_YEARQUARTER_EXTRACT:
+    return "YEARQUARTER";
+  case REC_DATE_YEARMONTH_EXTRACT:
+    return "YEARMONTH";
+  case REC_DATE_YEARWEEK_EXTRACT:
+    return "YEARWEEK";
+  case REC_DATE_YEARQUARTER_D_EXTRACT:
+    return "YEARQUARTERD";
+  case REC_DATE_YEARMONTH_D_EXTRACT:
+    return "YEARMONTHD";
+  case REC_DATE_YEARWEEK_D_EXTRACT:
+    return "YEARWEEKD";
   default:
     return NULL;
   }

--- a/core/sql/optimizer/SynthType.cpp
+++ b/core/sql/optimizer/SynthType.cpp
@@ -4429,6 +4429,14 @@ const NAType *Extract::synthesizeType()
         extractEndField = REC_DATE_DAY; // extracting week requires the day
       else
         extractEndField = REC_DATE_MONTH; // months/quarters need only the month
+
+      if (type == NA_INTERVAL_TYPE)  // YEARQUARTER etc. are not supported on intervals
+        {
+          *CmpCommon::diags() << DgSqlCode(-4037)
+            << DgString0(dti.getFieldName(getExtractField()))
+            << DgString1(dti.getTypeSQLname(TRUE /*terse*/));
+          return NULL;
+        }
     }
 
   if (dti.getStartField() > extractStartField ||


### PR DESCRIPTION
This change adds a check to Extract::synthesizeType (optimizer/SynthType.cpp) to raise a 4037 error if one attempts to perform DATE_PART on an Interval data type with an extract qualifier of YEARMONTH or YEARQUARTER.