### PR TITLE
[TRAFODION-3101] enhance get command to show rows get

### DIFF
--- a/core/sql/executor/ExExeUtil.h
+++ b/core/sql/executor/ExExeUtil.h
@@ -2491,6 +2491,11 @@ protected:
   Lng32 getUsedObjects(Queue * infoList,
                       NABoolean isShorthandView,
                       char* &viewName, Lng32 &len);
+  void setReturnRowCount( Lng32 n) { returnRowCount_ = n; }
+
+  Lng32 getReturnRowCount() {return returnRowCount_;}
+
+  void incReturnRowCount() {returnRowCount_++; }
 
 private:
 
@@ -2517,6 +2522,8 @@ private:
     const char *catName,
     const char *schName,
     const char *objName);
+
+  Lng32 returnRowCount_;
 
 };
 

--- a/core/sql/executor/ExExeUtil.h
+++ b/core/sql/executor/ExExeUtil.h
@@ -2497,6 +2497,8 @@ protected:
 
   void incReturnRowCount() {returnRowCount_++; }
 
+  Lng32 returnRowCount_;
+
 private:
 
   NABoolean checkUserPrivs(ContextCli * currConnext, const ComTdbExeUtilGetMetadataInfo::QueryType queryType);
@@ -2523,7 +2525,6 @@ private:
     const char *schName,
     const char *objName);
 
-  Lng32 returnRowCount_;
 
 };
 

--- a/core/sql/executor/ExExeUtilGet.cpp
+++ b/core/sql/executor/ExExeUtilGet.cpp
@@ -3346,14 +3346,13 @@ short ExExeUtilGetMetadataInfoTcb::work()
 
 	case DONE_:
 	  {
-            if (NOT getMItdb().noHeader())
+            if (NOT getMItdb().noHeader() && getReturnRowCount() > 0)
             {
               short rc = 0;
               char returnMsg[256];
               memset(returnMsg, 0, 256);
-              sprintf(returnMsg, "\n=======================\nSummary info of get:\nGet %d rows.", getReturnRowCount());
+              sprintf(returnMsg, "\n=======================\n %d row(s) returned", getReturnRowCount());
               moveRowToUpQueue(returnMsg, strlen(returnMsg), &rc);
-              moveRowToUpQueue(" ");
             }
 
 	    retcode = handleDone();
@@ -3907,14 +3906,13 @@ short ExExeUtilGetMetadataInfoComplexTcb::work()
 
 	case DONE_:
 	  {
-            if (NOT getMItdb().noHeader())
+            if (NOT getMItdb().noHeader() && getReturnRowCount() > 0)
             {
               short rc = 0;
               char returnMsg[256];
               memset(returnMsg, 0, 256);
-              sprintf(returnMsg, "\n=======================\nSummary info of get:\nGet %d rows.", getReturnRowCount());
+              sprintf(returnMsg, "\n=======================\n %d row(s) returned", getReturnRowCount());
               moveRowToUpQueue(returnMsg, strlen(returnMsg), &rc);
-              moveRowToUpQueue(" ");
             }
 	    retcode = handleDone();
 	    if (retcode == 1)

--- a/core/sql/executor/ExExeUtilGet.cpp
+++ b/core/sql/executor/ExExeUtilGet.cpp
@@ -1851,6 +1851,7 @@ short ExExeUtilGetMetadataInfoTcb::work()
 	    headingReturned_ = FALSE;
 
 	    numOutputEntries_ = 1;
+            returnRowCount_ = 0 ;
 
 	    objectUid_[0] = 0;
 	  }
@@ -3420,6 +3421,7 @@ short ExExeUtilGetMetadataInfoComplexTcb::work()
 	case INITIAL_:
 	  {
 	    step_ = SETUP_QUERY_;
+            returnRowCount_ = 0 ;
 	  }
 	break;
 

--- a/core/sql/executor/ExExeUtilGet.cpp
+++ b/core/sql/executor/ExExeUtilGet.cpp
@@ -949,7 +949,6 @@ short ExExeUtilGetMetadataInfoTcb::displayHeading()
 {
   if (getMItdb().noHeader())
     {
-printf("LMDBG noheader is true\n");
       return 0;
     }
   // make sure there is enough space to move header

--- a/core/sql/executor/ExExeUtilGet.cpp
+++ b/core/sql/executor/ExExeUtilGet.cpp
@@ -149,6 +149,7 @@ ExExeUtilGetMetadataInfoTcb::ExExeUtilGetMetadataInfoTcb(
   patternStr_ = new(glob->getDefaultHeap()) char[1000];
 
   numOutputEntries_ = 0;
+  returnRowCount_ = 0;
 }
 
 ExExeUtilGetMetadataInfoTcb::~ExExeUtilGetMetadataInfoTcb()
@@ -1818,11 +1819,8 @@ short ExExeUtilGetMetadataInfoTcb::work()
 {
   short retcode = 0;
   Lng32 cliRC = 0;
-  Lng32 returnRowCount=0;
-  char returnMsg[256];
   ex_expr::exp_return_type exprRetCode = ex_expr::EXPR_OK;
 
-  memset(returnMsg, 0, 256);
 
   // if no parent request, return
   if (qparent_.down->isEmpty())
@@ -3188,7 +3186,7 @@ short ExExeUtilGetMetadataInfoTcb::work()
             }
 
 	    infoList_->advance();
-            returnRowCount++;
+            incReturnRowCount();
 	  }
 	break;
 
@@ -3351,7 +3349,9 @@ short ExExeUtilGetMetadataInfoTcb::work()
             if (NOT getMItdb().noHeader())
             {
               short rc = 0;
-              sprintf(returnMsg, "\n=======================\nSummary info of get:\nGet %d rows.", returnRowCount);
+              char returnMsg[256];
+              memset(returnMsg, 0, 256);
+              sprintf(returnMsg, "\n=======================\nSummary info of get:\nGet %d rows.", getReturnRowCount());
               moveRowToUpQueue(returnMsg, strlen(returnMsg), &rc);
               moveRowToUpQueue(" ");
             }
@@ -3891,6 +3891,7 @@ short ExExeUtilGetMetadataInfoComplexTcb::work()
 	      moveRowToUpQueue(" ", 0, &rc);
 
 	    infoList_->advance();
+            incReturnRowCount();
 	  }
 	break;
 
@@ -3906,6 +3907,15 @@ short ExExeUtilGetMetadataInfoComplexTcb::work()
 
 	case DONE_:
 	  {
+            if (NOT getMItdb().noHeader())
+            {
+              short rc = 0;
+              char returnMsg[256];
+              memset(returnMsg, 0, 256);
+              sprintf(returnMsg, "\n=======================\nSummary info of get:\nGet %d rows.", getReturnRowCount());
+              moveRowToUpQueue(returnMsg, strlen(returnMsg), &rc);
+              moveRowToUpQueue(" ");
+            }
 	    retcode = handleDone();
 	    if (retcode == 1)
 	      return WORK_OK;
@@ -4741,6 +4751,7 @@ short ExExeUtilGetHiveMetadataInfoTcb::work()
             }
 
 	    infoList_->advance();
+            incReturnRowCount();
 	  }
 	  break;
 

--- a/core/sql/executor/ExExeUtilGet.cpp
+++ b/core/sql/executor/ExExeUtilGet.cpp
@@ -949,6 +949,7 @@ short ExExeUtilGetMetadataInfoTcb::displayHeading()
 {
   if (getMItdb().noHeader())
     {
+printf("LMDBG noheader is true\n");
       return 0;
     }
   // make sure there is enough space to move header
@@ -1818,7 +1819,11 @@ short ExExeUtilGetMetadataInfoTcb::work()
 {
   short retcode = 0;
   Lng32 cliRC = 0;
+  Lng32 returnRowCount=0;
+  char returnMsg[256];
   ex_expr::exp_return_type exprRetCode = ex_expr::EXPR_OK;
+
+  memset(returnMsg, 0, 256);
 
   // if no parent request, return
   if (qparent_.down->isEmpty())
@@ -3184,6 +3189,7 @@ short ExExeUtilGetMetadataInfoTcb::work()
             }
 
 	    infoList_->advance();
+            returnRowCount++;
 	  }
 	break;
 
