### PR TITLE
[TRAFODION-510] Internal error or core dump with set table timeout

### DIFF
--- a/core/sql/parser/sqlparser.y
+++ b/core/sql/parser/sqlparser.y
@@ -23397,12 +23397,20 @@ set_table_statement: TOK_SET TOK_TABLE set_table_name
                    {
 		     $$ = new (PARSERHEAP())   // a RESET 
 		       RelSetTimeout( *$3, NULL, $4, TRUE );
+                     *SqlParser_Diags << DgSqlCode(-4222)
+                                      << DgString0("SET TABLE TIMEOUT");
+                     yyerror("");
+                     YYABORT;
 		   }
                   |  TOK_SET TOK_TABLE set_table_name  // a timeout value
                      optional_stream TOK_TIMEOUT  timeout_value
                    {
 		     $$ = new (PARSERHEAP()) 
 		       RelSetTimeout( *$3, (ItemExpr *) $6 , $4);
+                     *SqlParser_Diags << DgSqlCode(-4222)
+                                      << DgString0("SET TABLE TIMEOUT");
+                     yyerror("");
+                     YYABORT;
 		   }
                      
 


### PR DESCRIPTION
Disable this syntax that is no longer supported, so that we don't
get a core dump in debug builds. This caused a core every time I
ran the core/TEST019 regression test on a debug build.