### PR TITLE
[TRAFODION-3015] retrieve a value from numeric type  get no result if…

### DIFF
--- a/core/sql/optimizer/BindItemExpr.cpp
+++ b/core/sql/optimizer/BindItemExpr.cpp
@@ -2258,6 +2258,13 @@ static ItemExpr * ItemExpr_handleIncompatibleComparison(
       srcOpIndex = 0;
       tgtOpIndex = 1;
       conversion = 1;
+      if(type2.getPrecision() > 18)
+      {
+        //*CmpCommon::diags() << DgSqlCode(-4041)<<DgString0()<<DgString1();
+        emitDyadicTypeSQLnameMsg(-4041, type1, type2);
+        bindWA->setErrStatus();
+        return NULL;  // error
+      }
     }
     else
     if ((type1.getTypeQualifier() == NA_NUMERIC_TYPE) &&
@@ -2267,6 +2274,13 @@ static ItemExpr * ItemExpr_handleIncompatibleComparison(
       srcOpIndex = 1;
       tgtOpIndex = 0;
       conversion = 1;
+      if(type1.getPrecision() > 18)
+      {
+        //*CmpCommon::diags() << DgSqlCode(-4041)<<DgString0()<<DgString1();
+        emitDyadicTypeSQLnameMsg(-4041, type1, type2);
+        bindWA->setErrStatus();
+        return NULL;  // error
+      }
     }
 
     //check for date to character literal comparison


### PR DESCRIPTION
… using xx='value'

When the column is defined as NUMERIC(19,0), underlying data type will use FLOAT to save the number. 
So an implicit cast will generate wrong result when user input is string literal.
For example:
create table t3015 (a1 NUMERIC(19,0) );
insert into t3015 values(27380468);
select * from t3015 where a1='27380468';

will have wrong output.

The fix is to report error, if the precision of NUMERIC is greater than 18, and try to cast STRING into it.
