### PR TITLE
[TRAFODION-3085] Add Examples for *CONTROL QUERY DEFAULT Statement* in *Trafodion SQL Reference Manual*

### DIFF
--- a/docs/sql_reference/src/asciidoc/_chapters/sql_statements.adoc
+++ b/docs/sql_reference/src/asciidoc/_chapters/sql_statements.adoc
@@ -1492,8 +1492,8 @@ SQL>CONTROL QUERY DEFAULT PARALLEL_NUM_ESPS '2';
 --- SQL operation complete.
 ```
 
-* This example resets the `PARALLEL_NUM_ESPS` attribute to its system value in the current process, 
-in this case, the compiler calculates the number of ESPs to be used.
+* This example resets the `PARALLEL_NUM_ESPS` attribute to its system value in the current process.
+In this case, the compiler calculates the number of ESPs to be used.
 +
 ```
 SQL>CONTROL QUERY DEFAULT PARALLEL_NUM_ESPS 'system';

--- a/docs/sql_reference/src/asciidoc/_chapters/sql_statements.adoc
+++ b/docs/sql_reference/src/asciidoc/_chapters/sql_statements.adoc
@@ -1484,16 +1484,21 @@ EXECUTE y;                              -- uses MYSCHEMA;
 [[control_query_default_examples]]
 === Examples of CONTROL QUERY DEFAULT
 
-* Increase the cache refresh time for the histogram cache to two hours (7,200 minutes).
+* This example changes the maximum degree of parallelism to 2 for a query. The value must be less than the number of CPUs in the cluster.
 +
 ```
-CONTROL QUERY DEFAULT CACHE_HISTOGRAMS_REFRESH_INTERVAL '7200';
+SQL>CONTROL QUERY DEFAULT PARALLEL_NUM_ESPS '2';
+
+--- SQL operation complete.
 ```
 
-* Reset the CACHE_HISTOGRAMS_REFRESH_INTERVAL attribute to its initial value in the current process:
+* This example resets the `PARALLEL_NUM_ESPS` attribute to its system value in the current process, 
+in this case, the compiler calculates the number of ESPs to be used.
 +
 ```
-CONTROL QUERY DEFAULT CACHE_HISTOGRAMS_REFRESH_INTERVAL RESET;
+SQL>CONTROL QUERY DEFAULT PARALLEL_NUM_ESPS 'system';
+
+--- SQL operation complete.
 ```
 
 <<<

--- a/docs/sql_reference/src/asciidoc/_chapters/sql_statements.adoc
+++ b/docs/sql_reference/src/asciidoc/_chapters/sql_statements.adoc
@@ -1491,12 +1491,20 @@ SQL>CONTROL QUERY DEFAULT PARALLEL_NUM_ESPS '2';
 
 --- SQL operation complete.
 ```
-
-* This example resets the `PARALLEL_NUM_ESPS` attribute to its system value in the current process.
++
+This example resets the `PARALLEL_NUM_ESPS` attribute to its system value in the current process.
 In this case, the compiler calculates the number of ESPs to be used.
 +
 ```
 SQL>CONTROL QUERY DEFAULT PARALLEL_NUM_ESPS 'system';
+
+--- SQL operation complete.
+```
+
+* This example allows the optimizer to generate an execution using hash join.
++
+```
+SQL>CONTROL QUERY DEFAULT HASH_JOIN 'ON';
 
 --- SQL operation complete.
 ```
@@ -6461,7 +6469,7 @@ The ON predicate must select a unique row if the MERGE has a _when-not-matched-c
 === Considerations for MERGE
 
 [[merge_upsert_using_single_row]]
-=== Upsert Using Single Row
+==== Upsert Using Single Row
 
 A MERGE statement allows you to specify a set of column values that should be updated if the row is found, and another 
 row to be inserted if the row is not found. The ON predicate must select exactly one row that is to be updated if the 


### PR DESCRIPTION
The CQD `CACHE_HISTOGRAMS_REFRESH_INTERVAL` has been removed.