### PR TITLE
Inaccurate conditions of judgment cause low efficiency

### DIFF
--- a/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/ctosqlconv.cpp
+++ b/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/ctosqlconv.cpp
@@ -354,8 +354,8 @@ unsigned long ODBC::ConvertCToSQL(SQLINTEGER	ODBCAppVersion,
 	if (errorMsg)
 		*errorMsg = '\0';
 	//if (targetPrecision < 19)
-	if( !(((SQLDataType == SQLTYPECODE_NUMERIC) && (targetPrecision > 18)) ||
-		((SQLDataType == SQLTYPECODE_NUMERIC_UNSIGNED) && (targetPrecision > 9))))
+    if(((SQLDataType == SQLTYPECODE_NUMERIC) && (targetPrecision <= 18)) ||
+       ((SQLDataType == SQLTYPECODE_NUMERIC_UNSIGNED) && (targetPrecision <= 9)))
 	getMaxNum(targetPrecision, targetScale, integralMax, decimalMax);
 
 	switch (ODBCDataType)

--- a/win-odbc64/odbcclient/drvr35/ctosqlconv.cpp
+++ b/win-odbc64/odbcclient/drvr35/ctosqlconv.cpp
@@ -277,8 +277,8 @@ unsigned long ODBC::ConvertCToSQL(SQLINTEGER	ODBCAppVersion,
 		*errorMsg = '\0';
 	
 	//if (targetPrecision < 19)
-	if( !(((SQLDataType == SQLTYPECODE_NUMERIC) && (targetPrecision > 18)) || 
-		((SQLDataType == SQLTYPECODE_NUMERIC_UNSIGNED) && (targetPrecision > 9))))
+    if (((SQLDataType == SQLTYPECODE_NUMERIC) && (targetPrecision <= 18)) ||
+        ((SQLDataType == SQLTYPECODE_NUMERIC_UNSIGNED) && (targetPrecision <= 9)))
 		getMaxNum(targetPrecision, targetScale, integralMax, decimalMax);
 
 	switch (ODBCDataType)


### PR DESCRIPTION
In ctosqlconv.cpp, the code below :

if( !(((SQLDataType == SQLTYPECODE_NUMERIC) && (targetPrecision > 18)) || 
((SQLDataType == SQLTYPECODE_NUMERIC_UNSIGNED) && (targetPrecision > 9))))

Only when the column is NUMERIC(19+,n), the code will skip.
It is only used for numeirc but now the other data type such as char will do the same process.