### PR TITLE
[TRAFODION-3015] query no result when comparing string with BIGNUM

### DIFF
--- a/core/sql/exp/exp_bignum.cpp
+++ b/core/sql/exp/exp_bignum.cpp
@@ -657,8 +657,15 @@ short BigNum::castFrom (Attributes * source,
       Lng32 scaleBy = getScale() + exponent;
       if (scaleBy < 0)
 	{
+          Int8 roundMe= 0;
 	  for (i = 0; i < -scaleBy; i++)
+	  {
+	    roundMe = ( mantissa %10 ) > 4? 1:0;
 	    mantissa /= 10;
+	  }
+
+	  if(roundMe == 1) //round it
+	    mantissa++;
 
 	  scaleBy = 0;
 	}
@@ -761,8 +768,15 @@ short BigNum::castFrom (Attributes * source,
       Lng32 scaleBy = getScale() + exponent;
       if (scaleBy < 0)
 	{
+	  Int8 roundMe = 0;
 	  for (i = 0; i < -scaleBy; i++)
+	  {
+	    roundMe = ( mantissa %10 ) > 4? 1:0;
 	    mantissa /= 10;
+	  }
+
+	  if(roundMe == 1)
+	    mantissa++;
 
 	  scaleBy = 0;
 	}

--- a/core/sql/regress/executor/EXPECTED016.SB
+++ b/core/sql/regress/executor/EXPECTED016.SB
@@ -30,7 +30,9 @@
 +>;
 
 --- SQL operation complete.
->>
+>>create table t3015 (a1 NUMERIC(19,0), a2 int);
+
+--- SQL operation complete.
 >>-- MVs not support on seabase
 >>#ifndef SEABASE_REGRESS
 >>create MVGroup MVG_016;
@@ -214,6 +216,9 @@ CREATE TABLE TRAFODION.SCH.T016T2
 
 --- 1 row(s) inserted.
 >>insert into t016t2 values (11, 22, null);
+
+--- 1 row(s) inserted.
+>>insert into t3015 values(27380468,27380468);
 
 --- 1 row(s) inserted.
 >>
@@ -869,11 +874,22 @@ C1                     C2
 >>select * from t016_2535_3 where (c1,c2) <= (1234567.3, 0);
 
 --- 0 row(s) selected.
->>
+>>--JIRA TRAFODION-3015
+>>select * from t3015 where a1='27380468';
+
+A1 A2
+----------
+
+ 27380468 27380468
+
+--- 1 row(s) selected.
 >>drop table t016_2535_2;
 
 --- SQL operation complete.
 >>drop table t016_2535_3;
+
+--- SQL operation complete.
+>>drop table t3015;
 
 --- SQL operation complete.
 >>

--- a/core/sql/regress/executor/TEST016
+++ b/core/sql/regress/executor/TEST016
@@ -80,7 +80,7 @@ hash partition by (a,b)
 #ifNT
 attribute all mvs allowed
 ;
-
+create table t3015 (a1 NUMERIC(19,0), a2 int);
 -- MVs not support on seabase
 #ifndef SEABASE_REGRESS
 create MVGroup MVG_016;
@@ -151,6 +151,7 @@ insert into t016t2 values (2234567890123456789012345.123456789012, 1234567890123
 insert into t016t2 values (-1234567890123456789012345.123456789012, 22345678901234567890, .000000000000000000001);
 insert into t016t2 values (10, 20, .30);
 insert into t016t2 values (11, 22, null);
+insert into t3015 values(27380468,27380468);
 
 select * from t016t2;
 
@@ -313,9 +314,11 @@ select * from t016_2535_3 where (c1,c2) > (1234568.3, 2);
 select * from t016_2535_3 where (c1,c2) < (1234568.3, 2);
 select * from t016_2535_3 where (c1,c2) <= (1234568.3, 2);
 select * from t016_2535_3 where (c1,c2) <= (1234567.3, 0);
-
+--JIRA TRAFODION-3015
+select * from t3015 where a1='27380468';
 drop table t016_2535_2;
 drop table t016_2535_3;
+drop table t3015;
 
 log;
 


### PR DESCRIPTION
When the column is BIGNUM, and the predicate is comparing to a string. Trafodion cast the string into FLOAT and the convert FLOAT into BIGNUM, 
There is an issue when convert FLOAT into BIGNUM that didn't considering the rounding:

so 2.73804679999999968E+007 will become 27380467 instead of 27380468