### PR TITLE
[TRAFODION-3140] Update QQ ID and other news on Apache Trafodion main page

### DIFF
--- a/docs/src/site/markdown/index.md
+++ b/docs/src/site/markdown/index.md
@@ -42,15 +42,16 @@ Trafodion provides SQL access to structured, semi-structured, and unstructured d
 
 
 <table><tr><td>
-  <p><h5>Apache Trafodion is now a Top Level Project!</h5></p>
-  <p>Check out the <a href="http://globenewswire.com/news-release/2018/01/10/1286517/0/en/The-Apache-Software-Foundation-Announces-Apache-Trafodion-as-a-Top-Level-Project.html">NewsWire</a> article for the official announcement.</p>
-  <p>See also this nice <a href="https://thenewstack.io/sql-hadoop-database-trafodion-bridges-transactions-analysis-divide/">article</a> where Trafodion's own Suresh Subbiah spreads the word on Trafodion's features.</p>
-  <p><h5>We're working on release 2.2!</h5></p> 
+  <p><h5>We're working on release 2.3!</h5></p> 
   <p>Check out the <a href="https://cwiki.apache.org/confluence/display/TRAFODION/Roadmap">Roadmap</a> page for planned content.</p>
-  <p><h5>Apache Trafodion 2.1.0-incubating was released on May 1, 2017</h5></p> 
+  <p><h5>Apache Trafodion 2.2.0, our first release as a Top Level Project, was released on March 12, 2018.</h5></p> 
   <p>Check it out on the <a href="http://trafodion.apache.org/download.html">Download</a> page.</p>
-  <p><h5>Want to disucss Trafodion in Chinese? Join the Trafodion discussion on Tencent QQ!</h5></p> 
-  <p><a href="http://im.qq.com/">QQ</a> Group ID: 176011868.</p>
+  <p><h5>Apache Trafodion is now a Top Level Project!</h5></p>
+  <p>See the <a href="http://globenewswire.com/news-release/2018/01/10/1286517/0/en/The-Apache-Software-Foundation-Announces-Apache-Trafodion-as-a-Top-Level-Project.html">NewsWire</a> article for the official announcement.</p>
+  <p>See also this nice <a href="https://thenewstack.io/sql-hadoop-database-trafodion-bridges-transactions-analysis-divide/">article</a> where Trafodion's own Suresh Subbiah spreads the word on Trafodion's features.</p>
+  <p><h5>Apache Trafodion 2.1.0-incubating was released on May 1, 2017.</h5></p>  
+  <p><h5>Want to discuss Trafodion in Chinese? Join the Trafodion discussion on Tencent QQ!</h5></p> 
+  <p><a href="http://im.qq.com/">QQ</a> Group ID: 233105278.</p>
 </td></tr></table>
 
 <!-- 20160524 GTA Need more logos before using this part.

--- a/docs/src/site/site.xml
+++ b/docs/src/site/site.xml
@@ -228,7 +228,7 @@
       <item href="http://www.apache.org/events/current-event.html" name="Events"/>
       <item href="logo.html" name="Logo"/>
       <item href="mail-lists.html" name="Mailing Lists"/>
-      <item href="http://im.qq.com" name="QQ (Group ID:176011868)"/>
+      <item href="http://im.qq.com" name="QQ (Group ID: 233105278)"/>
       <item href="http:divider" name=""/>
       <item href="source-repository.html" name="Source Repository"/>
       <item href="issue-tracking.html" name="Issue Tracking"/>


### PR DESCRIPTION
This change updates the QQ ID for Chinese discussions on the Apache Trafodion main page.

It also updates the news section of the page.