### PR TITLE
TRAFODION-3111 CentOS 7 build error

### DIFF
--- a/core/sqf/monitor/linux/cluster.cxx
+++ b/core/sqf/monitor/linux/cluster.cxx
@@ -42,6 +42,7 @@ using namespace std;
 #include <sys/resource.h>
 #include <errno.h>
 #include <limits.h>
+#include <unistd.h>
 
 #include "localio.h"
 #include "mlio.h"

--- a/core/sqf/monitor/linux/pnode.cxx
+++ b/core/sqf/monitor/linux/pnode.cxx
@@ -32,6 +32,8 @@
 #include <sys/time.h>
 #include <string.h>
 #include <iostream>
+#include <sys/types.h>
+#include <unistd.h>
 
 using namespace std;
 

--- a/core/sqf/src/seatrans/tm/hbasetmlib2/testrun.cpp
+++ b/core/sqf/src/seatrans/tm/hbasetmlib2/testrun.cpp
@@ -41,7 +41,7 @@ int main () {
    short lv_dtmid = 0;
    char *errStr = NULL;
    int   errStrLen = 0;
-   long ctrlPtNum;
+   long ctrlPtNum = 0;
    CHbaseTM *lp_myHbaseTM = 0;
 
    lp_myHbaseTM = new CHbaseTM();


### PR DESCRIPTION
Some new code checkin broke the build on CentOS 7

I will continously monitor the CentOS 7 build until the jenkins setup.
CentOS 7 jenkins test now failed on some UDR regression, it is hard to find out root cause yet, still need some time.