@@ -3343,6 +3349,14 @@ short ExExeUtilGetMetadataInfoTcb::work()
 
 	case DONE_:
 	  {
+            if (NOT getMItdb().noHeader())
+            {
+              short rc = 0;
+              sprintf(returnMsg, "\n=======================\nSummary info of get:\nGet %d rows.", returnRowCount);
+              moveRowToUpQueue(returnMsg, strlen(returnMsg), &rc);
+              moveRowToUpQueue(" ");
+            }
+
 	    retcode = handleDone();
 	    if (retcode == 1)
 	      return WORK_OK;

--- a/core/sql/regress/compGeneral/EXPECTED023
+++ b/core/sql/regress/compGeneral/EXPECTED023
@@ -23,6 +23,10 @@ SB_HISTOGRAMS
 SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
 
+=======================
+Summary info of get:
+Get 3 rows.
+
 --- SQL operation complete.
 >>
 >>CREATE TABLE stest
@@ -106,6 +110,10 @@ STEST
 STESTC
 STEST_EMPTY
 
+=======================
+Summary info of get:
+Get 6 rows.
+
 --- SQL operation complete.
 >>  -- should be just stest, stest_empty, stestc, and the sb_* tables
 >>
@@ -149,6 +157,10 @@ STESTC
 STEST_EMPTY
 TRAF_SAMPLE_07158060726899021395_1517441663_444545
 
+=======================
+Summary info of get:
+Get 7 rows.
+
 --- SQL operation complete.
 >> -- should be stest, stest_empty, stestc, sb_* tables + a sample table
 >>
@@ -172,6 +184,10 @@ STEST
 STESTC
 STEST_EMPTY
 TRAF_SAMPLE_07158060726899021395_1517441711_141471
+
+=======================
+Summary info of get:
+Get 7 rows.
 
 --- SQL operation complete.
 >> -- should be stest, stest_empty, stestc, sb_* tables + a different sample table
@@ -203,6 +219,10 @@ STEST
 STESTC
 STEST_EMPTY
 
+=======================
+Summary info of get:
+Get 6 rows.
+
 --- SQL operation complete.
 >> -- should be stest, stest_empty, stestc, sb_* tables only
 >>
@@ -229,6 +249,10 @@ STEST
 STESTC
 STEST_EMPTY
 TRAF_SAMPLE_07158060726899021395_1517441748_979037
+
+=======================
+Summary info of get:
+Get 7 rows.
 
 --- SQL operation complete.
 >> -- should be stest, stest_empty, stestc, sb_* tables + another sample table
@@ -263,6 +287,10 @@ STEST
 STESTC
 STEST_EMPTY
 TRAF_SAMPLE_07158060726899021395_1517441802_045572
+
+=======================
+Summary info of get:
+Get 7 rows.
 
 --- SQL operation complete.
 >> -- should be stest, stest_empty, stestc, sb_* tables + another sample table
@@ -393,6 +421,10 @@ STEST_EMPTY
 TRAF_SAMPLE_07158060726899021395_1517441802_045572
 TRAF_SAMPLE_07158060726899023220_1517441862_582002
 
+=======================
+Summary info of get:
+Get 8 rows.
+
 --- SQL operation complete.
 >>
 >>execute s1 using 'STESTC';
@@ -428,6 +460,10 @@ STEST_EMPTY
 TRAF_SAMPLE_07158060726899021395_1517441802_045572
 TRAF_SAMPLE_07158060726899023220_1517441862_582002
 
+=======================
+Summary info of get:
+Get 8 rows.
+
 --- SQL operation complete.
 >> -- should be the same as previous "get tables"
 >>
@@ -455,6 +491,10 @@ STESTC
 STEST_EMPTY
 TRAF_SAMPLE_07158060726899021395_1517441802_045572
 TRAF_SAMPLE_07158060726899023220_1517441862_582002
+
+=======================
+Summary info of get:
+Get 8 rows.
 
 --- SQL operation complete.
 >> -- should be the same as previous "get tables"
@@ -484,6 +524,10 @@ STESTC
 STEST_EMPTY
 TRAF_SAMPLE_07158060726899021395_1517441802_045572
 TRAF_SAMPLE_07158060726899023220_1517441862_582002
+
+=======================
+Summary info of get:
+Get 8 rows.
 
 --- SQL operation complete.
 >> -- should be the same as previous "get tables"
@@ -515,6 +559,10 @@ STESTC
 STEST_EMPTY
 TRAF_SAMPLE_07158060726899021395_1517441802_045572
 TRAF_SAMPLE_07158060726899023220_1517441862_582002
+
+=======================
+Summary info of get:
+Get 8 rows.
 
 --- SQL operation complete.
 >> -- should be the same as previous "get tables"
@@ -567,6 +615,10 @@ STESTC
 STEST_EMPTY
 TRAF_SAMPLE_07158060726899021395_1517441802_045572
 
+=======================
+Summary info of get:
+Get 7 rows.
+
 --- SQL operation complete.
 >> -- should be the same as previous "get tables" except only one sample table
 >>
@@ -591,6 +643,10 @@ Tables in Schema TRAFODION.COMPGENERAL_TEST023
 SB_HISTOGRAMS
 SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
+
+=======================
+Summary info of get:
+Get 3 rows.
 
 --- SQL operation complete.
 >>  -- sample tables should be gone too

--- a/core/sql/regress/compGeneral/EXPECTED023
+++ b/core/sql/regress/compGeneral/EXPECTED023
@@ -24,8 +24,7 @@ SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
 
 =======================
-Summary info of get:
-Get 3 rows.
+ 3 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -111,8 +110,7 @@ STESTC
 STEST_EMPTY
 
 =======================
-Summary info of get:
-Get 6 rows.
+ 6 row(s) returned
 
 --- SQL operation complete.
 >>  -- should be just stest, stest_empty, stestc, and the sb_* tables
@@ -158,8 +156,7 @@ STEST_EMPTY
 TRAF_SAMPLE_07158060726899021395_1517441663_444545
 
 =======================
-Summary info of get:
-Get 7 rows.
+ 7 row(s) returned
 
 --- SQL operation complete.
 >> -- should be stest, stest_empty, stestc, sb_* tables + a sample table
@@ -186,8 +183,7 @@ STEST_EMPTY
 TRAF_SAMPLE_07158060726899021395_1517441711_141471
 
 =======================
-Summary info of get:
-Get 7 rows.
+ 7 row(s) returned
 
 --- SQL operation complete.
 >> -- should be stest, stest_empty, stestc, sb_* tables + a different sample table
@@ -220,8 +216,7 @@ STESTC
 STEST_EMPTY
 
 =======================
-Summary info of get:
-Get 6 rows.
+ 6 row(s) returned
 
 --- SQL operation complete.
 >> -- should be stest, stest_empty, stestc, sb_* tables only
@@ -251,8 +246,7 @@ STEST_EMPTY
 TRAF_SAMPLE_07158060726899021395_1517441748_979037
 
 =======================
-Summary info of get:
-Get 7 rows.
+ 7 row(s) returned
 
 --- SQL operation complete.
 >> -- should be stest, stest_empty, stestc, sb_* tables + another sample table
@@ -289,8 +283,7 @@ STEST_EMPTY
 TRAF_SAMPLE_07158060726899021395_1517441802_045572
 
 =======================
-Summary info of get:
-Get 7 rows.
+ 7 row(s) returned
 
 --- SQL operation complete.
 >> -- should be stest, stest_empty, stestc, sb_* tables + another sample table
@@ -422,8 +415,7 @@ TRAF_SAMPLE_07158060726899021395_1517441802_045572
 TRAF_SAMPLE_07158060726899023220_1517441862_582002
 
 =======================
-Summary info of get:
-Get 8 rows.
+ 8 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -461,8 +453,7 @@ TRAF_SAMPLE_07158060726899021395_1517441802_045572
 TRAF_SAMPLE_07158060726899023220_1517441862_582002
 
 =======================
-Summary info of get:
-Get 8 rows.
+ 8 row(s) returned
 
 --- SQL operation complete.
 >> -- should be the same as previous "get tables"
@@ -493,8 +484,7 @@ TRAF_SAMPLE_07158060726899021395_1517441802_045572
 TRAF_SAMPLE_07158060726899023220_1517441862_582002
 
 =======================
-Summary info of get:
-Get 8 rows.
+ 8 row(s) returned
 
 --- SQL operation complete.
 >> -- should be the same as previous "get tables"
@@ -526,8 +516,7 @@ TRAF_SAMPLE_07158060726899021395_1517441802_045572
 TRAF_SAMPLE_07158060726899023220_1517441862_582002
 
 =======================
-Summary info of get:
-Get 8 rows.
+ 8 row(s) returned
 
 --- SQL operation complete.
 >> -- should be the same as previous "get tables"
@@ -561,8 +550,7 @@ TRAF_SAMPLE_07158060726899021395_1517441802_045572
 TRAF_SAMPLE_07158060726899023220_1517441862_582002
 
 =======================
-Summary info of get:
-Get 8 rows.
+ 8 row(s) returned
 
 --- SQL operation complete.
 >> -- should be the same as previous "get tables"
@@ -616,8 +604,7 @@ STEST_EMPTY
 TRAF_SAMPLE_07158060726899021395_1517441802_045572
 
 =======================
-Summary info of get:
-Get 7 rows.
+ 7 row(s) returned
 
 --- SQL operation complete.
 >> -- should be the same as previous "get tables" except only one sample table
@@ -645,8 +632,7 @@ SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
 
 =======================
-Summary info of get:
-Get 3 rows.
+ 3 row(s) returned
 
 --- SQL operation complete.
 >>  -- sample tables should be gone too

--- a/core/sql/regress/core/EXPECTED116
+++ b/core/sql/regress/core/EXPECTED116
@@ -777,12 +777,6 @@ T116T2
 --- SQL operation complete.
 >>get tables in schema t116sch1;
 
-
-=======================
-Summary info of get:
-Get 0 rows.
-
-
 --- SQL operation complete.
 >>select count(*) from "_MD_".objects where schema_name = 'T116SCH1' 
 +>   for read uncommitted access;

--- a/core/sql/regress/core/EXPECTED116
+++ b/core/sql/regress/core/EXPECTED116
@@ -739,6 +739,7 @@ T116T1
 Summary info of get:
 Get 1 rows.
 
+
 --- SQL operation complete.
 >>drop table t116t1;
 
@@ -755,6 +756,7 @@ SB_PERSISTENT_SAMPLES
 =======================
 Summary info of get:
 Get 3 rows.
+
 
 --- SQL operation complete.
 >>create table t116t2 (a int);
@@ -774,6 +776,7 @@ T116T2
 Summary info of get:
 Get 4 rows.
 
+
 --- SQL operation complete.
 >>drop schema t116sch1 cascade;
 
@@ -784,6 +787,7 @@ Get 4 rows.
 =======================
 Summary info of get:
 Get 0 rows.
+
 
 --- SQL operation complete.
 >>select count(*) from "_MD_".objects where schema_name = 'T116SCH1' 
@@ -811,6 +815,7 @@ T116T1
 =======================
 Summary info of get:
 Get 4 rows.
+
 
 --- SQL operation complete.
 >>

--- a/core/sql/regress/core/EXPECTED116
+++ b/core/sql/regress/core/EXPECTED116
@@ -735,6 +735,10 @@ Tables in Schema TRAFODION.T116SCH1
 
 T116T1
 
+=======================
+Summary info of get:
+Get 1 rows.
+
 --- SQL operation complete.
 >>drop table t116t1;
 
@@ -747,6 +751,10 @@ Tables in Schema TRAFODION.T116SCH1
 SB_HISTOGRAMS
 SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
+
+=======================
+Summary info of get:
+Get 3 rows.
 
 --- SQL operation complete.
 >>create table t116t2 (a int);
@@ -762,11 +770,20 @@ SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
 T116T2
 
+=======================
+Summary info of get:
+Get 4 rows.
+
 --- SQL operation complete.
 >>drop schema t116sch1 cascade;
 
 --- SQL operation complete.
 >>get tables in schema t116sch1;
+
+
+=======================
+Summary info of get:
+Get 0 rows.
 
 --- SQL operation complete.
 >>select count(*) from "_MD_".objects where schema_name = 'T116SCH1' 
@@ -790,6 +807,10 @@ SB_HISTOGRAMS
 SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
 T116T1
+
+=======================
+Summary info of get:
+Get 4 rows.
 
 --- SQL operation complete.
 >>

--- a/core/sql/regress/core/EXPECTED116
+++ b/core/sql/regress/core/EXPECTED116
@@ -736,9 +736,7 @@ Tables in Schema TRAFODION.T116SCH1
 T116T1
 
 =======================
-Summary info of get:
-Get 1 rows.
-
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>drop table t116t1;
@@ -754,9 +752,7 @@ SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
 
 =======================
-Summary info of get:
-Get 3 rows.
-
+ 3 row(s) returned
 
 --- SQL operation complete.
 >>create table t116t2 (a int);
@@ -773,9 +769,7 @@ SB_PERSISTENT_SAMPLES
 T116T2
 
 =======================
-Summary info of get:
-Get 4 rows.
-
+ 4 row(s) returned
 
 --- SQL operation complete.
 >>drop schema t116sch1 cascade;
@@ -813,9 +807,7 @@ SB_PERSISTENT_SAMPLES
 T116T1
 
 =======================
-Summary info of get:
-Get 4 rows.
-
+ 4 row(s) returned
 
 --- SQL operation complete.
 >>

--- a/core/sql/regress/executor/EXPECTED130
+++ b/core/sql/regress/executor/EXPECTED130
@@ -1595,6 +1595,10 @@ SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
 TLOB130TS2
 
+=======================
+Summary info of get:
+Get 7 rows.
+
 --- SQL operation complete.
 >>drop schema trafodion.lobsch cascade;
 

--- a/core/sql/regress/hive/DIFF009.KNOWN
+++ b/core/sql/regress/hive/DIFF009.KNOWN
@@ -1,3 +1,3 @@
-1071a1072,1073
+1074a1075,1076
 > *** WARNING[6008] Statistics for column (D_DATE) from table HIVE.HIVE.DATE_DIM were not available. As a result, the access path chosen might not be the best possible.
 > 

--- a/core/sql/regress/hive/EXPECTED007
+++ b/core/sql/regress/hive/EXPECTED007
@@ -198,6 +198,9 @@ Tables in View SCH007.VHIVE1
 
 HIVE.HIVE.THIVE1
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get tables in view trafodion.sch007.vhive11;
 
@@ -205,6 +208,9 @@ Tables in View SCH007.VHIVE11
 =============================
 
 HIVE.HIVE.THIVE2
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -216,6 +222,9 @@ Tables in View SCH007.VHIVE3
 HIVE.HIVE.THIVE1
 HIVE.HIVE.THIVE2
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get views in view trafodion.sch007.vhive3;
 
@@ -223,6 +232,9 @@ Views in View SCH007.VHIVE3
 ===========================
 
 TRAFODION.SCH007.VHIVE2
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get views on table hive.hive.thive1;
@@ -232,6 +244,9 @@ Views on Table HIVE.THIVE1
 
 TRAFODION.SCH007.VHIVE1
 TRAFODION.SCH007.VHIVE2
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>get all views on table hive.hive.thive2;
@@ -243,6 +258,9 @@ TRAFODION.SCH007.VHIVE11
 TRAFODION.SCH007.VHIVE2
 TRAFODION.SCH007.VHIVE3
 TRAFODION.SCH007.VHIVEHBASE
+
+=======================
+ 4 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -282,6 +300,9 @@ TRAFODION.SCH007.VHIVE11
 TRAFODION.SCH007.VHIVE2
 TRAFODION.SCH007.VHIVE3
 TRAFODION.SCH007.VHIVEHBASE
+
+=======================
+ 4 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -647,6 +668,9 @@ Views in View SCH007.VTRAFONHIVE
 
 HIVE.HIVESCH007.VHIVE11
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get views on view hive.hivesch007.vhive11;
 
@@ -654,6 +678,9 @@ Views ON View HIVESCH007.VHIVE11
 ================================
 
 TRAFODION.SCH007.VTRAFONHIVE
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -694,6 +721,9 @@ Views in View HIVESCH007.VHIVE11
 
 HIVE.HIVESCH007.VHIVE1
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get views on table hive.hivesch007.thive1;
 
@@ -702,6 +732,9 @@ Views on Table HIVESCH007.THIVE1
 
 HIVE.HIVESCH007.VHIVE1
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get views on view hive.hivesch007.vhive1;
 
@@ -709,6 +742,9 @@ Views ON View HIVESCH007.VHIVE1
 ===============================
 
 HIVE.HIVESCH007.VHIVE11
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -759,6 +795,9 @@ Tables in View HIVESCH0071.VH11
 
 HIVE.HIVESCH0071.H1
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get views in view vh11;
 
@@ -766,6 +805,9 @@ Views in View HIVESCH0071.VH11
 ==============================
 
 HIVE.HIVESCH0071.VH1
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get all objects in view vh11;
@@ -776,6 +818,9 @@ Objects in View HIVESCH0071.VH11
 HIVE.HIVESCH0071.H1
 HIVE.HIVESCH0071.VH1
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>
 >>get hive registered tables in catalog trafodion, match '%hivesch0071%';
@@ -784,6 +829,9 @@ Hive Registered Tables in Catalog TRAFODION
 ===========================================
 
 hive.hivesch0071.h1
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get hive registered views in catalog trafodion, match '%hivesch0071%';
@@ -794,6 +842,9 @@ Hive Registered Views in Catalog TRAFODION
 hive.hivesch0071.vh1
 hive.hivesch0071.vh11
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get hive registered objects in catalog trafodion, match '%hivesch0071%';
 
@@ -803,6 +854,9 @@ Hive Registered Objects in Catalog TRAFODION
 hive.hivesch0071.h1
 hive.hivesch0071.vh1
 hive.hivesch0071.vh11
+
+=======================
+ 3 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -883,6 +937,9 @@ Hive Registered Schemas in Catalog TRAFODION
 ============================================
 
 hive.hivesch0078
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>unregister hive schema hive.hivesch0078;
@@ -1016,6 +1073,9 @@ Privileges for User SQL_USER3
 =============================
 
 S------    HIVE.HIVESCH007.THIVE9
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>insert into hive.hivesch007.thive9 values (1), (2), (3), (4), (5), (6);

--- a/core/sql/regress/hive/EXPECTED009
+++ b/core/sql/regress/hive/EXPECTED009
@@ -431,9 +431,7 @@ T009T1
 T009T2
 
 =======================
-Summary info of get:
-Get 2 rows.
-
+ 2 row(s) returned
  
 --- SQL operation complete.
 >>invoke hive.sch_t009.t009t1;

--- a/core/sql/regress/hive/EXPECTED009
+++ b/core/sql/regress/hive/EXPECTED009
@@ -432,7 +432,7 @@ T009T2
 
 =======================
  2 row(s) returned
- 
+
 --- SQL operation complete.
 >>invoke hive.sch_t009.t009t1;
 

--- a/core/sql/regress/hive/EXPECTED009
+++ b/core/sql/regress/hive/EXPECTED009
@@ -430,6 +430,11 @@ Tables in Schema TRAFODION._HV_SCH_T009_
 T009T1
 T009T2
 
+=======================
+Summary info of get:
+Get 2 rows.
+
+ 
 --- SQL operation complete.
 >>invoke hive.sch_t009.t009t1;
 

--- a/core/sql/regress/privs1/EXPECTED123
+++ b/core/sql/regress/privs1/EXPECTED123
@@ -17,6 +17,9 @@ SQL_USER7
 SQL_USER8
 SQL_USER9
 
+=======================
+ 11 row(s) returned
+
 --- SQL operation complete.
 >>get roles;
 
@@ -29,6 +32,9 @@ DB__LIBMGRROLE
 DB__ROOTROLE
 PUBLIC
 
+=======================
+ 5 row(s) returned
+
 --- SQL operation complete.
 >>
 >>get privileges on component sql_operations for "PUBLIC";
@@ -38,6 +44,9 @@ Privilege information on Component SQL_OPERATIONS for PUBLIC
 
 CREATE_SCHEMA
 SHOW
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -195,6 +204,9 @@ SQL_USER7
 SQL_USER8
 SQL_USER9
 
+=======================
+ 11 row(s) returned
+
 --- SQL operation complete.
 >>get roles;
 
@@ -211,6 +223,9 @@ T123_DUMMYROLE
 T123_OWNERROLE
 T123_PLANNERROLE
 
+=======================
+ 9 row(s) returned
+
 --- SQL operation complete.
 >>get roles for user sql_user1;
 
@@ -221,6 +236,9 @@ PUBLIC
 T123_ADMINROLE
 T123_PLANNERROLE
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>get roles for user sql_user2;
 
@@ -230,6 +248,9 @@ Roles for User SQL_USER2
 PUBLIC
 T123_PLANNERROLE
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get roles for user sql_user3;
 
@@ -238,6 +259,9 @@ Roles for User SQL_USER3
 
 PUBLIC
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get roles for user sql_user4;
 
@@ -245,6 +269,9 @@ Roles for User SQL_USER4
 ========================
 
 PUBLIC
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get roles for user sql_user5;
@@ -255,6 +282,9 @@ Roles for User SQL_USER5
 PUBLIC
 T123_OWNERROLE
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>
 >>get users for role t123_adminrole;
@@ -264,6 +294,9 @@ Users granted Role T123_ADMINROLE
 
 SQL_USER1
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get users for role t123_plannerrole;
 
@@ -272,6 +305,9 @@ Users granted Role T123_PLANNERROLE
 
 SQL_USER1
 SQL_USER2
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>get users for role t123_dummyrole;
@@ -283,6 +319,9 @@ Users granted Role T123_OWNERROLE
 =================================
 
 SQL_USER5
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -305,6 +344,9 @@ S------    TRAFODION.T123SCH.PLAYERS <Column> PLAYER_TEAM_NUMBER
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NAME
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NUMBER
 
+=======================
+ 13 row(s) returned
+
 --- SQL operation complete.
 >>get privileges for user sql_user2;
 
@@ -322,6 +364,9 @@ S------    TRAFODION.T123SCH.PLAYERS <Column> PLAYER_TEAM_NUMBER
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NAME
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NUMBER
 
+=======================
+ 10 row(s) returned
+
 --- SQL operation complete.
 >>get privileges for user sql_user3;
 
@@ -335,6 +380,9 @@ S------    TRAFODION.T123SCH.PLAYERS <Column> PLAYER_NUMBER
 S------    TRAFODION.T123SCH.PLAYERS <Column> PLAYER_TEAM_NUMBER
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NAME
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NUMBER
+
+=======================
+ 7 row(s) returned
 
 --- SQL operation complete.
 >>get privileges for user sql_user4;
@@ -351,6 +399,9 @@ S------    TRAFODION.T123SCH.PLAYERS <Column> PLAYER_TEAM_NUMBER
 S------    TRAFODION.T123SCH.TEAMS
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NAME
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NUMBER
+
+=======================
+ 9 row(s) returned
 
 --- SQL operation complete.
 >>get privileges for user sql_user5;
@@ -376,6 +427,9 @@ SIDU-R-    TRAFODION.T123SCH.TEAMS
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NAME
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NUMBER
 
+=======================
+ 17 row(s) returned
+
 --- SQL operation complete.
 >>
 >>get privileges for role t123_adminrole;
@@ -386,6 +440,9 @@ Privileges for Role T123_ADMINROLE
 --DU---    TRAFODION.T123SCH.GAMES
 --DU---    TRAFODION.T123SCH.TEAMS
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get privileges for role t123_plannerrole;
 
@@ -395,6 +452,9 @@ Privileges for Role T123_PLANNERROLE
 -I-----    TRAFODION.T123SCH.GAMES
 ----G--    TRAFODION.T123SCH.PLAYERS_SEQUENCE
 -I-----    TRAFODION.T123SCH.TEAMS
+
+=======================
+ 3 row(s) returned
 
 --- SQL operation complete.
 >>get privileges for role t123_dummyrole;
@@ -416,6 +476,9 @@ SIDU-R-    TRAFODION.T123SCH.SB_HISTOGRAM_INTERVALS
 SIDU-R-    TRAFODION.T123SCH.SB_PERSISTENT_SAMPLES
 SIDU-R-    TRAFODION.T123SCH.TEAMS
 
+=======================
+ 10 row(s) returned
+
 --- SQL operation complete.
 >>get privileges for role "PUBLIC";
 
@@ -430,6 +493,9 @@ S------    TRAFODION.T123SCH.PLAYERS <Column> PLAYER_TEAM_NUMBER
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NAME
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NUMBER
 
+=======================
+ 7 row(s) returned
+
 --- SQL operation complete.
 >>
 >>get tables for user sql_user1;
@@ -441,6 +507,9 @@ TRAFODION."T123SCH".GAMES
 TRAFODION."T123SCH".PLAYERS
 TRAFODION."T123SCH".TEAMS
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>get tables for user sql_user2;
 
@@ -451,6 +520,9 @@ TRAFODION."T123SCH".GAMES
 TRAFODION."T123SCH".PLAYERS
 TRAFODION."T123SCH".TEAMS
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>get tables for user sql_user3;
 
@@ -459,6 +531,9 @@ Tables for User SQL_USER3
 
 TRAFODION."T123SCH".PLAYERS
 TRAFODION."T123SCH".TEAMS
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>get tables for user sql_user4;
@@ -469,6 +544,9 @@ Tables for User SQL_USER4
 TRAFODION."T123SCH".GAMES
 TRAFODION."T123SCH".PLAYERS
 TRAFODION."T123SCH".TEAMS
+
+=======================
+ 3 row(s) returned
 
 --- SQL operation complete.
 >>get tables for user sql_user5;
@@ -483,6 +561,9 @@ TRAFODION."T123SCH".SB_HISTOGRAM_INTERVALS
 TRAFODION."T123SCH".SB_PERSISTENT_SAMPLES
 TRAFODION."T123SCH".TEAMS
 
+=======================
+ 6 row(s) returned
+
 --- SQL operation complete.
 >>
 >>get indexes for user sql_user1;
@@ -492,6 +573,9 @@ Indexes for User SQL_USER1
 
 TRAFODION."T123SCH".GAMES_VISITOR
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get indexes for user sql_user2;
 
@@ -499,6 +583,9 @@ Indexes for User SQL_USER2
 ==========================
 
 TRAFODION."T123SCH".GAMES_VISITOR
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get indexes for user sql_user3;
@@ -511,6 +598,9 @@ Indexes for User SQL_USER4
 
 TRAFODION."T123SCH".GAMES_VISITOR
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get indexes for user sql_user5;
 
@@ -518,6 +608,9 @@ Indexes for User SQL_USER5
 ==========================
 
 TRAFODION."T123SCH".GAMES_VISITOR
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -542,6 +635,9 @@ TRAFODION."T123SCH".GAMES_BY_PLAYER
 TRAFODION."T123SCH".HOME_TEAMS_GAMES
 TRAFODION."T123SCH".PLAYERS_ON_TEAM
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>
 >>get libraries for user sql_user1;
@@ -552,6 +648,9 @@ Libraries for User SQL_USER1
 DB__LIBMGRNAME
 DB__LIBMGR_LIB_CPP
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get libraries for user sql_user2;
 
@@ -560,6 +659,9 @@ Libraries for User SQL_USER2
 
 DB__LIBMGRNAME
 DB__LIBMGR_LIB_CPP
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>get libraries for user sql_user3;
@@ -570,6 +672,9 @@ Libraries for User SQL_USER3
 DB__LIBMGRNAME
 DB__LIBMGR_LIB_CPP
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get libraries for user sql_user4;
 
@@ -579,6 +684,9 @@ Libraries for User SQL_USER4
 DB__LIBMGRNAME
 DB__LIBMGR_LIB_CPP
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get libraries for user sql_user5;
 
@@ -587,6 +695,9 @@ Libraries for User SQL_USER5
 
 DB__LIBMGRNAME
 DB__LIBMGR_LIB_CPP
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -611,6 +722,9 @@ Users
 
 SQL_USER1
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get roles;
 
@@ -620,6 +734,9 @@ Roles
 PUBLIC
 T123_ADMINROLE
 T123_PLANNERROLE
+
+=======================
+ 3 row(s) returned
 
 --- SQL operation complete.
 >>get roles for user sql_user1;
@@ -631,6 +748,9 @@ PUBLIC
 T123_ADMINROLE
 T123_PLANNERROLE
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>get roles for user sql_user2;
 
@@ -638,6 +758,9 @@ Roles for User SQL_USER2
 ========================
 
 PUBLIC
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get roles for user sql_user3;
@@ -647,6 +770,9 @@ Roles for User SQL_USER3
 
 PUBLIC
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get roles for user sql_user4;
 
@@ -655,6 +781,9 @@ Roles for User SQL_USER4
 
 PUBLIC
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get roles for user sql_user5;
 
@@ -662,6 +791,9 @@ Roles for User SQL_USER5
 ========================
 
 PUBLIC
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -672,6 +804,9 @@ Users granted Role T123_ADMINROLE
 
 SQL_USER1
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get users for role t123_plannerrole;
 
@@ -679,6 +814,9 @@ Users granted Role T123_PLANNERROLE
 ===================================
 
 SQL_USER1
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get users for role t123_dummyrole;
@@ -707,6 +845,9 @@ S------    TRAFODION.T123SCH.PLAYERS <Column> PLAYER_TEAM_NUMBER
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NAME
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NUMBER
 
+=======================
+ 13 row(s) returned
+
 --- SQL operation complete.
 >>get privileges for user sql_user2;
 
@@ -729,6 +870,9 @@ Privileges for Role T123_ADMINROLE
 --DU---    TRAFODION.T123SCH.GAMES
 --DU---    TRAFODION.T123SCH.TEAMS
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get privileges for role t123_plannerrole;
 
@@ -738,6 +882,9 @@ Privileges for Role T123_PLANNERROLE
 -I-----    TRAFODION.T123SCH.GAMES
 ----G--    TRAFODION.T123SCH.PLAYERS_SEQUENCE
 -I-----    TRAFODION.T123SCH.TEAMS
+
+=======================
+ 3 row(s) returned
 
 --- SQL operation complete.
 >>get privileges for role t123_dummyrole;
@@ -759,6 +906,9 @@ S------    TRAFODION.T123SCH.PLAYERS <Column> PLAYER_TEAM_NUMBER
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NAME
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NUMBER
 
+=======================
+ 7 row(s) returned
+
 --- SQL operation complete.
 >>
 >>get tables for user sql_user1;
@@ -769,6 +919,9 @@ Tables for User SQL_USER1
 TRAFODION."T123SCH".GAMES
 TRAFODION."T123SCH".PLAYERS
 TRAFODION."T123SCH".TEAMS
+
+=======================
+ 3 row(s) returned
 
 --- SQL operation complete.
 >>get tables for user sql_user2;
@@ -798,6 +951,9 @@ Indexes for User SQL_USER1
 ==========================
 
 TRAFODION."T123SCH".GAMES_VISITOR
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get indexes for user sql_user2;
@@ -852,6 +1008,9 @@ Libraries for User SQL_USER1
 
 DB__LIBMGRNAME
 DB__LIBMGR_LIB_CPP
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>get libraries for user sql_user2;
@@ -900,6 +1059,9 @@ Users
 
 SQL_USER2
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get roles;
 
@@ -909,6 +1071,9 @@ Roles
 PUBLIC
 T123_PLANNERROLE
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get roles for user sql_user1;
 
@@ -916,6 +1081,9 @@ Roles for User SQL_USER1
 ========================
 
 PUBLIC
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get roles for user sql_user2;
@@ -926,6 +1094,9 @@ Roles for User SQL_USER2
 PUBLIC
 T123_PLANNERROLE
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get roles for user sql_user3;
 
@@ -933,6 +1104,9 @@ Roles for User SQL_USER3
 ========================
 
 PUBLIC
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get roles for user sql_user4;
@@ -942,6 +1116,9 @@ Roles for User SQL_USER4
 
 PUBLIC
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get roles for user sql_user5;
 
@@ -949,6 +1126,9 @@ Roles for User SQL_USER5
 ========================
 
 PUBLIC
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -961,6 +1141,9 @@ Users granted Role T123_PLANNERROLE
 ===================================
 
 SQL_USER2
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get users for role t123_dummyrole;
@@ -989,6 +1172,9 @@ S------    TRAFODION.T123SCH.PLAYERS <Column> PLAYER_TEAM_NUMBER
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NAME
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NUMBER
 
+=======================
+ 10 row(s) returned
+
 --- SQL operation complete.
 >>get privileges for user sql_user3;
 
@@ -1012,6 +1198,9 @@ Privileges for Role T123_PLANNERROLE
 ----G--    TRAFODION.T123SCH.PLAYERS_SEQUENCE
 -I-----    TRAFODION.T123SCH.TEAMS
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>get privileges for role t123_dummyrole;
 
@@ -1032,6 +1221,9 @@ S------    TRAFODION.T123SCH.PLAYERS <Column> PLAYER_TEAM_NUMBER
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NAME
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NUMBER
 
+=======================
+ 7 row(s) returned
+
 --- SQL operation complete.
 >>
 >>get tables for user sql_user1;
@@ -1047,6 +1239,9 @@ Tables for User SQL_USER2
 TRAFODION."T123SCH".GAMES
 TRAFODION."T123SCH".PLAYERS
 TRAFODION."T123SCH".TEAMS
+
+=======================
+ 3 row(s) returned
 
 --- SQL operation complete.
 >>get tables for user sql_user3;
@@ -1076,6 +1271,9 @@ Indexes for User SQL_USER2
 ==========================
 
 TRAFODION."T123SCH".GAMES_VISITOR
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get indexes for user sql_user3;
@@ -1131,6 +1329,9 @@ Libraries for User SQL_USER2
 DB__LIBMGRNAME
 DB__LIBMGR_LIB_CPP
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get libraries for user sql_user3;
 
@@ -1173,6 +1374,9 @@ Users
 
 SQL_USER3
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get roles;
 
@@ -1180,6 +1384,9 @@ Roles
 =====
 
 PUBLIC
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get roles for user sql_user1;
@@ -1189,6 +1396,9 @@ Roles for User SQL_USER1
 
 PUBLIC
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get roles for user sql_user2;
 
@@ -1196,6 +1406,9 @@ Roles for User SQL_USER2
 ========================
 
 PUBLIC
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get roles for user sql_user3;
@@ -1205,6 +1418,9 @@ Roles for User SQL_USER3
 
 PUBLIC
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get roles for user sql_user4;
 
@@ -1213,6 +1429,9 @@ Roles for User SQL_USER4
 
 PUBLIC
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get roles for user sql_user5;
 
@@ -1220,6 +1439,9 @@ Roles for User SQL_USER5
 ========================
 
 PUBLIC
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1255,6 +1477,9 @@ S------    TRAFODION.T123SCH.PLAYERS <Column> PLAYER_TEAM_NUMBER
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NAME
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NUMBER
 
+=======================
+ 7 row(s) returned
+
 --- SQL operation complete.
 >>get privileges for user sql_user4;
 
@@ -1288,6 +1513,9 @@ S------    TRAFODION.T123SCH.PLAYERS <Column> PLAYER_TEAM_NUMBER
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NAME
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NUMBER
 
+=======================
+ 7 row(s) returned
+
 --- SQL operation complete.
 >>
 >>get tables for user sql_user1;
@@ -1307,6 +1535,9 @@ Tables for User SQL_USER3
 
 TRAFODION."T123SCH".PLAYERS
 TRAFODION."T123SCH".TEAMS
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>get tables for user sql_user4;
@@ -1386,6 +1617,9 @@ Libraries for User SQL_USER3
 DB__LIBMGRNAME
 DB__LIBMGR_LIB_CPP
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get libraries for user sql_user4;
 
@@ -1423,6 +1657,9 @@ Users
 
 SQL_USER4
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get roles;
 
@@ -1430,6 +1667,9 @@ Roles
 =====
 
 PUBLIC
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get roles for user sql_user1;
@@ -1439,6 +1679,9 @@ Roles for User SQL_USER1
 
 PUBLIC
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get roles for user sql_user2;
 
@@ -1446,6 +1689,9 @@ Roles for User SQL_USER2
 ========================
 
 PUBLIC
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get roles for user sql_user3;
@@ -1455,6 +1701,9 @@ Roles for User SQL_USER3
 
 PUBLIC
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get roles for user sql_user4;
 
@@ -1463,6 +1712,9 @@ Roles for User SQL_USER4
 
 PUBLIC
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get roles for user sql_user5;
 
@@ -1470,6 +1722,9 @@ Roles for User SQL_USER5
 ========================
 
 PUBLIC
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1510,6 +1765,9 @@ S------    TRAFODION.T123SCH.TEAMS
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NAME
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NUMBER
 
+=======================
+ 9 row(s) returned
+
 --- SQL operation complete.
 >>get privileges for user sql_user5;
 
@@ -1540,6 +1798,9 @@ S------    TRAFODION.T123SCH.PLAYERS <Column> PLAYER_TEAM_NUMBER
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NAME
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NUMBER
 
+=======================
+ 7 row(s) returned
+
 --- SQL operation complete.
 >>
 >>get tables for user sql_user1;
@@ -1565,6 +1826,9 @@ Tables for User SQL_USER4
 TRAFODION."T123SCH".GAMES
 TRAFODION."T123SCH".PLAYERS
 TRAFODION."T123SCH".TEAMS
+
+=======================
+ 3 row(s) returned
 
 --- SQL operation complete.
 >>get tables for user sql_user5;
@@ -1594,6 +1858,9 @@ Indexes for User SQL_USER4
 ==========================
 
 TRAFODION."T123SCH".GAMES_VISITOR
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get indexes for user sql_user5;
@@ -1649,6 +1916,9 @@ Libraries for User SQL_USER4
 DB__LIBMGRNAME
 DB__LIBMGR_LIB_CPP
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get libraries for user sql_user5;
 
@@ -1681,6 +1951,9 @@ Users
 
 SQL_USER5
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get roles;
 
@@ -1690,6 +1963,9 @@ Roles
 PUBLIC
 T123_OWNERROLE
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get roles for user sql_user1;
 
@@ -1697,6 +1973,9 @@ Roles for User SQL_USER1
 ========================
 
 PUBLIC
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get roles for user sql_user2;
@@ -1706,6 +1985,9 @@ Roles for User SQL_USER2
 
 PUBLIC
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get roles for user sql_user3;
 
@@ -1713,6 +1995,9 @@ Roles for User SQL_USER3
 ========================
 
 PUBLIC
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get roles for user sql_user4;
@@ -1722,6 +2007,9 @@ Roles for User SQL_USER4
 
 PUBLIC
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get roles for user sql_user5;
 
@@ -1730,6 +2018,9 @@ Roles for User SQL_USER5
 
 PUBLIC
 T123_OWNERROLE
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1748,6 +2039,9 @@ Users granted Role T123_OWNERROLE
 =================================
 
 SQL_USER5
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1786,6 +2080,9 @@ SIDU-R-    TRAFODION.T123SCH.TEAMS
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NAME
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NUMBER
 
+=======================
+ 17 row(s) returned
+
 --- SQL operation complete.
 >>
 >>get privileges for role t123_adminrole;
@@ -1813,6 +2110,9 @@ SIDU-R-    TRAFODION.T123SCH.SB_HISTOGRAM_INTERVALS
 SIDU-R-    TRAFODION.T123SCH.SB_PERSISTENT_SAMPLES
 SIDU-R-    TRAFODION.T123SCH.TEAMS
 
+=======================
+ 10 row(s) returned
+
 --- SQL operation complete.
 >>get privileges for role "PUBLIC";
 
@@ -1826,6 +2126,9 @@ S------    TRAFODION.T123SCH.PLAYERS <Column> PLAYER_NUMBER
 S------    TRAFODION.T123SCH.PLAYERS <Column> PLAYER_TEAM_NUMBER
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NAME
 S------    TRAFODION.T123SCH.TEAMS <Column> TEAM_NUMBER
+
+=======================
+ 7 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1861,6 +2164,9 @@ TRAFODION."T123SCH".SB_HISTOGRAM_INTERVALS
 TRAFODION."T123SCH".SB_PERSISTENT_SAMPLES
 TRAFODION."T123SCH".TEAMS
 
+=======================
+ 6 row(s) returned
+
 --- SQL operation complete.
 >>
 >>get indexes for user sql_user1;
@@ -1889,6 +2195,9 @@ Indexes for User SQL_USER5
 ==========================
 
 TRAFODION."T123SCH".GAMES_VISITOR
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1921,6 +2230,9 @@ TRAFODION."T123SCH".GAMES_BY_PLAYER
 TRAFODION."T123SCH".HOME_TEAMS_GAMES
 TRAFODION."T123SCH".PLAYERS_ON_TEAM
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>
 >>get libraries for user sql_user1;
@@ -1950,6 +2262,9 @@ Libraries for User SQL_USER5
 
 DB__LIBMGRNAME
 DB__LIBMGR_LIB_CPP
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1981,6 +2296,9 @@ Roles for User UNKNOWN_USER
 ===========================
 
 PUBLIC
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get users for role unknown_role;

--- a/core/sql/regress/privs1/EXPECTED125
+++ b/core/sql/regress/privs1/EXPECTED125
@@ -497,6 +497,9 @@ SIDU-R-    TRAFODION.T125SCH3.PLAYERS
 ----G--    TRAFODION.T125SCH3.T125_L1
 ------E    TRAFODION.T125SCH3.TRANSLATEBITMAP
 
+=======================
+ 7 row(s) returned
+
 --- SQL operation complete.
 >>get privileges for user sql_user1;
 
@@ -510,6 +513,9 @@ Privileges for User SQL_USER1
 -I-----    TRAFODION.T125SCH3.GAMES
 S------    TRAFODION.T125SCH3.GAMES_BY_PLAYER
 S------    TRAFODION.T125SCH3.GAMES_BY_PLAYER <Column> PLAYER_NAME
+
+=======================
+ 7 row(s) returned
 
 --- SQL operation complete.
 >>get privileges for user sql_user2;
@@ -533,6 +539,9 @@ SIDU-R-    TRAFODION.T125SCH3.PLAYERS
 ----G--    TRAFODION.T125SCH3.T125_L1
 ------E    TRAFODION.T125SCH3.TRANSLATEBITMAP
 
+=======================
+ 15 row(s) returned
+
 --- SQL operation complete.
 >>get privileges for user sql_user7;
 
@@ -548,6 +557,9 @@ S------    TRAFODION.T125SCH2.TEAMS <Column> TEAM_NUMBER
 SIDU-R-    TRAFODION.T125SCH3.PLAYERS
 ----G--    TRAFODION.T125SCH3.T125_L1
 ------E    TRAFODION.T125SCH3.TRANSLATEBITMAP
+
+=======================
+ 9 row(s) returned
 
 --- SQL operation complete.
 >>get privileges for user sql_user8;
@@ -574,6 +586,9 @@ SIDU-R-    TRAFODION.T125SCH3.TEAMS
 ------E    TRAFODION.T125SCH3.TESTHIVE
 ------E    TRAFODION.T125SCH3.TRANSLATEBITMAP
 
+=======================
+ 18 row(s) returned
+
 --- SQL operation complete.
 >>
 >>set schema t125sch1;
@@ -588,6 +603,9 @@ Privileges on Table T125SCH1.GAMES
 SIDU-R-    DB__ROOT
 SIDU-R-    SQL_USER2
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on table games for sql_user1;
 
@@ -598,6 +616,9 @@ Privileges on Table T125SCH1.GAMES
 ==================================
 
 SIDU-R-    SQL_USER2
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on table games for sql_user7;
@@ -620,6 +641,9 @@ Privileges on View T125SCH1.GAMES_BY_PLAYER
 S----R-    DB__ROOT
 S------    SQL_USER2
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on view games_by_player for sql_user1;
 
@@ -630,6 +654,9 @@ Privileges on View T125SCH1.GAMES_BY_PLAYER
 ===========================================
 
 S------    SQL_USER2
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on view games_by_player for sql_user7;
@@ -652,6 +679,9 @@ Privileges on Sequence T125SCH1.T125_L1
 ---UG--    DB__ROOT
 ----G--    T125_ROLE1
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on library t125_l1 for sql_user1;
 
@@ -663,6 +693,9 @@ Privileges on Sequence T125SCH1.T125_L1
 
 ----G--    T125_ROLE1
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on library t125_l1 for sql_user7;
 
@@ -670,6 +703,9 @@ Privileges on Sequence T125SCH1.T125_L1
 =======================================
 
 ----G--    T125_ROLE1
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on library t125_l1 for sql_user8;
@@ -682,6 +718,9 @@ Privileges on Sequence T125SCH1.T125_L1
 
 ----G--    T125_ROLE1
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on library t125_l1 for t125_adminrole;
 
@@ -692,6 +731,9 @@ Privileges on Sequence T125SCH1.PLAYERS_SEQUENCE
 ================================================
 
 ----G--    DB__ROOT
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on sequence players_sequence for sql_user1;
@@ -726,6 +768,9 @@ SIDU-R-    DB__ROOT
 SIDU-R-    SQL_USER2
 S------    T125_ROLE1
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on table games for sql_user1;
 
@@ -738,6 +783,9 @@ Privileges on Table T125SCH2.GAMES
 SIDU-R-    SQL_USER2
 S------    T125_ROLE1
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on table games for sql_user7;
 
@@ -745,6 +793,9 @@ Privileges on Table T125SCH2.GAMES
 ==================================
 
 S------    T125_ROLE1
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on table games for sql_user8;
@@ -756,6 +807,9 @@ Privileges on Table T125SCH2.GAMES
 ==================================
 
 S------    T125_ROLE1
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on table games for t125_adminrole;
@@ -769,6 +823,9 @@ Privileges on View T125SCH2.GAMES_BY_PLAYER
 S----R-    DB__ROOT
 S------    SQL_USER2
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on view games_by_player for sql_user1;
 
@@ -779,6 +836,9 @@ Privileges on View T125SCH2.GAMES_BY_PLAYER
 ===========================================
 
 S------    SQL_USER2
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on view games_by_player for sql_user7;
@@ -801,6 +861,9 @@ Privileges on Sequence T125SCH2.T125_L1
 ---UG--    DB__ROOT
 ----G--    T125_ROLE1
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on library t125_l1 for sql_user1;
 
@@ -812,6 +875,9 @@ Privileges on Sequence T125SCH2.T125_L1
 
 ----G--    T125_ROLE1
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on library t125_l1 for sql_user7;
 
@@ -819,6 +885,9 @@ Privileges on Sequence T125SCH2.T125_L1
 =======================================
 
 ----G--    T125_ROLE1
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on library t125_l1 for sql_user8;
@@ -830,6 +899,9 @@ Privileges on Sequence T125SCH2.T125_L1
 =======================================
 
 ----G--    T125_ROLE1
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on library t125_l1 for t125_adminrole;
@@ -843,6 +915,9 @@ Privileges on Sequence T125SCH2.PLAYERS_SEQUENCE
 ----G--    DB__ROOT
 ----G--    SQL_USER1
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on sequence players_sequence for sql_user1;
 
@@ -850,6 +925,9 @@ Privileges on Sequence T125SCH2.PLAYERS_SEQUENCE
 ================================================
 
 ----G--    SQL_USER1
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on sequence players_sequence for sql_user2;
@@ -881,6 +959,9 @@ Privileges on Table T125SCH3.GAMES
 SIDU-R-    SQL_USER2
 SIDU-R-    T125_ADMINROLE
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on table games for sql_user1;
 
@@ -889,6 +970,9 @@ Privileges on Table T125SCH3.GAMES
 
 -I-----    SQL_USER1
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on table games for sql_user2;
 
@@ -896,6 +980,9 @@ Privileges on Table T125SCH3.GAMES
 ==================================
 
 SIDU-R-    SQL_USER2
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on table games for sql_user7;
@@ -908,6 +995,9 @@ Privileges on Table T125SCH3.GAMES
 
 SIDU-R-    T125_ADMINROLE
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on table games for t125_role1;
 
@@ -919,6 +1009,9 @@ Privileges on Table T125SCH3.GAMES
 
 SIDU-R-    T125_ADMINROLE
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on view games_by_player;
 
@@ -929,6 +1022,9 @@ S------    SQL_USER1
 S------    SQL_USER2
 S----R-    T125_ADMINROLE
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on view games_by_player for sql_user1;
 
@@ -937,6 +1033,9 @@ Privileges on View T125SCH3.GAMES_BY_PLAYER
 
 S------    SQL_USER1
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on view games_by_player for sql_user2;
 
@@ -944,6 +1043,9 @@ Privileges on View T125SCH3.GAMES_BY_PLAYER
 ===========================================
 
 S------    SQL_USER2
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on view games_by_player for sql_user7;
@@ -956,6 +1058,9 @@ Privileges on View T125SCH3.GAMES_BY_PLAYER
 
 S----R-    T125_ADMINROLE
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on view games_by_player for t125_role1;
 
@@ -967,6 +1072,9 @@ Privileges on View T125SCH3.GAMES_BY_PLAYER
 
 S----R-    T125_ADMINROLE
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on library t125_l1;
 
@@ -975,6 +1083,9 @@ Privileges on Sequence T125SCH3.T125_L1
 
 ---UG--    T125_ADMINROLE
 ----G--    T125_ROLE1
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on library t125_l1 for sql_user1;
@@ -987,6 +1098,9 @@ Privileges on Sequence T125SCH3.T125_L1
 
 ----G--    T125_ROLE1
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on library t125_l1 for sql_user7;
 
@@ -994,6 +1108,9 @@ Privileges on Sequence T125SCH3.T125_L1
 =======================================
 
 ----G--    T125_ROLE1
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on library t125_l1 for sql_user8;
@@ -1003,6 +1120,9 @@ Privileges on Sequence T125SCH3.T125_L1
 
 ---UG--    T125_ADMINROLE
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on library t125_l1 for t125_role1;
 
@@ -1010,6 +1130,9 @@ Privileges on Sequence T125SCH3.T125_L1
 =======================================
 
 ----G--    T125_ROLE1
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on library t125_l1 for t125_adminrole;
@@ -1019,6 +1142,9 @@ Privileges on Sequence T125SCH3.T125_L1
 
 ---UG--    T125_ADMINROLE
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on sequence players_sequence;
 
@@ -1026,6 +1152,9 @@ Privileges on Sequence T125SCH3.PLAYERS_SEQUENCE
 ================================================
 
 ----G--    T125_ADMINROLE
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on sequence players_sequence for sql_user1;
@@ -1044,6 +1173,9 @@ Privileges on Sequence T125SCH3.PLAYERS_SEQUENCE
 
 ----G--    T125_ADMINROLE
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on sequence players_sequence for t125_role1;
 
@@ -1054,6 +1186,9 @@ Privileges on Sequence T125SCH3.PLAYERS_SEQUENCE
 ================================================
 
 ----G--    T125_ADMINROLE
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1081,6 +1216,9 @@ T125SCH1
 T125SCH2
 T125SCH3
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>
 >>set schema t125sch1;
@@ -1098,6 +1236,9 @@ SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
 TEAMS
 
+=======================
+ 6 row(s) returned
+
 --- SQL operation complete.
 >>get views;
 
@@ -1108,6 +1249,9 @@ GAMES_BY_PLAYER
 HOME_TEAMS_GAMES
 PLAYERS_ON_TEAM
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>get indexes;
 
@@ -1115,6 +1259,9 @@ Indexes in Schema TRAFODION.T125SCH1
 ====================================
 
 PLAYERS_TEAMS
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get sequences, match 'T125SCH%';
@@ -1126,6 +1273,9 @@ T125SCH1.PLAYERS_SEQUENCE
 T125SCH2.PLAYERS_SEQUENCE
 T125SCH3.PLAYERS_SEQUENCE
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>get libraries, match 'T125%';
 
@@ -1135,6 +1285,9 @@ Libraries in Schema TRAFODION.T125SCH1
 T125_L1
 T125_L2
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get functions;
 
@@ -1143,6 +1296,9 @@ Functions in Schema TRAFODION.T125SCH1
 
 TRANSLATEBITMAP
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get procedures;
 
@@ -1150,6 +1306,9 @@ Procedures in Schema TRAFODION.T125SCH1
 =======================================
 
 TESTHIVE
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1160,6 +1319,9 @@ Indexes on Table T125SCH1.PLAYERS
 
 PLAYERS_TEAMS
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get views on table players;
 
@@ -1168,6 +1330,9 @@ Views on Table T125SCH1.PLAYERS
 
 TRAFODION.T125SCH1.PLAYERS_ON_TEAM
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get views on view players_on_team;
 
@@ -1175,6 +1340,9 @@ Views ON View T125SCH1.PLAYERS_ON_TEAM
 ======================================
 
 TRAFODION.T125SCH1.GAMES_BY_PLAYER
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1186,6 +1354,9 @@ Tables in View T125SCH1.GAMES_BY_PLAYER
 TRAFODION.T125SCH1.GAMES
 TRAFODION.T125SCH1.TEAMS
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get views in view games_by_player;
 
@@ -1193,6 +1364,9 @@ Views in View T125SCH1.GAMES_BY_PLAYER
 ======================================
 
 TRAFODION.T125SCH1.PLAYERS_ON_TEAM
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get objects in view games_by_player;
@@ -1203,6 +1377,9 @@ Objects in View T125SCH1.GAMES_BY_PLAYER
 TRAFODION.T125SCH1.GAMES
 TRAFODION.T125SCH1.PLAYERS_ON_TEAM
 TRAFODION.T125SCH1.TEAMS
+
+=======================
+ 3 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1221,6 +1398,9 @@ SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
 TEAMS
 
+=======================
+ 6 row(s) returned
+
 --- SQL operation complete.
 >>get views in schema t125sch2;
 
@@ -1231,6 +1411,9 @@ GAMES_BY_PLAYER
 HOME_TEAMS_GAMES
 PLAYERS_ON_TEAM
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>get indexes in schema t125sch2;
 
@@ -1239,6 +1422,9 @@ Indexes in Schema TRAFODION.T125SCH2
 
 PLAYERS_TEAMS
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get sequences in schema t125sch2;
 
@@ -1246,6 +1432,9 @@ Sequences in schema TRAFODION.T125SCH2
 ======================================
 
 PLAYERS_SEQUENCE
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get libraries in schema t125sch2;
@@ -1256,6 +1445,9 @@ Libraries in Schema TRAFODION.T125SCH2
 T125_L1
 T125_L2
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get functions in schema t125sch2;
 
@@ -1264,6 +1456,9 @@ Functions in Schema TRAFODION.T125SCH2
 
 TRANSLATEBITMAP
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get procedures in schema t125sch2;
 
@@ -1271,6 +1466,9 @@ Procedures in Schema TRAFODION.T125SCH2
 =======================================
 
 TESTHIVE
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1289,6 +1487,9 @@ SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
 TEAMS
 
+=======================
+ 6 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on table games;
 
@@ -1298,6 +1499,9 @@ Privileges on Table T125SCH3.GAMES
 -I-----    SQL_USER1
 SIDU-R-    SQL_USER2
 SIDU-R-    T125_ADMINROLE
+
+=======================
+ 3 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on table games for t125_role1;
@@ -1318,6 +1522,9 @@ T125SCH3.GAMES_BY_PLAYER
 T125SCH3.HOME_TEAMS_GAMES
 T125SCH3.PLAYERS_ON_TEAM
 
+=======================
+ 9 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on view games_by_player;
 
@@ -1328,6 +1535,9 @@ S------    SQL_USER1
 S------    SQL_USER2
 S----R-    T125_ADMINROLE
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on view games_by_player for user sql_user8;
 
@@ -1336,6 +1546,9 @@ Privileges on View T125SCH3.GAMES_BY_PLAYER
 
 S----R-    T125_ADMINROLE
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get indexes in schema t125sch3;
 
@@ -1343,6 +1556,9 @@ Indexes in Schema TRAFODION.T125SCH3
 ====================================
 
 PLAYERS_TEAMS
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get sequences in catalog trafodion, match 'T125SCH%';
@@ -1354,6 +1570,9 @@ T125SCH1.PLAYERS_SEQUENCE
 T125SCH2.PLAYERS_SEQUENCE
 T125SCH3.PLAYERS_SEQUENCE
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on sequence players_sequence;
 
@@ -1361,6 +1580,9 @@ Privileges on Sequence T125SCH3.PLAYERS_SEQUENCE
 ================================================
 
 ----G--    T125_ADMINROLE
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on sequence players_sequence for t125_role1;
@@ -1374,6 +1596,9 @@ Libraries in Schema TRAFODION.T125SCH3
 T125_L1
 T125_L2
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on library t125_l1;
 
@@ -1383,6 +1608,9 @@ Privileges on Sequence T125SCH3.T125_L1
 ---UG--    T125_ADMINROLE
 ----G--    T125_ROLE1
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on library t125_l1 for user sql_user8;
 
@@ -1390,6 +1618,9 @@ Privileges on Sequence T125SCH3.T125_L1
 =======================================
 
 ---UG--    T125_ADMINROLE
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get functions in schema t125sch3;
@@ -1399,6 +1630,9 @@ Functions in Schema TRAFODION.T125SCH3
 
 TRANSLATEBITMAP
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get procedures;
 
@@ -1406,6 +1640,9 @@ Procedures in Schema TRAFODION.T125SCH3
 =======================================
 
 TESTHIVE
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1416,6 +1653,9 @@ Functions for Library T125SCH3.T125_L1
 
 T125SCH3.TRANSLATEBITMAP
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get procedures for library t125_l2;
 
@@ -1423,6 +1663,9 @@ Procedures for Library T125SCH3.T125_L2
 =======================================
 
 T125SCH3.TESTHIVE
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1454,6 +1697,9 @@ T125SCH1
 T125SCH2
 T125SCH3
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>
 >>set schema t125sch1;
@@ -1474,6 +1720,9 @@ Sequences in catalog TRAFODION
 ==============================
 
 T125SCH3.PLAYERS_SEQUENCE
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get libraries, match 'T125%';
@@ -1546,6 +1795,9 @@ SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
 TEAMS
 
+=======================
+ 6 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on table games;
 
@@ -1553,6 +1805,9 @@ Privileges on Table T125SCH3.GAMES
 ==================================
 
 SIDU-R-    T125_ADMINROLE
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on table games for t125_role1;
@@ -1567,6 +1822,9 @@ T125SCH3.GAMES_BY_PLAYER
 T125SCH3.HOME_TEAMS_GAMES
 T125SCH3.PLAYERS_ON_TEAM
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on view games_by_player;
 
@@ -1575,6 +1833,9 @@ Privileges on View T125SCH3.GAMES_BY_PLAYER
 
 S----R-    T125_ADMINROLE
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on view games_by_player for user sql_user8;
 
@@ -1582,6 +1843,9 @@ Privileges on View T125SCH3.GAMES_BY_PLAYER
 ===========================================
 
 S----R-    T125_ADMINROLE
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get indexes in schema t125sch3;
@@ -1594,6 +1858,9 @@ Sequences in catalog TRAFODION
 
 T125SCH3.PLAYERS_SEQUENCE
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on sequence players_sequence;
 
@@ -1601,6 +1868,9 @@ Privileges on Sequence T125SCH3.PLAYERS_SEQUENCE
 ================================================
 
 ----G--    T125_ADMINROLE
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on sequence players_sequence for t125_role1;
@@ -1614,6 +1884,9 @@ Libraries in Schema TRAFODION.T125SCH3
 T125_L1
 T125_L2
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on library t125_l1;
 
@@ -1621,6 +1894,9 @@ Privileges on Sequence T125SCH3.T125_L1
 =======================================
 
 ---UG--    T125_ADMINROLE
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on library t125_l1 for user sql_user8;
@@ -1630,6 +1906,9 @@ Privileges on Sequence T125SCH3.T125_L1
 
 ---UG--    T125_ADMINROLE
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get functions in schema t125sch3;
 
@@ -1638,6 +1917,9 @@ Functions in Schema TRAFODION.T125SCH3
 
 TRANSLATEBITMAP
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get procedures;
 
@@ -1645,6 +1927,9 @@ Procedures in Schema TRAFODION.T125SCH3
 =======================================
 
 TESTHIVE
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1655,6 +1940,9 @@ Functions for Library T125SCH3.T125_L1
 
 T125SCH3.TRANSLATEBITMAP
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get procedures for library t125_l2;
 
@@ -1662,6 +1950,9 @@ Procedures for Library T125SCH3.T125_L2
 =======================================
 
 T125SCH3.TESTHIVE
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1692,6 +1983,9 @@ Schemas in Catalog TRAFODION
 T125SCH2
 T125SCH3
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>
 >>set schema t125sch1;
@@ -1712,6 +2006,9 @@ Sequences in catalog TRAFODION
 ==============================
 
 T125SCH2.PLAYERS_SEQUENCE
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get libraries, match 'T125%';
@@ -1763,6 +2060,9 @@ Sequences in schema TRAFODION.T125SCH2
 
 PLAYERS_SEQUENCE
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get libraries in schema t125sch2;
 
@@ -1770,6 +2070,9 @@ Libraries in Schema TRAFODION.T125SCH2
 ======================================
 
 T125_L2
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get functions in schema t125sch2;
@@ -1781,6 +2084,9 @@ Procedures in Schema TRAFODION.T125SCH2
 =======================================
 
 TESTHIVE
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1794,6 +2100,9 @@ Tables in Schema TRAFODION.T125SCH3
 
 GAMES
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on table games;
 
@@ -1801,6 +2110,9 @@ Privileges on Table T125SCH3.GAMES
 ==================================
 
 -I-----    SQL_USER1
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on table games for t125_role1;
@@ -1813,6 +2125,9 @@ Views in Catalog TRAFODION
 
 T125SCH3.GAMES_BY_PLAYER
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on view games_by_player;
 
@@ -1820,6 +2135,9 @@ Privileges on View T125SCH3.GAMES_BY_PLAYER
 ===========================================
 
 S------    SQL_USER1
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on view games_by_player for user sql_user8;
@@ -1834,6 +2152,9 @@ Sequences in catalog TRAFODION
 ==============================
 
 T125SCH2.PLAYERS_SEQUENCE
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on sequence players_sequence;
@@ -1893,6 +2214,9 @@ T125SCH1
 T125SCH2
 T125SCH3
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>
 >>set schema t125sch1;
@@ -1905,6 +2229,9 @@ Tables in Schema TRAFODION.T125SCH1
 
 GAMES
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get views;
 
@@ -1912,6 +2239,9 @@ Views in Schema TRAFODION.T125SCH1
 ==================================
 
 GAMES_BY_PLAYER
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get indexes;
@@ -1948,6 +2278,9 @@ Tables in View T125SCH1.GAMES_BY_PLAYER
 TRAFODION.T125SCH1.GAMES
 TRAFODION.T125SCH1.TEAMS
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get views in view games_by_player;
 
@@ -1955,6 +2288,9 @@ Views in View T125SCH1.GAMES_BY_PLAYER
 ======================================
 
 TRAFODION.T125SCH1.PLAYERS_ON_TEAM
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get objects in view games_by_player;
@@ -1965,6 +2301,9 @@ Objects in View T125SCH1.GAMES_BY_PLAYER
 TRAFODION.T125SCH1.GAMES
 TRAFODION.T125SCH1.PLAYERS_ON_TEAM
 TRAFODION.T125SCH1.TEAMS
+
+=======================
+ 3 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1979,6 +2318,9 @@ Tables in Schema TRAFODION.T125SCH2
 GAMES
 TEAMS
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get views in schema t125sch2;
 
@@ -1986,6 +2328,9 @@ Views in Schema TRAFODION.T125SCH2
 ==================================
 
 GAMES_BY_PLAYER
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get indexes in schema t125sch2;
@@ -2015,6 +2360,9 @@ Tables in Schema TRAFODION.T125SCH3
 GAMES
 PLAYERS
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on table games;
 
@@ -2022,6 +2370,9 @@ Privileges on Table T125SCH3.GAMES
 ==================================
 
 SIDU-R-    SQL_USER2
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on table games for t125_role1;
@@ -2036,6 +2387,9 @@ T125SCH1.GAMES_BY_PLAYER
 T125SCH2.GAMES_BY_PLAYER
 T125SCH3.GAMES_BY_PLAYER
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on view games_by_player;
 
@@ -2043,6 +2397,9 @@ Privileges on View T125SCH3.GAMES_BY_PLAYER
 ===========================================
 
 S------    SQL_USER2
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on view games_by_player for user sql_user8;
@@ -2067,6 +2424,9 @@ Libraries in Schema TRAFODION.T125SCH3
 
 T125_L1
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on library t125_l1;
 
@@ -2074,6 +2434,9 @@ Privileges on Sequence T125SCH3.T125_L1
 =======================================
 
 ----G--    T125_ROLE1
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on library t125_l1 for user sql_user8;
@@ -2086,6 +2449,9 @@ Functions in Schema TRAFODION.T125SCH3
 
 TRANSLATEBITMAP
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get procedures;
 
@@ -2097,6 +2463,9 @@ Functions for Library T125SCH3.T125_L1
 ======================================
 
 T125SCH3.TRANSLATEBITMAP
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get procedures for library t125_l2;
@@ -2131,6 +2500,9 @@ Schemas in Catalog TRAFODION
 T125SCH1
 T125SCH2
 T125SCH3
+
+=======================
+ 3 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -2190,6 +2562,9 @@ Tables in Schema TRAFODION.T125SCH2
 GAMES
 TEAMS
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get views in schema t125sch2;
 
@@ -2219,6 +2594,9 @@ Tables in Schema TRAFODION.T125SCH3
 ===================================
 
 PLAYERS
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on table games;
@@ -2255,6 +2633,9 @@ Libraries in Schema TRAFODION.T125SCH3
 
 T125_L1
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on library t125_l1;
 
@@ -2262,6 +2643,9 @@ Privileges on Sequence T125SCH3.T125_L1
 =======================================
 
 ----G--    T125_ROLE1
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on library t125_l1 for user sql_user8;
@@ -2274,6 +2658,9 @@ Functions in Schema TRAFODION.T125SCH3
 
 TRANSLATEBITMAP
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get procedures;
 
@@ -2285,6 +2672,9 @@ Functions for Library T125SCH3.T125_L1
 ======================================
 
 T125SCH3.TRANSLATEBITMAP
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get procedures for library t125_l2;

--- a/core/sql/regress/privs1/EXPECTED132
+++ b/core/sql/regress/privs1/EXPECTED132
@@ -21,6 +21,9 @@ Privilege information on Component SQL_OPERATIONS for PUBLIC
 CREATE_SCHEMA
 SHOW
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>
 >>-- succeed: DB__ROOT can create a library
@@ -41,6 +44,9 @@ Libraries in Schema TRAFODION.T132SCH
 =====================================
 
 T132_L1
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>drop library t132_l1;
@@ -102,6 +108,9 @@ Libraries in Schema TRAFODION.T132SCH
 =====================================
 
 T132_L1
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>drop library t132_l1;
@@ -171,6 +180,9 @@ Libraries in Schema TRAFODION.T132SCH
 
 T132_L1
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>drop library t132_l1;
 
@@ -198,6 +210,9 @@ Privilege information on Component SQL_OPERATIONS for PUBLIC
 
 CREATE_SCHEMA
 SHOW
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -248,6 +263,9 @@ Tables in Schema TRAFODION.T132SCH
 
 T132T1
 T132T2
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>cqd SHOWDDL_DISPLAY_PRIVILEGE_GRANTS 'ON';
@@ -649,6 +667,9 @@ Privilege information on Component SQL_OPERATIONS for PUBLIC
 CREATE_SCHEMA
 SHOW
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>revoke component privilege "SHOW" on sql_operations from "PUBLIC";
 
@@ -659,6 +680,9 @@ Privilege information on Component SQL_OPERATIONS for PUBLIC
 ============================================================
 
 CREATE_SCHEMA
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1265,6 +1289,9 @@ Privilege information on Component SQL_OPERATIONS for PUBLIC
 
 CREATE_SCHEMA
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>grant component privilege "SHOW" on sql_operations to "PUBLIC";
 
@@ -1276,6 +1303,9 @@ Privilege information on Component SQL_OPERATIONS for PUBLIC
 
 CREATE_SCHEMA
 SHOW
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>changeuser sql_user1;
@@ -1494,6 +1524,9 @@ Tables in Schema TRAFODION.T132SCH
 T132T1
 T132T2
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>select count(*) from t132t1;
 
@@ -1636,6 +1669,9 @@ Privilege information on Component SQL_OPERATIONS for PUBLIC
 CREATE_SCHEMA
 SHOW
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>revoke component privilege "SHOW" on sql_operations from "PUBLIC";
 
@@ -1646,6 +1682,9 @@ Privilege information on Component SQL_OPERATIONS for PUBLIC
 ============================================================
 
 CREATE_SCHEMA
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1708,6 +1747,9 @@ Privilege information on Component SQL_OPERATIONS for SQL_USER3
 ===============================================================
 
 MANAGE_STATISTICS
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>changeuser sql_user3;
@@ -1889,6 +1931,9 @@ Privilege information on Component SQL_OPERATIONS for SQL_USER3
 
 MANAGE_STATISTICS
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>changeuser sql_user3;
 >>obey TEST132(update_stats1);
@@ -1927,6 +1972,9 @@ Privilege information on Component SQL_OPERATIONS for PUBLIC
 
 CREATE_SCHEMA
 SHOW
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>

--- a/core/sql/regress/privs1/EXPECTED136
+++ b/core/sql/regress/privs1/EXPECTED136
@@ -249,6 +249,9 @@ SQL_USER7
 SQL_USER8
 SQL_USER9
 
+=======================
+ 11 row(s) returned
+
 --- SQL operation complete.
 >>
 >>-- succeed:  test unreserved words

--- a/core/sql/regress/privs1/EXPECTED141
+++ b/core/sql/regress/privs1/EXPECTED141
@@ -234,6 +234,9 @@ U1T2
 U1T3
 U1T4
 
+=======================
+ 4 row(s) returned
+
 --- SQL operation complete.
 >>
 >>set schema t141_user2;
@@ -259,6 +262,9 @@ Tables in Schema TRAFODION.T141_USER2
 U2T1
 U2T2
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>
 >>set schema t141_user3;
@@ -276,6 +282,9 @@ Tables in Schema TRAFODION.T141_USER3
 =====================================
 
 U3T1
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -343,6 +352,9 @@ Tables in Schema TRAFODION.T141_USER1
 
 U2T1
 U2T2
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -538,6 +550,9 @@ U1T2
 U1T3
 U1T4
 
+=======================
+ 4 row(s) returned
+
 --- SQL operation complete.
 >>
 >>set schema t141_user2;
@@ -563,6 +578,9 @@ Tables in Schema TRAFODION.T141_USER2
 U2T1
 U2T2
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>
 >>set schema t141_user3;
@@ -580,6 +598,9 @@ Tables in Schema TRAFODION.T141_USER3
 =====================================
 
 U3T1
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -675,6 +696,9 @@ Tables in Schema TRAFODION.T141_USER1
 
 U2T1
 U2T2
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1011,6 +1035,9 @@ Tables in Schema TRAFODION.T141_USER3
 
 U3T1
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get views;
 
@@ -1021,6 +1048,9 @@ U3V1
 U3V2
 U3V3
 U3V4
+
+=======================
+ 4 row(s) returned
 
 --- SQL operation complete.
 >>

--- a/core/sql/regress/privs2/EXPECTED135
+++ b/core/sql/regress/privs2/EXPECTED135
@@ -26,6 +26,9 @@ OBJECT_PRIVILEGES
 ROLE_USAGE
 SCHEMA_PRIVILEGES
 
+=======================
+ 7 row(s) returned
+
 --- SQL operation complete.
 >>
 >>-- Prepare metadata queries
@@ -902,6 +905,9 @@ DB__ROOTROLE
 PUBLIC
 T135_ROLE1
 
+=======================
+ 6 row(s) returned
+
 --- SQL operation complete.
 >>
 >>grant component privilege MANAGE_LIBRARY on sql_operations to t135_role1;
@@ -917,6 +923,9 @@ Privilege information on Component SQL_OPERATIONS for T135_ROLE1
 
 MANAGE_LIBRARY
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on component sql_operations for "PUBLIC";
 
@@ -926,6 +935,9 @@ Privilege information on Component SQL_OPERATIONS for PUBLIC
 CREATE_ROUTINE
 CREATE_SCHEMA
 SHOW
+
+=======================
+ 3 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1300,6 +1312,9 @@ Privilege information on Component SQL_OPERATIONS for PUBLIC
 CREATE_SCHEMA
 SHOW
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>
 >>revoke role t135_role1 from sql_user1;
@@ -1318,6 +1333,9 @@ DB__HIVEROLE
 DB__LIBMGRROLE
 DB__ROOTROLE
 PUBLIC
+
+=======================
+ 5 row(s) returned
 
 --- SQL operation complete.
 >>

--- a/core/sql/regress/privs2/EXPECTED138
+++ b/core/sql/regress/privs2/EXPECTED138
@@ -21,6 +21,9 @@ SB_HISTOGRAMS
 SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>
 >>-- Verify sql_user1 does not have CREATE or CREATE_TABLE privilege
@@ -36,6 +39,9 @@ Tables in Schema TRAFODION.T138SCH
 SB_HISTOGRAMS
 SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
+
+=======================
+ 3 row(s) returned
 
 --- SQL operation complete.
 >>create table user1_t1 (c1 int not null primary key, c2 int);
@@ -113,6 +119,9 @@ Privilege information on Component SQL_OPERATIONS for SQL_USER1
 
 CREATE_TABLE
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>sh sqlci -i "TEST138(create_tbl)" -u sql_user1;
 >>get tables;
@@ -123,6 +132,9 @@ Tables in Schema TRAFODION.T138SCH
 SB_HISTOGRAMS
 SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
+
+=======================
+ 3 row(s) returned
 
 --- SQL operation complete.
 >>create table user1_t1 (c1 int not null primary key, c2 int);
@@ -208,6 +220,9 @@ SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
 USER1_T1
 USER1_T2
+
+=======================
+ 5 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -402,6 +417,9 @@ SB_PERSISTENT_SAMPLES
 USER1_T1
 USER1_T2
 
+=======================
+ 5 row(s) returned
+
 --- SQL operation complete.
 >>drop table user1_t1 cascade;
 
@@ -424,6 +442,9 @@ SB_PERSISTENT_SAMPLES
 USER1_T1
 USER1_T2
 
+=======================
+ 5 row(s) returned
+
 --- SQL operation complete.
 >>
 >>exit;
@@ -441,6 +462,9 @@ SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
 USER1_T1
 USER1_T2
+
+=======================
+ 5 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -463,6 +487,9 @@ SB_PERSISTENT_SAMPLES
 USER1_T1
 USER1_T2
 
+=======================
+ 5 row(s) returned
+
 --- SQL operation complete.
 >>drop table user1_t1 cascade;
 
@@ -479,6 +506,9 @@ SB_HISTOGRAMS
 SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>
 >>
@@ -490,6 +520,9 @@ Tables in Schema TRAFODION.T138SCH
 SB_HISTOGRAMS
 SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
+
+=======================
+ 3 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -513,6 +546,9 @@ SB_HISTOGRAMS
 SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>
 >>-- Verify sql_user2 does not have ALTER or ALTER_TABLE privilege
@@ -533,6 +569,9 @@ Tables in Schema TRAFODION.T138SCH
 SB_HISTOGRAMS
 SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
+
+=======================
+ 3 row(s) returned
 
 --- SQL operation complete.
 >>create table user1_t1 (c1 int not null primary key, c2 int);
@@ -622,6 +661,9 @@ SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
 USER1_T1
 USER1_T2
+
+=======================
+ 5 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -820,6 +862,9 @@ SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
 USER1_T1
 USER1_T2
+
+=======================
+ 5 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1022,6 +1067,9 @@ ALTER_ROUTINE
 ALTER_SEQUENCE
 ALTER_VIEW
 
+=======================
+ 4 row(s) returned
+
 --- SQL operation complete.
 >>sh sqlci -i "TEST138(alter_tbl)" -u sql_user2;
 >>get tables;
@@ -1034,6 +1082,9 @@ SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
 USER1_T1
 USER1_T2
+
+=======================
+ 5 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1242,6 +1293,9 @@ SB_PERSISTENT_SAMPLES
 USER1_T1
 USER1_T2
 
+=======================
+ 5 row(s) returned
+
 --- SQL operation complete.
 >>drop table user1_t1 cascade;
 
@@ -1257,6 +1311,9 @@ Tables in Schema TRAFODION.T138SCH
 SB_HISTOGRAMS
 SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
+
+=======================
+ 3 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1274,6 +1331,9 @@ Privilege information on Component SQL_OPERATIONS for PUBLIC
 
 CREATE_SCHEMA
 SHOW
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on component sql_operations for sql_user1;
@@ -1312,6 +1372,9 @@ Tables in Schema TRAFODION.T138SCH
 SB_HISTOGRAMS
 SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
+
+=======================
+ 3 row(s) returned
 
 --- SQL operation complete.
 >>create table user1_t1 (c1 int not null primary key, c2 int);
@@ -1425,6 +1488,9 @@ Privilege information on Component SQL_OPERATIONS for SQL_USER1
 
 CREATE_VIEW
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>sh sqlci -i "TEST138(create_view)" -u sql_user1;
 >>get views;
@@ -1445,6 +1511,9 @@ Views in Schema TRAFODION.T138SCH
 USER1_V1
 USER1_V2
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>
 >>exit;
@@ -1461,6 +1530,9 @@ Views in Schema TRAFODION.T138SCH
 
 USER1_V1
 USER1_V2
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>drop view user1_v1;
@@ -1481,6 +1553,9 @@ Views in Schema TRAFODION.T138SCH
 USER1_V1
 USER1_V2
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>
 >>exit;
@@ -1499,6 +1574,9 @@ Privilege information on Component SQL_OPERATIONS for SQL_USER2
 
 DROP_VIEW
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>sh sqlci -i "TEST138(drop_view)" -u sql_user2;
 >>get views;
@@ -1508,6 +1586,9 @@ Views in Schema TRAFODION.T138SCH
 
 USER1_V1
 USER1_V2
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>drop view user1_v1;
@@ -1557,6 +1638,9 @@ SB_PERSISTENT_SAMPLES
 USER1_T1
 USER1_T2
 
+=======================
+ 5 row(s) returned
+
 --- SQL operation complete.
 >>drop table user1_t1 cascade;
 
@@ -1572,6 +1656,9 @@ Tables in Schema TRAFODION.T138SCH
 SB_HISTOGRAMS
 SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
+
+=======================
+ 3 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1630,6 +1717,9 @@ Privilege information on Component SQL_OPERATIONS for SQL_USER1
 
 CREATE_SEQUENCE
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>sh sqlci -i "TEST138(create_sequence)" -u sql_user1;
 >>get sequences in schema t138sch;
@@ -1649,6 +1739,9 @@ Sequences in schema TRAFODION.T138SCH
 USER1_SEQ1
 USER1_SEQ2
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>
 >>exit;
@@ -1665,6 +1758,9 @@ Sequences in schema TRAFODION.T138SCH
 
 USER1_SEQ1
 USER1_SEQ2
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>drop sequence user1_seq1;
@@ -1685,6 +1781,9 @@ Sequences in schema TRAFODION.T138SCH
 USER1_SEQ1
 USER1_SEQ2
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>
 >>exit;
@@ -1703,6 +1802,9 @@ Privilege information on Component SQL_OPERATIONS for SQL_USER2
 
 DROP_SEQUENCE
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>sh sqlci -i "TEST138(drop_sequence)" -u sql_user2;
 >>get sequences in schema t138sch;
@@ -1712,6 +1814,9 @@ Sequences in schema TRAFODION.T138SCH
 
 USER1_SEQ1
 USER1_SEQ2
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>drop sequence user1_seq1;

--- a/core/sql/regress/privs2/EXPECTED140
+++ b/core/sql/regress/privs2/EXPECTED140
@@ -209,6 +209,9 @@ SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
 TEAMS
 
+=======================
+ 6 row(s) returned
+
 --- SQL operation complete.
 >>
 >>

--- a/core/sql/regress/privs2/EXPECTED143
+++ b/core/sql/regress/privs2/EXPECTED143
@@ -442,6 +442,9 @@ SB_HISTOGRAMS
 SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>get views;
 
@@ -452,6 +455,9 @@ U3V1
 U3V2
 U3V3
 U3V4
+
+=======================
+ 4 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -800,6 +806,9 @@ SB_HISTOGRAMS
 SB_HISTOGRAM_INTERVALS
 SB_PERSISTENT_SAMPLES
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>get views;
 
@@ -810,6 +819,9 @@ U3V1
 U3V2
 U3V3
 U3V4
+
+=======================
+ 4 row(s) returned
 
 --- SQL operation complete.
 >>

--- a/core/sql/regress/privs2/EXPECTED144
+++ b/core/sql/regress/privs2/EXPECTED144
@@ -140,6 +140,9 @@ Privilege information on Component SQL_OPERATIONS for PUBLIC
 
 CREATE_SCHEMA
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>
 >>obey TEST144(set_up);
@@ -195,6 +198,9 @@ Privileges on Routine T144USER1.GEN_PHONE
 
 ------E    SQL_USER1
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on function gen_random;
 
@@ -203,6 +209,9 @@ Privileges on Routine T144USER1.GEN_RANDOM
 
 ------E    SQL_USER1
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on function gen_time;
 
@@ -210,6 +219,9 @@ Privileges on Routine T144USER1.GEN_TIME
 ========================================
 
 ------E    SQL_USER1
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on procedure "_LIBMGR_".help;
@@ -220,6 +232,9 @@ Privileges on Routine _LIBMGR_.HELP
 ------E    DB__LIBMGRROLE
 ------E    DB__ROOT
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on table_mapping function "_LIBMGR_".event_log_reader;
 
@@ -228,6 +243,9 @@ Privileges on Routine _LIBMGR_.EVENT_LOG_READER
 
 ------E    DB__ROOT
 ------E    PUBLIC
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -240,6 +258,9 @@ Privileges on Routine T144USER1.GEN_PHONE
 
 ------E    SQL_USER1
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on procedure "_LIBMGR_".help for sql_user1;
 
@@ -250,6 +271,9 @@ Privileges on Routine _LIBMGR_.EVENT_LOG_READER
 ===============================================
 
 ------E    PUBLIC
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>sh sqlci -i "TEST144(cmds)" -u sql_user1;
@@ -272,6 +296,9 @@ Privileges on Routine T144USER1.GEN_TIME
 
 ------E    SQL_USER1
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>-- should return no rows for users other than sql_user1
 >>get privileges on function gen_random for sql_user1;
@@ -280,6 +307,9 @@ Privileges on Routine T144USER1.GEN_RANDOM
 ==========================================
 
 ------E    SQL_USER1
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>select customer_id, 
@@ -579,6 +609,9 @@ Privileges on Routine T144USER1.GEN_PHONE
 
 ------E    SQL_USER2
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on function gen_random for sql_user2;
 
@@ -587,6 +620,9 @@ Privileges on Routine T144USER1.GEN_RANDOM
 
 ------E    SQL_USER2
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>get privileges on function gen_time for user sql_user2;
 
@@ -594,6 +630,9 @@ Privileges on Routine T144USER1.GEN_TIME
 ========================================
 
 ------E    SQL_USER2
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on procedure "_LIBMGR_".help for user sql_user2;
@@ -646,6 +685,9 @@ Privileges on Routine T144USER1.GEN_TIME
 ========================================
 
 ------E    SQL_USER2
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>-- should return no rows for users other than sql_user1
@@ -816,6 +858,9 @@ Privileges on Routine T144USER1.GEN_PHONE
 =========================================
 
 ------E    SQL_USER3
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get privileges on function gen_random for user sql_user3;

--- a/core/sql/regress/privs2/EXPECTED146
+++ b/core/sql/regress/privs2/EXPECTED146
@@ -146,6 +146,9 @@ HBase Registered Tables in Catalog TRAFODION
 "_ROW_".T146T1
 "_ROW_".T146T3
 
+=======================
+ 4 row(s) returned
+
 --- SQL operation complete.
 >>
 >>create role t146_role1;
@@ -167,6 +170,9 @@ Privilege information on Component SQL_OPERATIONS for PUBLIC
 ============================================================
 
 CREATE_SCHEMA
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>get external hbase objects, match '%T146%';
@@ -518,6 +524,9 @@ HBase Registered Tables in Catalog TRAFODION
 "_CELL_".T146T1
 "_ROW_".T146T1
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>exit;
 
@@ -667,6 +676,9 @@ HBase Registered Tables in Catalog TRAFODION
 
 "_CELL_".T146T1
 "_ROW_".T146T1
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>exit;
@@ -822,6 +834,9 @@ HBase Registered Tables in Catalog TRAFODION
 
 "_CELL_".T146T1
 "_ROW_".T146T1
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>exit;
@@ -1094,6 +1109,9 @@ HBase Registered Tables in Catalog TRAFODION
 "_ROW_".T146T1
 "_ROW_".T146T3
 
+=======================
+ 4 row(s) returned
+
 --- SQL operation complete.
 >>exit;
 
@@ -1259,6 +1277,9 @@ HBase Registered Tables in Catalog TRAFODION
 
 "_CELL_".T146T1
 "_ROW_".T146T1
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>exit;
@@ -1524,6 +1545,9 @@ HBase Registered Tables in Catalog TRAFODION
 
 "_CELL_".T146T1
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>exit;
 
@@ -1586,6 +1610,9 @@ SIDU-R-    HBASE._ROW_.T146T3
 SIDU-R-    TRAFODION._HB_MAP_.T146T1
 SIDU-R-    TRAFODION._HB_MAP_.T146T2
 
+=======================
+ 6 row(s) returned
+
 --- SQL operation complete.
 >>
 >>drop hbase table t146t2;
@@ -1601,6 +1628,9 @@ SIDU-R-    HBASE._CELL_.T146T3
 SIDU-R-    HBASE._ROW_.T146T1
 SIDU-R-    HBASE._ROW_.T146T3
 SIDU-R-    TRAFODION._HB_MAP_.T146T1
+
+=======================
+ 5 row(s) returned
 
 --- SQL operation complete.
 >>
@@ -1722,6 +1752,9 @@ SIDU-R-    HBASE._ROW_.T146T3
 SIDU-R-    TRAFODION._HB_MAP_.T146T1
 SIDU-R-    TRAFODION._HB_MAP_.T146T2
 
+=======================
+ 6 row(s) returned
+
 --- SQL operation complete.
 >>
 >>drop hbase table t146t2;
@@ -1737,6 +1770,9 @@ SIDU-R-    HBASE._CELL_.T146T3
 SIDU-R-    HBASE._ROW_.T146T1
 SIDU-R-    HBASE._ROW_.T146T3
 SIDU-R-    TRAFODION._HB_MAP_.T146T1
+
+=======================
+ 4 row(s) returned
 
 --- SQL operation complete.
 >>

--- a/core/sql/regress/seabase/EXPECTED011
+++ b/core/sql/regress/seabase/EXPECTED011
@@ -1296,9 +1296,7 @@ METRIC_SESSION_TABLE
 METRIC_TEXT_TABLE
 
 =======================
-Summary info of get:
-Get 4 rows.
-
+ 4 row(s) returned
 
 --- SQL operation complete.
 >>invoke trafodion."_REPOS_".metric_query_table;

--- a/core/sql/regress/seabase/EXPECTED011
+++ b/core/sql/regress/seabase/EXPECTED011
@@ -1299,6 +1299,7 @@ METRIC_TEXT_TABLE
 Summary info of get:
 Get 4 rows.
 
+
 --- SQL operation complete.
 >>invoke trafodion."_REPOS_".metric_query_table;
 

--- a/core/sql/regress/seabase/EXPECTED011
+++ b/core/sql/regress/seabase/EXPECTED011
@@ -1295,6 +1295,10 @@ METRIC_QUERY_TABLE
 METRIC_SESSION_TABLE
 METRIC_TEXT_TABLE
 
+=======================
+Summary info of get:
+Get 4 rows.
+
 --- SQL operation complete.
 >>invoke trafodion."_REPOS_".metric_query_table;
 

--- a/core/sql/regress/seabase/EXPECTED012
+++ b/core/sql/regress/seabase/EXPECTED012
@@ -289,6 +289,10 @@ SB_PERSISTENT_SAMPLES
 T012T11
 T012T12
 
+=======================
+Summary info of get:
+Get 5 rows.
+
 --- SQL operation complete.
 >>get indexes in schema trafodion.zschema;
 
@@ -300,6 +304,10 @@ T012T11C2
 T012T11I1
 T012T11I2
 
+=======================
+Summary info of get:
+Get 4 rows.
+
 --- SQL operation complete.
 >>get views in schema trafodion.zschema;
 
@@ -307,6 +315,10 @@ Views in Schema TRAFODION.ZSCHEMA
 =================================
 
 T012T11V1
+
+=======================
+Summary info of get:
+Get 1 rows.
 
 --- SQL operation complete.
 >>
@@ -316,11 +328,26 @@ T012T11V1
 >>
 >>get tables in schema trafodion.zschema;
 
+
+=======================
+Summary info of get:
+Get 0 rows.
+
 --- SQL operation complete.
 >>get indexes in schema trafodion.zschema;
 
+
+=======================
+Summary info of get:
+Get 0 rows.
+
 --- SQL operation complete.
 >>get views in schema trafodion.zschema;
+
+
+=======================
+Summary info of get:
+Get 0 rows.
 
 --- SQL operation complete.
 >>
@@ -364,6 +391,10 @@ Tables in View ZSCHEMA1.V
 TRAFODION.ZSCHEMA1.T
 TRAFODION.ZSCHEMA2.T
 
+=======================
+Summary info of get:
+Get 2 rows.
+
 --- SQL operation complete.
 >>get views on table zschema1.t;
 
@@ -372,6 +403,10 @@ Views on Table ZSCHEMA1.T
 
 TRAFODION.ZSCHEMA1.V
 TRAFODION.ZSCHEMA2.V
+
+=======================
+Summary info of get:
+Get 2 rows.
 
 --- SQL operation complete.
 >>
@@ -382,6 +417,10 @@ Tables in View ZSCHEMA2.V2
 
 TRAFODION.ZSCHEMA2.T
 
+=======================
+Summary info of get:
+Get 1 rows.
+
 --- SQL operation complete.
 >>get all tables in view zschema2.v2;
 
@@ -391,6 +430,10 @@ Tables in View ZSCHEMA2.V2
 TRAFODION.ZSCHEMA1.T
 TRAFODION.ZSCHEMA2.T
 
+=======================
+Summary info of get:
+Get 2 rows.
+
 --- SQL operation complete.
 >>get views in view zschema2.v2;
 
@@ -398,6 +441,10 @@ Views in View ZSCHEMA2.V2
 =========================
 
 TRAFODION.ZSCHEMA1.V
+
+=======================
+Summary info of get:
+Get 1 rows.
 
 --- SQL operation complete.
 >>get all objects in view zschema2.v2;
@@ -408,6 +455,11 @@ Objects in View ZSCHEMA2.V2
 TRAFODION.ZSCHEMA1.T
 TRAFODION.ZSCHEMA1.V
 TRAFODION.ZSCHEMA2.T
+
+
+=======================
+Summary info of get:
+Get 3 rows.
 
 --- SQL operation complete.
 >>

--- a/core/sql/regress/seabase/EXPECTED022
+++ b/core/sql/regress/seabase/EXPECTED022
@@ -1339,12 +1339,6 @@ REGISTER HBASE TABLE T022HBM2;
 --- SQL operation complete.
 >>get hbase registered tables in catalog trafodion, match '%T022HBM2%';
 
-
-=======================
-Summary info of get:
-Get 0 rows.
-
-
 --- SQL operation complete.
 >>showddl hbase."_CELL_".t022hbm2;
 

--- a/core/sql/regress/seabase/EXPECTED022
+++ b/core/sql/regress/seabase/EXPECTED022
@@ -1268,6 +1268,8 @@ HBase Registered Tables in Catalog TRAFODION
 =======================
 Summary info of get:
 Get 2 rows.
+
+
 --- SQL operation complete.
 >>unregister hbase table t022hbm2;
 
@@ -1286,6 +1288,8 @@ HBase Registered Tables in Catalog TRAFODION
 =======================
 Summary info of get:
 Get 2 rows.
+
+
 --- SQL operation complete.
 >>showddl hbase."_CELL_".t022hbm2;
 
@@ -1344,6 +1348,7 @@ REGISTER HBASE TABLE T022HBM2;
 Summary info of get:
 Get 0 rows.
 
+
 --- SQL operation complete.
 >>showddl hbase."_CELL_".t022hbm2;
 
@@ -1398,6 +1403,8 @@ HBase Registered Tables in Catalog TRAFODION
 =======================
 Summary info of get:
 Get 1 rows.
+
+
 --- SQL operation complete.
 >>showddl hbase."_CELL_".t022hbm2;
 
@@ -1466,6 +1473,8 @@ HBase Registered Tables in Catalog TRAFODION
 =======================
 Summary info of get:
 Get 1 rows.
+
+
 --- SQL operation complete.
 >>showddl hbase."_CELL_".t022hbm2;
 

--- a/core/sql/regress/seabase/EXPECTED022
+++ b/core/sql/regress/seabase/EXPECTED022
@@ -1265,6 +1265,9 @@ HBase Registered Tables in Catalog TRAFODION
 "_CELL_".T022HBM2
 "_ROW_".T022HBM2
 
+=======================
+Summary info of get:
+Get 2 rows.
 --- SQL operation complete.
 >>unregister hbase table t022hbm2;
 
@@ -1280,6 +1283,9 @@ HBase Registered Tables in Catalog TRAFODION
 "_CELL_".T022HBM2
 "_ROW_".T022HBM2
 
+=======================
+Summary info of get:
+Get 2 rows.
 --- SQL operation complete.
 >>showddl hbase."_CELL_".t022hbm2;
 
@@ -1333,6 +1339,11 @@ REGISTER HBASE TABLE T022HBM2;
 --- SQL operation complete.
 >>get hbase registered tables in catalog trafodion, match '%T022HBM2%';
 
+
+=======================
+Summary info of get:
+Get 0 rows.
+
 --- SQL operation complete.
 >>showddl hbase."_CELL_".t022hbm2;
 
@@ -1384,6 +1395,9 @@ HBase Registered Tables in Catalog TRAFODION
 
 "_CELL_".T022HBM2
 
+=======================
+Summary info of get:
+Get 1 rows.
 --- SQL operation complete.
 >>showddl hbase."_CELL_".t022hbm2;
 
@@ -1449,6 +1463,9 @@ HBase Registered Tables in Catalog TRAFODION
 
 "_CELL_".T022HBM2
 
+=======================
+Summary info of get:
+Get 1 rows.
 --- SQL operation complete.
 >>showddl hbase."_CELL_".t022hbm2;
 

--- a/core/sql/regress/seabase/EXPECTED022
+++ b/core/sql/regress/seabase/EXPECTED022
@@ -1266,9 +1266,7 @@ HBase Registered Tables in Catalog TRAFODION
 "_ROW_".T022HBM2
 
 =======================
-Summary info of get:
-Get 2 rows.
-
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>unregister hbase table t022hbm2;
@@ -1286,9 +1284,7 @@ HBase Registered Tables in Catalog TRAFODION
 "_ROW_".T022HBM2
 
 =======================
-Summary info of get:
-Get 2 rows.
-
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>showddl hbase."_CELL_".t022hbm2;
@@ -1401,9 +1397,7 @@ HBase Registered Tables in Catalog TRAFODION
 "_CELL_".T022HBM2
 
 =======================
-Summary info of get:
-Get 1 rows.
-
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>showddl hbase."_CELL_".t022hbm2;
@@ -1471,9 +1465,7 @@ HBase Registered Tables in Catalog TRAFODION
 "_CELL_".T022HBM2
 
 =======================
-Summary info of get:
-Get 1 rows.
-
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>showddl hbase."_CELL_".t022hbm2;

--- a/core/sql/regress/seabase/EXPECTED031
+++ b/core/sql/regress/seabase/EXPECTED031
@@ -1072,6 +1072,10 @@ Catalogs
 TRAFODION
 HIVE
 
+=======================
+Summary info of get:
+Get 2 rows.
+
 --- SQL operation complete.
 >>
 >>-- external and hive table mismatch on hive 'string' datatype

--- a/core/sql/regress/seabase/EXPECTED031
+++ b/core/sql/regress/seabase/EXPECTED031
@@ -1076,6 +1076,7 @@ HIVE
 Summary info of get:
 Get 2 rows.
 
+
 --- SQL operation complete.
 >>
 >>-- external and hive table mismatch on hive 'string' datatype

--- a/core/sql/regress/seabase/EXPECTED031
+++ b/core/sql/regress/seabase/EXPECTED031
@@ -1073,9 +1073,7 @@ TRAFODION
 HIVE
 
 =======================
-Summary info of get:
-Get 2 rows.
-
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>

--- a/core/sql/regress/udr/EXPECTED001
+++ b/core/sql/regress/udr/EXPECTED001
@@ -231,6 +231,9 @@ SCH.Fibonacci
 SCH.SESSIONIZE_DYNAMIC
 SCH.SESSIONIZE_DYNAMIC_SHARED
 
+=======================
+ 3 row(s) returned
+
 --- SQL operation complete.
 >>
 >>showddl table_mapping function sessionize_dynamic;
@@ -257,6 +260,9 @@ Table_mapping Functions for Library SCH.TEST001_JAVA
 
 SCH.FIBONACCI_JAVA
 SCH.SESSIONIZE_JAVA
+
+=======================
+ 2 row(s) returned
 
 --- SQL operation complete.
 >>

--- a/core/sql/regress/udr/EXPECTED102
+++ b/core/sql/regress/udr/EXPECTED102
@@ -53,6 +53,9 @@ Libraries in Schema TRAFODION._LIBMGR_
 DB__LIBMGRNAME
 DB__LIBMGR_LIB_CPP
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get procedures;
 
@@ -70,6 +73,9 @@ PUT
 PUTFILE
 RM
 RMREX
+
+=======================
+ 11 row(s) returned
 
 --- SQL operation complete.
 >>showddl procedure rm;
@@ -127,6 +133,9 @@ DB__LIBMGRROLE
 DB__ROOTROLE
 PUBLIC
 
+=======================
+ 5 row(s) returned
+
 --- SQL operation complete.
 >>showddl procedure rm;
 
@@ -178,6 +187,9 @@ Roles
 
 PUBLIC
 
+=======================
+ 1 row(s) returned
+
 --- SQL operation complete.
 >>
 >>-- ****************************************************************************
@@ -210,6 +222,9 @@ DB__LIBMGRROLE
 DB__ROOTROLE
 PUBLIC
 
+=======================
+ 5 row(s) returned
+
 --- SQL operation complete.
 >>
 >>-- enable library management
@@ -236,6 +251,9 @@ Libraries in Schema TRAFODION._LIBMGR_
 DB__LIBMGRNAME
 DB__LIBMGR_LIB_CPP
 
+=======================
+ 2 row(s) returned
+
 --- SQL operation complete.
 >>get procedures;
 
@@ -253,6 +271,9 @@ PUT
 PUTFILE
 RM
 RMREX
+
+=======================
+ 11 row(s) returned
 
 --- SQL operation complete.
 >>showddl procedure rm;
@@ -319,6 +340,9 @@ PUTFILE
 RM
 RMREX
 
+=======================
+ 9 row(s) returned
+
 --- SQL operation complete.
 >>call ls(?);
 
@@ -346,6 +370,9 @@ PUT
 PUTFILE
 RM
 RMREX
+
+=======================
+ 11 row(s) returned
 
 --- SQL operation complete.
 >>showddl procedure put;
@@ -418,6 +445,9 @@ PUT
 PUTFILE
 RM
 RMREX
+
+=======================
+ 11 row(s) returned
 
 --- SQL operation complete.
 >>

--- a/core/sql/regress/udr/EXPECTED103
+++ b/core/sql/regress/udr/EXPECTED103
@@ -553,6 +553,9 @@ GENERATEPHONENUMBER
 GENERATERANDOMNUMBER
 NONDETERMINISTICRANDOM
 
+=======================
+ 4 row(s) returned
+
 --- SQL operation complete.
 >>get procedures in schema udr103sch;
 
@@ -560,6 +563,9 @@ Procedures in Schema TRAFODION.UDR103SCH
 ========================================
 
 UPDATESUBSCRIPTIONS
+
+=======================
+ 1 row(s) returned
 
 --- SQL operation complete.
 >>showddl function generatePhoneNumber;

--- a/core/sql/regress/udr/EXPECTED107.SB
+++ b/core/sql/regress/udr/EXPECTED107.SB
@@ -482,6 +482,9 @@ SCH.VALIDATE_CURRENT_ROLE_NAME
 SCH.VALIDATE_CURRENT_USER_NAME
 SCH.VALIDATE_SESSION_USER_NAME
 
+=======================
+ 37 row(s) returned
+
 --- SQL operation complete.
 >>
 >>showddl function errorwarn ;


### PR DESCRIPTION
At field, engineers issue get tables to list all tables, and want to count how many tables got, it will be good to show that info by 'get' command itself.
The current implementation is to show that count as part of get command output, just as header info.