### PR TITLE
[TRAFODION-3039] SendEventMsg is used in a wrong way

### DIFF
--- a/core/conn/odbc/src/odbc/nsksrvrcore/srvrothers.cpp
+++ b/core/conn/odbc/src/odbc/nsksrvrcore/srvrothers.cpp
@@ -6533,6 +6533,8 @@ odbc_SQLSrvr_ExtractLob_sme_(
         if (retcode == SQL_ERROR)
         {
             ERROR_DESC_def *p_buffer = QryLobExtractSrvrStmt->sqlError.errorList._buffer;
+            char             errNumStr[128];
+            sprintf(errNumStr, "%d", p_buffer->sqlcode);
             strncpy(RequestError, p_buffer->errorText, sizeof(RequestError) - 1);
 
             SendEventMsg(MSG_SQL_ERROR,
@@ -6541,7 +6543,7 @@ odbc_SQLSrvr_ExtractLob_sme_(
                          ODBCMX_SERVER,
                          srvrGlobal->srvrObjRef,
                          2,
-                         p_buffer->sqlcode,
+                         errNumStr,
                          RequestError);
 
             exception_->exception_nr = odbc_SQLsrvr_ExtractLob_ParamError_exn_;
@@ -6616,6 +6618,9 @@ odbc_SQLSrvr_UpdateLob_sme_(
         if (retcode == SQL_ERROR)
         {
             ERROR_DESC_def * p_buffer = QryLobUpdateSrvrStmt->sqlError.errorList._buffer;
+            char             errNumStr[128];
+            sprintf(errNumStr, "%d", p_buffer->sqlcode);
+
             strncpy(RequestError, p_buffer->errorText, sizeof(RequestError) - 1);
 
             SendEventMsg(MSG_SQL_ERROR,
@@ -6624,7 +6629,7 @@ odbc_SQLSrvr_UpdateLob_sme_(
                          ODBCMX_SERVER,
                          srvrGlobal->srvrObjRef,
                          2,
-                         p_buffer->sqlcode,
+                         errNumStr,
                          RequestError);
             exception_->exception_nr = odbc_SQLSvc_UpdateLob_ParamError_exn_;
             exception_->u.SQLError.errorList._length = QryLobUpdateSrvrStmt->sqlError.errorList._length;

--- a/core/conn/odbc/src/odbc/nsksrvrcore/srvrothers.cpp
+++ b/core/conn/odbc/src/odbc/nsksrvrcore/srvrothers.cpp
@@ -5242,6 +5242,8 @@ odbc_SQLSvc_GetSQLCatalogs_sme_(
                  if (retcode == SQL_ERROR)
                  {
                     ERROR_DESC_def *p_buffer = QryCatalogSrvrStmt->sqlError.errorList._buffer;
+                    char             errNumStr[128] = {0};
+                    sprintf(errNumStr, "%d", (int)p_buffer->sqlcode);
                     strncpy(RequestError, p_buffer->errorText,sizeof(RequestError) -1);
                     RequestError[sizeof(RequestError) - 1] = '\0';
 
@@ -5251,7 +5253,7 @@ odbc_SQLSvc_GetSQLCatalogs_sme_(
                                  ODBCMX_SERVER,
                                  srvrGlobal->srvrObjRef,
                                  2,
-                                 p_buffer->sqlcode,
+                                 errNumStr,
                                  RequestError);
 
                     exception_->exception_nr = odbc_SQLSvc_GetSQLCatalogs_ParamError_exn_;
@@ -6533,8 +6535,8 @@ odbc_SQLSrvr_ExtractLob_sme_(
         if (retcode == SQL_ERROR)
         {
             ERROR_DESC_def *p_buffer = QryLobExtractSrvrStmt->sqlError.errorList._buffer;
-            char             errNumStr[128];
-            sprintf(errNumStr, "%d", p_buffer->sqlcode);
+            char            errNumStr[128] = {0};
+            sprintf(errNumStr, "%d", (int)p_buffer->sqlcode);
             strncpy(RequestError, p_buffer->errorText, sizeof(RequestError) - 1);
 
             SendEventMsg(MSG_SQL_ERROR,
@@ -6618,8 +6620,8 @@ odbc_SQLSrvr_UpdateLob_sme_(
         if (retcode == SQL_ERROR)
         {
             ERROR_DESC_def * p_buffer = QryLobUpdateSrvrStmt->sqlError.errorList._buffer;
-            char             errNumStr[128];
-            sprintf(errNumStr, "%d", p_buffer->sqlcode);
+            char             errNumStr[128] = {0};
+            sprintf(errNumStr, "%d", (int)p_buffer->sqlcode);
 
             strncpy(RequestError, p_buffer->errorText, sizeof(RequestError) - 1);
 


### PR DESCRIPTION
SendEventMsg use dynamic parameter.
And there is a parameter control the total, all of dynamic parameters are string data type.
But some place input a number parameter for it.
I checked it again and found two such mistakes.