### PR TITLE
[TRAFODION-3126] Refactored HDFS client implementation should also su…

### DIFF
--- a/core/sql/pom.xml
+++ b/core/sql/pom.xml
@@ -84,6 +84,12 @@
       <artifactId>protobuf-java</artifactId>
       <version>2.5.0</version>
     </dependency>
+    <dependency>
+       <groupId>org.alluxio</groupId>
+       <artifactId>alluxio-core-client-runtime</artifactId>
+       <scope>compile</scope>
+       <version>1.7.1</version>
+    </dependency>
   </dependencies>
 
   <groupId>org.trafodion.sql</groupId>

--- a/core/sql/pom.xml.apache
+++ b/core/sql/pom.xml.apache
@@ -119,6 +119,12 @@
       <artifactId>protobuf-java</artifactId>
       <version>2.5.0</version>
     </dependency>
+    <dependency>
+       <groupId>org.alluxio</groupId>
+       <artifactId>alluxio-core-client-runtime</artifactId>
+       <scope>compile</scope>
+       <version>1.7.1</version>
+    </dependency>
   </dependencies>
 
   <groupId>org.trafodion.sql</groupId>

--- a/core/sql/pom.xml.hdp
+++ b/core/sql/pom.xml.hdp
@@ -99,6 +99,12 @@
       <artifactId>protobuf-java</artifactId>
       <version>2.5.0</version>
     </dependency>
+    <dependency>
+       <groupId>org.alluxio</groupId>
+       <artifactId>alluxio-core-client-runtime</artifactId>
+       <scope>compile</scope>
+       <version>1.7.1</version>
+    </dependency>
   </dependencies>
 
   <groupId>org.trafodion.sql</groupId>


### PR DESCRIPTION
…pport Alluxio file system

Alluxio doesn't support direct ByteBuffer access. Circumvented
this problem by using non-direct ByteBuffer to read hdfs files
when it belongs to Alluxio file system.

No need to change the default setting of USE_LIBHDFS for Alluxio to work.