### PR TITLE
[TRAFODION-3049] ODBC Numeric convert skip the calculation of max value

### DIFF
--- a/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/ctosqlconv.cpp
+++ b/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/ctosqlconv.cpp
@@ -354,8 +354,7 @@ unsigned long ODBC::ConvertCToSQL(SQLINTEGER	ODBCAppVersion,
 	if (errorMsg)
 		*errorMsg = '\0';
 	//if (targetPrecision < 19)
-    if(((SQLDataType == SQLTYPECODE_NUMERIC) && (targetPrecision <= 18)) ||
-       ((SQLDataType == SQLTYPECODE_NUMERIC_UNSIGNED) && (targetPrecision <= 9)))
+    if((ODBCDataType == SQL_NUMERIC) && ((targetPrecision <= 18) || (targetPrecision <= 9)))
 	getMaxNum(targetPrecision, targetScale, integralMax, decimalMax);
 
 	switch (ODBCDataType)

--- a/win-odbc64/odbcclient/drvr35/ctosqlconv.cpp
+++ b/win-odbc64/odbcclient/drvr35/ctosqlconv.cpp
@@ -277,8 +277,7 @@ unsigned long ODBC::ConvertCToSQL(SQLINTEGER	ODBCAppVersion,
 		*errorMsg = '\0';
 	
 	//if (targetPrecision < 19)
-    if (((SQLDataType == SQLTYPECODE_NUMERIC) && (targetPrecision <= 18)) ||
-        ((SQLDataType == SQLTYPECODE_NUMERIC_UNSIGNED) && (targetPrecision <= 9)))
+    if ((ODBCDataType == SQL_NUMERIC) && ((targetPrecision <= 18) || (targetPrecision <= 9)))
 		getMaxNum(targetPrecision, targetScale, integralMax, decimalMax);
 
 	switch (ODBCDataType)


### PR DESCRIPTION
When column is Numeric in the range of 1 to 18, the calculation of max value will skip
Because when the column is Numeric, the SQLDataType is like SQLTYPECODE_INTEGER but not SQLTYPECODE_NUMERIC.
I am not sure whether the bug is the type from mxosrvr.