### PR TITLE
[TRAFODION-3050] Change default for CQD COMP_BOOL_158 to 'ON'

### DIFF
--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -629,7 +629,7 @@ SDDkwd__(CAT_ENABLE_QUERY_INVALIDATION, "ON"),
   DDkwd__(COMP_BOOL_154,      "OFF"),
   DDkwd__(COMP_BOOL_155,      "OFF"),
   DDkwd__(COMP_BOOL_156,      "ON"),  // Used by RTS to turn on RTS Stats collection for ROOT operators
-  DDkwd__(COMP_BOOL_158,      "OFF"),
+  DDkwd__(COMP_BOOL_158,      "ON"),  // ON --> allows equijoins on VARCHAR/VARCHAR and CHAR/VARCHAR to be rewritten as VEGPreds
   DDkwd__(COMP_BOOL_159,      "OFF"),
 
   DDkwd__(COMP_BOOL_160,      "OFF"),


### PR DESCRIPTION
This pull request changes the default for CQD COMP_BOOL_158 to 'ON'.

This causes equi-join predicates on VARCHAR/VARCHAR and CHAR/VARCHAR pairs of columns to be rewritten as VEGPreds, enabling transitive closure on them. It also makes the predicate available to the scan index elimination logic (Scan::addIndexInfo) so that certain queries that formerly did not make use of certain indexes will now consider them. This can lead to very efficient nested join plans in some cases.

There is a side effect to turning this CQD on, however. By allowing free use of VEGPreds for such equi-join predicates, the compiler may substitute references to one column with another, if the two columns compare as equal in a join predicate. 

This side effect is thought to be less undesirable at this time than getting bad query plans when such equi-join predicates are present.

Nevertheless, a separate JIRA, TRAFODION-3051, has been written to address this side effect. When that one is fixed, we will be able to have our cake and eat it too.