### PR TITLE
[TRAFODION-3083] Fix compile problem on CentOS7

### DIFF
--- a/core/sqf/src/trafconf/Makefile
+++ b/core/sqf/src/trafconf/Makefile
@@ -46,6 +46,9 @@ LIBSX	+= -lrt
 # need -lsqlite3 for SQLite
 LIBSX	+=  -lsqlite3
 
+# need -lpthread starting on CentOS7
+LIBSX	+=  -lpthread  
+
 PROGS		= $(TRAFCONF)
 
 OBJTRAFCONFIG		= $(OUTDIR)/trafconfig.o \


### PR DESCRIPTION
Add -lpthread to list of libraries used for link.