### PR TITLE
[TRAFODION-3052] Fix core in PCode evaluator

### DIFF
--- a/core/sql/optimizer/ItemExprList.cpp
+++ b/core/sql/optimizer/ItemExprList.cpp
@@ -222,6 +222,17 @@ void ItemExprList::unparse(NAString &result, PhaseEnum phase,
 //----------------------------------------------------------------------------
 void ItemExprList::print(FILE* ofd, const char* indent, const char* title) const
 {
+  if (entries() > 0)
+    {
+#pragma nowarn(1506)   // warning elimination
+      BUMP_INDENT(indent);
+#pragma warn(1506)  // warning elimination
+
+      NAString unparsed;
+
+      unparse(unparsed, DEFAULT_PHASE, EXPLAIN_FORMAT);
+      fprintf(ofd, "%s%s%s\n", NEW_INDENT, title, unparsed.data());
+    }
 } // ItemExprList::print()
 
 // To be called from the debugger.

--- a/core/sql/optimizer/NATable.cpp
+++ b/core/sql/optimizer/NATable.cpp
@@ -2299,10 +2299,10 @@ RangePartitionBoundaries * createRangePartitionBoundariesFromStats
          NAColumn* ncol = partColArray[c];
          const NAType* nt = ncol->getType();
          
-         if (rangePartBoundValues->getOperatorType() == ITM_ITEM_LIST ) 
-            val = (ItemExpr*) (*list) [c];
-          else
-            val = (ItemExpr*) (*list) [0];
+         val = (ItemExpr*) (*list) [c];
+
+         // make sure the value is the same type as the column
+         val = new(heap) Cast(val, nt->newCopy(heap));
 
          if (nt->isEncodingNeeded())
             encodeExpr = new(heap) CompEncode(val, !(partColArray.isAscending(c)));
@@ -2327,7 +2327,7 @@ RangePartitionBoundaries * createRangePartitionBoundariesFromStats
                                     (CmpCommon::diags()));
 
          totalEncodedKeyLength += encodedKeyLength;
-         totalEncodedKeyBuf += encodedKeyBuffer;
+         totalEncodedKeyBuf.append(encodedKeyBuffer, encodedKeyLength);
 
          if ( ok != 0 ) 
             return NULL;

--- a/core/sql/optimizer/OptPhysRelExpr.cpp
+++ b/core/sql/optimizer/OptPhysRelExpr.cpp
@@ -14839,7 +14839,7 @@ PhysicalProperty * FileScan::synthHbaseScanPhysicalProperty(
   Lng32 numESPs = 1;
   PartitioningFunction * ixDescPartFunc = NULL;
    
-  // Nothing we can do if the requirment is a single partition func
+  // Nothing we can do if the requirement is a single partition func
   if ( partReq && partReq->castToRequireExactlyOnePartition() ) {
     myPartFunc = new (CmpCommon::statementHeap())
               SinglePartitionPartitioningFunction();

--- a/core/sql/optimizer/PartFunc.cpp
+++ b/core/sql/optimizer/PartFunc.cpp
@@ -689,12 +689,12 @@ void PartitioningFunction::print(FILE* ofd, const char* indent,
   if (NOT partitionInputValues_.isEmpty())
     partitionInputValues_.print(ofd, NEW_INDENT,
 				"Partition Input Values");
-  if (NOT getPartitionInputValuesLayout().isEmpty())
-    getPartitionInputValuesLayout().print(ofd, NEW_INDENT,
-				"Partition Input Values Layout");
+  if (NOT partitionInputValuesLayout_.isEmpty())
+    partitionInputValuesLayout_.print(ofd, NEW_INDENT,
+                                      "Partition Input Values Layout");
 
   if (getPartitioningExpression()) {
-    NAString partExpr("Partitionin Expression\n",  CmpCommon::statementHeap());
+    NAString partExpr("Partitioning Expression\n",  CmpCommon::statementHeap());
 
     getPartitioningExpression()->
       unparse(partExpr, DEFAULT_PHASE, EXPLAIN_FORMAT);
@@ -3937,20 +3937,32 @@ void RangePartitionBoundaries::print(FILE* ofd, const char* indent,
 				     const char* title) const
 {
   BUMP_INDENT(indent);
-  char  btitle[50];
-  char* S = btitle;
-  Lng32 index;
+  char S[500];
+  int index;
 
   fprintf(ofd,"%s %s\n",NEW_INDENT,title);
   for (index = 0; index < partitionCount_; index++)
     {
       const ItemExprList* iel = boundaryValues_[index];
-      sprintf(S,"boundary[%d] :",index);
+      snprintf(S, sizeof(S), "boundary[%d]: ", index);
       if (iel)
 	iel->print(ofd, indent, S);
       else
 	fprintf(ofd,"%s %s is empty\n",NEW_INDENT,S);
     }
+  for (int index2 = 0; index2 < partitionCount_; index2++)
+    if (binaryBoundaryValues_.used(index2) &&
+        binaryBoundaryValues_[index2])
+      {
+        const char *binaryVal = binaryBoundaryValues_[index2];
+
+        fprintf(ofd, "binary boundary[%d]: 0x", // %#0*",
+                index2);
+
+        for (int b=0; b<encodedBoundaryKeyLength_; b++)
+          fprintf(ofd, "%02hhx", binaryVal[b]);
+        fprintf(ofd, "\n");
+      }
 
   fprintf(ofd,"%s %s (in binary form)\n",NEW_INDENT,title);
   Lng32 keyLen = getEncodedBoundaryKeyLength();
@@ -4936,6 +4948,30 @@ const NAString RangePartitioningFunction::getText() const
     }
 
     result += ")";
+    /* enable this for debugging of binary key problems
+    result += " binary (";
+    Lng32 encodedBoundaryKeyLength = partitionBoundaries_->getEncodedBoundaryKeyLength();
+    char hexDigits[4];
+
+    for (Int32 index2 = 0; index2 < partitionBoundaries_->getCountOfPartitions(); index2++)
+    {
+      const char * binaryVal = partitionBoundaries_->getBinaryBoundaryValue(index2);
+
+      if (binaryVal)
+        {
+          if (index2 > 0)
+            result += ", ";
+          result += "b(0x";
+          for (int b=0; b<encodedBoundaryKeyLength; b++)
+            {
+              snprintf(hexDigits, sizeof(hexDigits), "%02hhx", binaryVal[b]);
+              result += hexDigits;
+            }
+          result += ")";
+        }
+    }
+    result += ")";
+    end of code for binary keys */
   }
 
   return result;


### PR DESCRIPTION
This change adds a Cast node on top of the data value passed to CompEncode, insuring that it is the proper data type. This resolves an issue that was causing a compile-time core in the PCode evaluator. Also included is some debug code concerning range partitioning functions.

Thanks go to @zellerh for this code.