### PR TITLE
[TRAFODION-3124] initialize session name in connection string

### DIFF
--- a/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/cconnect.cpp
+++ b/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/cconnect.cpp
@@ -815,6 +815,7 @@ SQLRETURN CConnect::Connect(SQLCHAR *ServerName,
 	// populate the inContext
 	inContext.location[0] = '\0';
 	inContext.userRole[0] = '\0';
+    inContext.sessionName[0] = '\0';
 
 	// we need to keep the following in UTF8 internally
 	// m_DSValue.m_DSSchema, m_DSValue.m_DSServerDSName, m_DSValue.m_DSName

--- a/win-odbc64/odbcclient/drvr35/cconnect.cpp
+++ b/win-odbc64/odbcclient/drvr35/cconnect.cpp
@@ -611,6 +611,7 @@ SQLRETURN CConnect::Connect(SQLCHAR *ServerName,
 	// populate the inContext
 	inContext.location[0] = '\0';
 	inContext.userRole[0] = '\0';
+    inContext.sessionName[0] = '\0';
 
 	if (m_DSValue.m_DSServerDSName[0] != 0)
 		strcpy(inContext.datasource, m_DSValue.m_DSServerDSName);


### PR DESCRIPTION
 SQLConnect returns failure when the connection string has an incorrect value  which is"sessionName":"10".
The sessionName is an uninitialized variable.