### PR TITLE
[TRAFODION-3056] Change UPDATE STATISTICS to tolerate absence of RMS

### DIFF
--- a/core/sql/ustat/hs_cli.cpp
+++ b/core/sql/ustat/hs_cli.cpp
@@ -5754,6 +5754,7 @@ Lng32 printPlan(SQLSTMT_ID *stmt)
     SQLSTMT_ID* ppStmtId = ppCursor.getStmt();
     SQLDESC_ID* ppOutputDesc = ppCursor.getOutDesc();
     retcode = ppCursor.open();
+    HSFilterWarning(retcode);
     HSHandleError(retcode);
 
     printPlanHeader(LM);

--- a/core/sql/ustat/hs_globals.cpp
+++ b/core/sql/ustat/hs_globals.cpp
@@ -8530,6 +8530,7 @@ Lng32 HSGlobalsClass::groupListFromTable(HSColGroupStruct*& groupList,
                                       (void *)&colNum, (void *)&colCount
                                       );
           // Don't read any more (break out of loop) if fetch did not succeed.
+          HSFilterWarning(retcode);
           if (retcode)
             break;
           // If EXISTING keyword specified and REASON field is EMPTY, skip.
@@ -10457,6 +10458,7 @@ Lng32 HSGlobalsClass::DisplayHistograms(NAString& displayData, Space& space,
 
     // Go ahead to write information for intervals of this histogram if DETAIL
     // option was specified, else return now.
+    HSFilterWarning(retcode);  // clean up any warnings before possible return
     if (!(optFlags & DETAIL_OPT))
         return 0;
 
@@ -10582,6 +10584,8 @@ Lng32 HSGlobalsClass::DisplayHistograms(NAString& displayData, Space& space,
     }
     intData.close();
     displayData += "\n";
+
+    HSFilterWarning(retcode);  // filter out any warnings so HSErrorCatcher doesn't act up
 
     return 0;
 }

--- a/core/sql/ustat/hs_log.h
+++ b/core/sql/ustat/hs_log.h
@@ -175,6 +175,7 @@ void HSFuncLogError(Lng32 error, char *filename, Lng32 lineno);
               (retcode == 6007) || \
               (retcode == 4030) || \
               (retcode == 2053) || \
+              (retcode == 2024) || \
               (retcode == HS_WARNING)) \
             retcode = 0; \
         }


### PR DESCRIPTION
When RMS is absent, UPDATE STATISTICS either fails with an internal error 9200 or cores.

This set of changes adds code to UPDATE STATISTICS so that it will ignore any 2024 warnings returned by the Executor due to RMS being absent.