### PR TITLE
[TRAFODION-3015] retrieve a value from numeric type get no result

### DIFF
--- a/core/sql/optimizer/BindItemExpr.cpp
+++ b/core/sql/optimizer/BindItemExpr.cpp
@@ -2249,11 +2249,17 @@ static ItemExpr * ItemExpr_handleIncompatibleComparison(
     //3. Comparing date to numeric
     //4. Comparing interval to numeric
     //6. Comparing date to char of form: DD-MON-YYYY
-
+    NAString LiteralNumeric("NUMERIC");
     //check for numeric to character comparison
     if ((type1.getTypeQualifier() == NA_CHARACTER_TYPE) &&
 	(type2.getTypeQualifier() == NA_NUMERIC_TYPE))
     {
+      if(type2.getPrecision() > 18 && type2.getTypeName()==LiteralNumeric)
+      {
+        emitDyadicTypeSQLnameMsg(-4041, type1, type2);
+        bindWA->setErrStatus();
+        return NULL;  // error
+      }
       // convert op1(char) to numeric type
       srcOpIndex = 0;
       tgtOpIndex = 1;
@@ -2263,6 +2269,12 @@ static ItemExpr * ItemExpr_handleIncompatibleComparison(
     if ((type1.getTypeQualifier() == NA_NUMERIC_TYPE) &&
         (type2.getTypeQualifier() == NA_CHARACTER_TYPE))
     {
+      if(type1.getPrecision() > 18 && type1.getTypeName()==LiteralNumeric)
+      {
+        emitDyadicTypeSQLnameMsg(-4041, type1, type2);
+        bindWA->setErrStatus();
+        return NULL;  // error
+      }
       // convert op2(character) to numeric type
       srcOpIndex = 1;
       tgtOpIndex = 0;


### PR DESCRIPTION
When the column is defined as NUMERIC(19,0), underlying data type will use FLOAT to save the number.
So an implicit cast will generate wrong result when user input is string literal.
For example:
create table t3015 (a1 NUMERIC(19,0) );
insert into t3015 values(27380468);
select * from t3015 where a1='27380468';

will have wrong output.

The fix is to report error, if the precision of NUMERIC is greater than 18, and try to cast STRING into it.