### PR TITLE
[TRAFODION-3059] remove "mt_" column family

### DIFF
--- a/core/sql/src/main/java/org/trafodion/sql/HBaseClient.java
+++ b/core/sql/src/main/java/org/trafodion/sql/HBaseClient.java
@@ -219,13 +219,6 @@ public class HBaseClient {
                   colDesc.setMaxVersions(DtmConst.SSCC_MAX_VERSION);
                 desc.addFamily(colDesc);
             }
-            HColumnDescriptor metaColDesc = new HColumnDescriptor(DtmConst.TRANSACTION_META_FAMILY);
-            if (isMVCC)
-              metaColDesc.setMaxVersions(DtmConst.MVCC_MAX_DATA_VERSION);
-            else
-              metaColDesc.setMaxVersions(DtmConst.SSCC_MAX_DATA_VERSION);
-            metaColDesc.setInMemory(true);
-            desc.addFamily(metaColDesc);
             Admin admin = getConnection().getAdmin();
             admin.createTable(desc);
             admin.close();
@@ -523,13 +516,6 @@ public class HBaseClient {
                 desc.addFamily(colDesc);
             }
 
-            HColumnDescriptor metaColDesc = new HColumnDescriptor(DtmConst.TRANSACTION_META_FAMILY);
-            if (isMVCC)
-              metaColDesc.setMaxVersions(DtmConst.MVCC_MAX_DATA_VERSION);
-            else
-              metaColDesc.setMaxVersions(DtmConst.SSCC_MAX_DATA_VERSION);
-            metaColDesc.setInMemory(true);
-            desc.addFamily(metaColDesc);
             Admin admin = getConnection().getAdmin();
                if (beginEndKeys != null && beginEndKeys.length > 0)
                {


### PR DESCRIPTION
All Trafodion tables have a second column family named "mt_", which was originally designed for SSCC.
SSCC is not enabled now
SSCC plan to not use a new column family

So it is good to remove this extra, no use column family