### PR TITLE
[TRAFODION-2901] Self-reference Holloween problem fix

### DIFF
--- a/core/sql/optimizer/RelExpr.cpp
+++ b/core/sql/optimizer/RelExpr.cpp
@@ -13342,7 +13342,9 @@ void GenericUpdate::pushdownCoveredExpr(const ValueIdSet &outputExpr,
 				predicatesOnParent,
 				&localExprs);
 
-  if (avoidHalloween() && child(0) && child(0)->getGroupAttr())
+  if (avoidHalloween() && child(0) &&
+      child(0)->getOperatorType() == REL_SCAN &&
+      child(0)->getGroupAttr())
     {
       ValueIdSet cur_output = child(0)->getGroupAttr()->getCharacteristicOutputs();
       if (cur_output.isEmpty())

--- a/core/sql/optimizer/RelExpr.cpp
+++ b/core/sql/optimizer/RelExpr.cpp
@@ -13331,10 +13331,6 @@ void GenericUpdate::pushdownCoveredExpr(const ValueIdSet &outputExpr,
     localExprs += *setOfValuesReqdByParent ;
   localExprs += exprsInDerivedClasses_;
 
-  ValueIdSet original_output;
-  if (avoidHalloween() && child(0) && child(0)->getGroupAttr())
-    original_output = child(0)->getGroupAttr()->getCharacteristicOutputs();
-
   // ---------------------------------------------------------------------
   // Check which expressions can be evaluated by my child.
   // Modify the Group Attributes of those children who inherit some of
@@ -13354,9 +13350,10 @@ void GenericUpdate::pushdownCoveredExpr(const ValueIdSet &outputExpr,
           ValueId exprId;
           ValueId atLeastOne;
 
-          for (exprId = original_output.init();
-               original_output.next(exprId);
-               original_output.advance(exprId))
+          ValueIdSet output_source = child(0)->getTableDescForExpr()->getColumnList();
+          for (exprId = output_source.init();
+               output_source.next(exprId);
+               output_source.advance(exprId))
             {
               atLeastOne = exprId;
               if (!(exprId.getItemExpr()->doesExprEvaluateToConstant(FALSE, TRUE)))


### PR DESCRIPTION
For query " insert into to t1 select seqnum(seq1, next) from t1;", there is no SORT as left child of TSJ, and it is a self-referencing updates Halloween problem.  In NestedJoin::genWriteOpLeftChildSortReq(), child(0) producing no outputs for this query, which means that there is no column to sort on. So we  solve this by having the source for Halloween insert produce at least one output column always.