### PR TITLE
[TRAFODION-3149] Delete duplicated property names in T4Messages.prope…

### DIFF
--- a/core/conn/jdbcT4/src/main/java/T4Messages.properties
+++ b/core/conn/jdbcT4/src/main/java/T4Messages.properties
@@ -172,17 +172,9 @@ unsupported_encoding_msg=Unsupported encoding {0}
 unsupported_encoding_sqlstate=HY000
 unsupported_encoding_sqlcode=29036
 
-forward_only_cursor_msg=The Result Set Type is TYPE_FORWARD_ONLY
-forward_only_cursor_sqlstate=HY106
-forward_only_cursor_sqlcode=29037
-
 invalid_row_number_msg=The row number is not valid
 invalid_row_number_sqlstate=HY107
 invalid_row_number_sqlcode=29038
-
-read_only_concur_msg=The concurrency mode of the result set is CONCUR_READ_ONLY
-read_only_concur_sqlstate=HY092
-read_only_concur_sqlcode=29039
 
 invalid_operation_msg=Operation invalid, since the current row is insert row
 invalid_operation_sqlstate=HY000
@@ -304,9 +296,9 @@ address_format_2_error_msg=//<{IP Address|Machine Name}[:port]>/<database name>
 address_format_2_error_sqlstate=HY000
 address_format_2_error_sqlcode=29109
 
-missing ip_or_name_error_msg=Address is missing an IP address or machine name
-missing ip_or_name_error_sqlstate=HY000
-missing ip_or_name_error_sqlcode=29110
+missing_ip_or_name_error_msg=Address is missing an IP address or machine name
+missing_ip_or_name_error_sqlstate=HY000
+missing_ip_or_name_error_sqlcode=29110
 
 address_lookup_error_msg=Unable to evaluate address {0} Cause: {1}
 address_lookup_error_sqlstate=HY000

--- a/core/conn/jdbcT4/src/main/samples/t4jdbc.properties
+++ b/core/conn/jdbcT4/src/main/samples/t4jdbc.properties
@@ -23,4 +23,4 @@ catalog = TRAFODION
 schema  = SEABASE
 url = jdbc:t4jdbc://server:port/:
 user = usr
-password = pwd
+password = password


### PR DESCRIPTION
Some simple mistakes exist in jdbct4 property file, which causing failure to pass inspection of JTEST.

Duplicated property name 'forward_only_cursor_msg' on line 143
Duplicated property name 'forward_only_cursor_sqlstate' on line 144
Duplicated property name 'forward_only_cursor_sqlcode' on line 145
Duplicated property name 'read_only_concur_msg' on line 147
Duplicated property name 'read_only_concur_sqlstate' on line 148 
Duplicated property name 'read_only_concur_sqlcode' on line 149


