### PR TITLE
[TRAFODION-3054] update pom.xml.cdh for hbase-trx to build protobuf

### DIFF
--- a/core/sqf/src/seatrans/hbase-trx/pom.xml.cdh54
+++ b/core/sqf/src/seatrans/hbase-trx/pom.xml.cdh54
@@ -299,7 +299,7 @@ if we can combine these profiles somehow -->
           <plugin>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-maven-plugins</artifactId>
-            <-version>2.6.0</version>
+            <version>2.6.0</version>
             <executions>
               <execution>
                 <id>compile-protoc</id>

--- a/core/sqf/src/seatrans/hbase-trx/pom.xml.cdh54
+++ b/core/sqf/src/seatrans/hbase-trx/pom.xml.cdh54
@@ -299,6 +299,7 @@ if we can combine these profiles somehow -->
           <plugin>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-maven-plugins</artifactId>
+            <-version>2.6.0</version>
             <executions>
               <execution>
                 <id>compile-protoc</id>

--- a/core/sqf/src/seatrans/hbase-trx/pom.xml.cdh55
+++ b/core/sqf/src/seatrans/hbase-trx/pom.xml.cdh55
@@ -299,6 +299,7 @@ if we can combine these profiles somehow -->
           <plugin>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-maven-plugins</artifactId>
+            <version>2.6.0</version>
             <executions>
               <execution>
                 <id>compile-protoc</id>

--- a/core/sqf/src/seatrans/hbase-trx/pom.xml.cdh57
+++ b/core/sqf/src/seatrans/hbase-trx/pom.xml.cdh57
@@ -299,6 +299,7 @@ if we can combine these profiles somehow -->
           <plugin>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-maven-plugins</artifactId>
+            <version>2.6.0</version>
             <executions>
               <execution>
                 <id>compile-protoc</id>


### PR DESCRIPTION
The various pom.xml.cdh<version> file can be used as pom.xml for maven input, to build protobuf java output for hbase-trx.
As we want to modify the .proto to add a new coprocessor, we found that it failed with ERROR:

Caused by: java.lang.UnsupportedClassVersionError: org/apache/hadoop/maven/plugin/protoc/ProtocMojo : Unsupported major.minor version 52.0

And the plug-in information is 

[INFO] --- hadoop-maven-plugins:3.1.0:protoc (compile-protoc) @ hbase-trx-cdh5_4 ---

So the lasted Hadoop maven plugins for protoc is 3.1.0 which need JDK 1.8.

It also means the pom.xml.cdh<version> files should be updated to match the Hadoop-Maven-plugin version same as its hadoop version, instead of using latest version (without specifying the version tag)