### PR TITLE
[TRAFODION-3153] Fix issue with CREATE EXTERNAL TABLE

### DIFF
--- a/core/sql/parser/sqlparser.y
+++ b/core/sql/parser/sqlparser.y
@@ -25411,7 +25411,7 @@ create_table_start_tokens :
                      $$ = tableTokens;
 
                      SqlParser_CurrentParser->hiveDDLInfo_->
-                       setValues(TRUE, StmtDDLonHiveObjects::CREATE_, StmtDDLonHiveObjects::TABLE_, $3);
+                       setValues(TRUE, StmtDDLonHiveObjects::CREATE_, StmtDDLonHiveObjects::TABLE_, $4);
 		   }
 
                    | TOK_CREATE TOK_IMPLICIT TOK_EXTERNAL TOK_TABLE optional_if_not_exists_clause


### PR DESCRIPTION
Change the parser production for CREATE EXTERNAL TABLE to point to the proper token for the optional IF NOT EXISTS clause.