### PR TITLE
[TRAFODION-3061] eliminate building errors on CentOS7

### DIFF
--- a/core/sqf/src/trafconf/tcdbsqlite.cpp
+++ b/core/sqf/src/trafconf/tcdbsqlite.cpp
@@ -2142,7 +2142,6 @@ int CTcdbSqlite::GetSNodeData( int pnid
         }
     }
 
-    int  spnid;
     int  sparedpnid;
     int  spareCount = 0;
 
@@ -2165,7 +2164,6 @@ int CTcdbSqlite::GetSNodeData( int pnid
                 }
             }
 
-            spnid = sqlite3_column_int(prepStmt, 0);
             sparedpnid = sqlite3_column_int(prepStmt, 1);
             spareNodeConfig.spare_pnid[spareCount] = sparedpnid;
             spareCount++;

--- a/core/sqf/src/trafconf/tctrace.cpp
+++ b/core/sqf/src/trafconf/tctrace.cpp
@@ -60,7 +60,7 @@ CTrafConfigTrace::CTrafConfigTrace()
                 , traceFileFb_(0)
                 , traceFileBase_(NULL)
 {
-    numTraceAreas_ = sizeof(traceAreaList_)/sizeof(TraceArea_t);
+    numTraceAreas_ = (int)(sizeof(traceAreaList_)/sizeof(TraceArea_t));
 }
 
 const char *CTrafConfigTrace::GetEnvStr(const char *key)

--- a/core/sql/sqlcomp/CmpSeabaseDDLmd.h
+++ b/core/sql/sqlcomp/CmpSeabaseDDLmd.h
@@ -1699,7 +1699,7 @@ static const QString createTrafViewsViewQuery[] =
 
 static const QString createTrafObjectCommentViewQuery[] =
 {
-  {" create view %s.\"%s\"."TRAF_OBJECT_COMMENT_VIEW" as "},
+  {" create view %s.\"%s\"." TRAF_OBJECT_COMMENT_VIEW" as "},
   {" select O.catalog_name, O.schema_name, O.object_name, T.text as comment "},
   {"   from %s.\"%s\".\"%s\" as O, %s.\"%s\".\"%s\" as T "},
   {"  where O.object_uid = T.text_uid and T.text_type = %s "},
@@ -1709,7 +1709,7 @@ static const QString createTrafObjectCommentViewQuery[] =
 
 static const QString createTrafColumnCommentViewQuery[] =
 {
-  {" create view %s.\"%s\"."TRAF_COLUMN_COMMENT_VIEW" as "},
+  {" create view %s.\"%s\"." TRAF_COLUMN_COMMENT_VIEW" as "},
   {" select O.CATALOG_NAME, O.SCHEMA_NAME, O.OBJECT_NAME, C.COLUMN_NAME, T.TEXT as COMMENT "},
   {"   from %s.\"%s\".\"%s\" as O, %s.\"%s\".\"%s\" as C, %s.\"%s\".\"%s\" as T "},
   {"  where O.OBJECT_UID = C.OBJECT_UID and T.TEXT_UID = O.OBJECT_UID and T.TEXT_TYPE = %s and T.SUB_ID = C.COLUMN_NUMBER "},


### PR DESCRIPTION
There are some coding cannot be compiled using GCC in CentOS 7.
We need to continuously check and fix these issues until CentOS7 is supported and jenkins test established.