### PR TITLE
[TRAFODION-3148] Fix UPDATE STATS bug on Hive tables w/ column _DIVISION_1_

### DIFF
--- a/core/sql/ustat/hs_la.cpp
+++ b/core/sql/ustat/hs_la.cpp
@@ -1372,7 +1372,10 @@ void HSTableDef::addTruncatedSelectList(NAString & qry)
         if (DFS2REC::isLOB(getColInfo(i).datatype)) // skip LOB columns
           continue;
 
-        if (!ComTrafReservedColName(*getColInfo(i).colname))
+        // skip derived column names (e.g. "_SALT_", "_DIVISION_n_")
+        // but only in Trafodion tables
+        if ((getTblOrigin() != HBASE_TBL) ||
+            (!ComTrafReservedColName(*getColInfo(i).colname)))
           {
             if (!first)
               qry += ", ";


### PR DESCRIPTION
This fixes a bug concerning sample tables created by UPDATE STATISTICS on Hive tables.

When a Hive table had a column named "_DIVISION_1_" (or any other reserved Trafodion column name), the UPDATE STATISTICS command would fail if a sample table needed to be created. The failure would occur because we would not include "_DIVISION_1_" etc. in the select list of the UPSERT/SELECT statement used to populate the sample table.

This has been fixed.