### PR TITLE
[TRAFODION 3128] Fix issue with interval literals in multi-column histograms

### DIFF
--- a/core/sql/common/NAWinNT.h
+++ b/core/sql/common/NAWinNT.h
@@ -181,6 +181,7 @@ NAWchar na_towlower (NAWchar wc)
 Int64 na_wcstoll (const NAWchar *);
 Lng32 na_wcstol (const NAWchar *);
 NAWchar *na_wcschr (const NAWchar *, NAWchar);
+NAWchar *na_wcschrSkipOverParenText (const NAWchar *, NAWchar);
 NAWchar *na_wcsrchr (const NAWchar *, NAWchar);
 Int32 na_wsprintf(NAWchar *buffer, const NAWchar *format, ... );
 NAWchar *na_wmemchr(const NAWchar *ws, NAWchar wc, Int32 n); // used by swsprintf

--- a/core/sql/common/wstr.cpp
+++ b/core/sql/common/wstr.cpp
@@ -286,6 +286,39 @@ NAWchar *na_wcschr (const NAWchar * wstr, NAWchar wc)
    return NULL;
 }
 
+// like na_wcschr, except this variant skips over any text
+// that is within matched parentheses (note that it will never
+// find a left parenthesis as a consequence)
+NAWchar *na_wcschrSkipOverParenText (const NAWchar * wstr, NAWchar wc)
+{
+   NAWchar* p = (NAWchar*)wstr;
+
+   if ( wc == 0 )
+     return p+na_wcslen(wstr);
+
+   int ignoringTextDepth = 0;
+   while ( *p != (NAWchar)0 )
+     {
+       if (ignoringTextDepth > 0)
+         {
+           if (*p == L')')
+             ignoringTextDepth--;
+           p++;
+         }
+       else if (*p == L'(')
+         {
+           ignoringTextDepth++;
+           p++;
+         }
+       else if ( wc == *p )
+         return p;
+       else 
+         p++;
+     }
+
+   return NULL;
+}
+
 NAWchar *na_wcsrchr (const NAWchar * wstr, NAWchar wc)
 {
    NAWchar* p = (NAWchar*)wstr;

--- a/core/sql/optimizer/EncodedValue.cpp
+++ b/core/sql/optimizer/EncodedValue.cpp
@@ -745,12 +745,16 @@ EncodedValue::constructorFunction (const NAWchar * theValue,
     // in the case of a string, next has been advanced to the closing quote while
     // item still points to the beginning of the string. Scanning for a comma
     // starting at item may find a comma that is part of the string.
+    // Note: In the case of INTERVAL literals, we might have a nasty SECOND(m,n)
+    // qualifier at the end. We don't want to mistake a possible comma within such
+    // a qualifier for our delimiter, so we have to use na_wcschrSkipOverParenText
+    // instead of na_wcschr to search for the comma.
     if ( i == entries-1 OR entries==0 ) // sometimes columns is an empty list
       next = na_wcsrchr(next, L')') ;
     else  // it's an MCH
       {
     	NAWchar* nextSave = next;
-        next = na_wcschr(next, L',');
+        next = na_wcschrSkipOverParenText(next, L',');
         if ( next == NULL )
           {
             // Number of components of boundary value is less than the number of


### PR DESCRIPTION
When an INTERVAL SECOND(m,n) column participates in a multi-column histogram, EncodedValue::constructorFunction (optimizer/EncodedValue.cpp) did not properly scan for the comma delimiter between column values, resulting in 6003 warnings. This has been fixed; we now ignore commas within sets of parentheses.