### PR TITLE
[TRAFODION-3066] Fix bug that causes 2053 warning on deeply nested subqueries

### DIFF
--- a/core/sql/optimizer/GroupAttr.h
+++ b/core/sql/optimizer/GroupAttr.h
@@ -812,8 +812,21 @@ private:
 
   // values used to avoid bushy join trees
   Int32          numBaseTables_;    // # of base tables involved in this subtree
-  Int32          numJoinedTables_;  // # of tables in join backbone
+  Int32          numJoinedTables_;  // # of tables in join backbone (see note below)
   Int32          numTMUDFs_;        // # of table-mapping UDFs in this subtree
+
+  // Note: For numJoinedTables_, we calculate this when we create the
+  // GroupAttributes for an expression for the first time. For most nodes
+  // this will be 1; for a Join node it will be more than 1 in general.
+  // Later, when we form Groups for a given expression, this initial value
+  // applies to the Group. Optimization will in general add more expressions
+  // to a given group. For example, a Group originally associated with a
+  // GroupByAgg node might get a Join expression if the GroupByOnJoinRule
+  // chooses to push a Group By below a Join. When this happens, though,
+  // we leave numJoinedTables_ as 1 in the GroupAttributes (see
+  // Join::synthLogProp), which will inhibit the LeftShiftJoinRule from
+  // firing on that Join. This is important, because we want the large
+  // scope rules to control what join orders are enumerated.
 
   // QSTUFF VV
   // --------------------------------------------------------------------

--- a/core/sql/optimizer/NormRelExpr.cpp
+++ b/core/sql/optimizer/NormRelExpr.cpp
@@ -2888,6 +2888,8 @@ RelExpr* Join::transformSemiJoin(NormWA& normWARef)
 				child(1)->castToRelExpr()) ;
 	newGrby->setGroupAttr(new (stmtHeap) 
 	  GroupAttributes(*(child(1)->getGroupAttr())));
+	// must reset numJoinedTables_; we might be copying GroupAttributes from a join
+	newGrby->getGroupAttr()->resetNumJoinedTables(1);
 	newGrby->getGroupAttr()->clearLogProperties();
 	  
 	newGrby->setGroupExpr(equiJoinCols1);


### PR DESCRIPTION
When a query has at least three levels of subquery, and when the subqueries are transformed from semi-joins to inner-joins, we may see an Optimizer assertion failure warning (2053) when preparing the query. This bug has been there for a long time but is more likely now due to the changes in https://github.com/apache/trafodion/pull/1530.

The problem is that when transforming a semi-join to an inner-join + group by, the new GroupByAgg node was getting its GroupAttributes as a copy of the child node. If the child node happened to also be a Join (as would happen with nested subqueries), the numJoinedTables_ field for the GroupByAgg's GroupAttributes would remain 2 or more. If during optimization, the GroupByOnJoinRule fired, pushing the GroupByAgg down, we end up with another Join expression in the same group. But having numJoinedTables_ being 2 or more in that Group would allow the LeftShiftJoinRule to fire, with the result that we might get multiple GroupBy criteria in the same join backbone. The Analysis.cpp module does not expect this expansion of the join back bone, and raises the assertion, which results in the 2053 warning.

The fix is that when Join::transformSemiJoin creates the new GroupByAgg node, it must reset numJoinedTables_ in its new GroupAttributes object to 1.