### PR TITLE
[TRAFODION-3088] Fix data conversion issue with INTERVAL literals

### DIFF
--- a/core/sql/optimizer/ValueDesc.cpp
+++ b/core/sql/optimizer/ValueDesc.cpp
@@ -6382,7 +6382,32 @@ void ValueIdList::convertToTextKey(const ValueIdList& keyList, NAString& result)
 	 {
            short vLen = val.length();
 
-	   if ((constType->getTypeQualifier()  == NA_NUMERIC_TYPE) &&
+	   if (constType->getTypeQualifier() == NA_INTERVAL_TYPE)
+	     {
+	       // In some code paths, the text may have "INTERVAL 'xxx' <qualifier>"
+	       // junk around it so we have to strip that off. (Example: An equality
+	       // predicate when query caching has been turned off via 
+	       // CQD QUERY_CACHE '0'. Another example happens with BETWEEN, whether 
+	       // or not query caching is turned off. See JIRA TRAFODION-3088 for
+	       // that example.)
+	       Lng32 start = val.index("'");
+	       Lng32 minus = val.index("-");
+	       if (start > 0)
+	         {
+	           Lng32 end = val.index("'", start+1);
+	           if (end > 0)
+	             {
+	               val = val(start+1, (end-start-1));
+	               if (minus > 0)
+	                 {
+	                   // prepend '-' to the output
+	                   val.prepend('-', 1);
+	                 }
+	               vLen = val.length();		         
+	             }
+	         }             
+	     }
+	   else if ((constType->getTypeQualifier()  == NA_NUMERIC_TYPE) &&
 	       (((NumericType*)constType)->isExact()) &&
                (NOT ((NumericType*)constType)->isBigNum()) &&
 	       (constType->getScale() > 0))

--- a/core/sql/optimizer/ValueDesc.cpp
+++ b/core/sql/optimizer/ValueDesc.cpp
@@ -6398,7 +6398,7 @@ void ValueIdList::convertToTextKey(const ValueIdList& keyList, NAString& result)
 	           if (end > 0)
 	             {
 	               val = val(start+1, (end-start-1));
-	               if (minus > 0)
+	               if ((minus > 0) && (minus < start))  // '-' before the string part
 	                 {
 	                   // prepend '-' to the output
 	                   val.prepend('-', 1);


### PR DESCRIPTION
ValueIdList::convertToTextKey (optimizer/ValueDesc.cpp) in some cases was encountering INTERVAL literal values containing the text "INTERVAL ... < qualifier >". The code expects this text to be there in some code paths but not all. With this change, I've taken care of the remaining code paths. So we should no longer see data conversion errors in the cases noted in the JIRA.