### PR TITLE
TRAFODION-3025 support order by with limit N in subquery

### DIFF
--- a/core/sql/optimizer/NormRelExpr.cpp
+++ b/core/sql/optimizer/NormRelExpr.cpp
@@ -7692,7 +7692,6 @@ RelExpr * RelRoot::normalizeNode(NormWA & normWARef)
   if ((reqdOrder().entries() > 0) && 
       (child(0)->getOperatorType() == REL_FIRST_N))
     {
-printf("LMDBG root push order by to firstn\n");
       FirstN * firstn = (FirstN *)child(0)->castToRelExpr();
       if (firstn->isFirstN())  // that is, [first n], not [any n] or [last n]
         firstn->reqdOrder().insert(reqdOrder());

--- a/core/sql/optimizer/NormRelExpr.cpp
+++ b/core/sql/optimizer/NormRelExpr.cpp
@@ -7471,7 +7471,15 @@ void RelRoot::transformNode(NormWA & normWARef,
         }
       else
         updatableSelect() = FALSE;
-
+      
+      if ((child(0)->castToRelExpr()->getOperatorType() == REL_FIRST_N) )
+      {
+         FirstN* firstn = (FirstN *)child(0)->castToRelExpr();
+         if(firstn->reqdOrderInSubquery().entries() >0 )
+         {
+           reqdOrder().insert( firstn->reqdOrderInSubquery());
+         }
+      }
     }
   else
     {
@@ -7490,6 +7498,14 @@ void RelRoot::transformNode(NormWA & normWARef,
     
       locationOfPointerToMe = child(0); // my parent now -> my child
       child(0)->setFirstNRows(getFirstNRows());
+
+      //keep the order if there is FIRSTN
+      if (child(0)->getOperatorType()==REL_FIRST_N)
+      {
+         FirstN* firstn = (FirstN *)child(0)->castToRelExpr();
+         firstn->reqdOrderInSubquery().insert(reqdOrder()) ;
+      }
+
       deleteInstance();                 // Goodbye!
       
       
@@ -7676,6 +7692,7 @@ RelExpr * RelRoot::normalizeNode(NormWA & normWARef)
   if ((reqdOrder().entries() > 0) && 
       (child(0)->getOperatorType() == REL_FIRST_N))
     {
+printf("LMDBG root push order by to firstn\n");
       FirstN * firstn = (FirstN *)child(0)->castToRelExpr();
       if (firstn->isFirstN())  // that is, [first n], not [any n] or [last n]
         firstn->reqdOrder().insert(reqdOrder());

--- a/core/sql/optimizer/RelMisc.h
+++ b/core/sql/optimizer/RelMisc.h
@@ -1662,6 +1662,7 @@ public:
   NABoolean isFirstN()                          { return isFirstN_; }
 
   ValueIdList & reqdOrder()                     { return reqdOrder_; }
+  ValueIdList & reqdOrderInSubquery()           { return reqdOrderInSubquery_; }
 
 private:
   // Otherwise, return firstNRows_ at runtime.
@@ -1673,6 +1674,7 @@ private:
   // Optional ORDER BY to force ordering before applying First N; populated
   // at normalizeNode time.
   ValueIdList reqdOrder_;
+  ValueIdList reqdOrderInSubquery_;
 
 }; // class FirstN
 

--- a/core/sql/regress/core/EXPECTED002.LINUX
+++ b/core/sql/regress/core/EXPECTED002.LINUX
@@ -867,12 +867,18 @@ A            AMAX         B                   BMAX                C            C
 >>create table t002FUI(x int);
 
 --- SQL operation complete.
+>>create table t002sol(x int);
+
+--- SQL operation complete.
 >>insert into  t002FU  values(3),(4);
 
 --- 2 row(s) inserted.
 >>insert into  t002FUI values(13);
 
 --- 1 row(s) inserted.
+>>insert into t002sol values(2),(5),(4),(3),(7);
+
+--- 5 row(s) inserted.
 >>
 >>-- Tables t002ZZ and t002ZZI are empty (have zero rows), tables t002FU and t002FUI are full.
 >>--
@@ -1264,4 +1270,13 @@ RESULT_VALUE
 
 --- 1 row(s) selected.
 >>
+>>-- Should return 7
+>>select x from (select [first 1] x from t002sol order by x desc );
+
+X
+----------
+
+ 7
+
+--- 1 row(s) selected.
 >>log;

--- a/core/sql/regress/core/TEST002
+++ b/core/sql/regress/core/TEST002
@@ -480,8 +480,10 @@ create table t002ZZ (x int);
 create table t002ZZI(x int);
 create table t002FU (x int);
 create table t002FUI(x int);
+create table t002sol(x int);
 insert into  t002FU  values(3),(4);
 insert into  t002FUI values(13);
+insert into  t002sol values(2),(5),(4),(3),(7);
 
 -- Tables t002ZZ and t002ZZI are empty (have zero rows), tables t002FU and t002FUI are full.
 --
@@ -586,6 +588,8 @@ select
 (select [last 0] x from t002sub) as result_value
 from t002main;
 
+-- Should return 7
+select x from (select [first 1] x from t002sol order by x desc );
 log;
 obey TEST002(clnup);
 exit;
@@ -601,6 +605,7 @@ drop table t002ZZ;
 drop table t002ZZI;
 drop table t002FU;
 drop table t002FUI;
+drop table t002sol;
 
 #ifMX
 drop table t002ut1;


### PR DESCRIPTION
ORDER BY in subquery is ignored by Trafodion, when in the subquery, there is a limit N, it is good to keep the order by:

select * from t ( select * from t order by c limit 20);

for example