### PR TITLE
[TRAFODION-3136] Bug fixed:  If position is a negative value, the result does not match expectations.

### DIFF
--- a/core/sql/optimizer/ItemFunc.h
+++ b/core/sql/optimizer/ItemFunc.h
@@ -5859,6 +5859,7 @@ public:
    
    virtual ItemExpr * copyTopNode(ItemExpr *derivedNode = NULL,
                       CollHeap *outheap = 0);
+   virtual ItemExpr * preCodeGen(Generator*);
 }; //class SplitPart
 
 #endif /* ITEMFUNC_H */

--- a/core/sql/regress/core/EXPECTED038.LINUX
+++ b/core/sql/regress/core/EXPECTED038.LINUX
@@ -4723,6 +4723,11 @@ sc
          
 
 --- 4 row(s) selected.
+>>select split_part('sa:sbl:sc', ':', -4) from t038sf;
+
+*** ERROR[8691] Field position must be greater than zero, currently is -4.
+
+--- 0 row(s) selected.
 >>
 >>insert into T038sf values(110, 'a/b/c', 'sa/dsd/s');
 

--- a/core/sql/regress/core/TEST038
+++ b/core/sql/regress/core/TEST038
@@ -1148,6 +1148,7 @@ select split_part('sa:sbl:sc', ':', 3) from t038sf;
 -- **EMPTY RESULT** 
 select split_part('sa:sbl:sc', ':', 0) from t038sf;
 select split_part('sa:sbl:sc', ':', 4) from t038sf;
+select split_part('sa:sbl:sc', ':', -4) from t038sf;
 
 insert into T038sf values(110, 'a/b/c', 'sa/dsd/s');
 insert into T038sf values(111, 'sasd', 'dsa:/~sd');


### PR DESCRIPTION
**Before this, the result of below SQL are incorrect:**
```
>> select split_part('aaabbcc', 'bb', -2) from dual;

Expr
------

      

--- 1 row(s) selected.   (error)
```


**for now,** 
```
>> select split_part('aaabbcc', 'bb', -2) from dual;

*** ERROR[8691] Field position must be greater than zero, currently is -2.

--- 0 row(s) selected.
```

`