### PR TITLE
[TRAFODION-3166] enhance 8427 error detail when thrown by sequence operator

### DIFF
--- a/core/sql/executor/ExSequence.cpp
+++ b/core/sql/executor/ExSequence.cpp
@@ -1481,17 +1481,14 @@ void ExSequenceTcb::updateDiagsArea(ex_queue_entry * centry)
 
 void ExSequenceTcb::updateDiagsArea(ComDiagsArea *da)
 {
-    if (da) 
+    if (workAtp_->getDiagsArea())
+    {     
+      workAtp_->getDiagsArea()->mergeAfter(*da);
+    }
+    else
     {
-      if (workAtp_->getDiagsArea())
-      {     
-        workAtp_->getDiagsArea()->mergeAfter(*da);
-      }
-      else
-      {
-        workAtp_->setDiagsArea(da);
-        da->incrRefCount();
-      }
+      workAtp_->setDiagsArea(da);
+      da->incrRefCount();
     }
 }
 

--- a/core/sql/executor/ExSequence.cpp
+++ b/core/sql/executor/ExSequence.cpp
@@ -996,7 +996,7 @@ short ExSequenceTcb::work()
           ComDiagsArea *myDiags = NULL;
           if (!cluster_->flush(myDiags, heap_)) {  // flush the buffers
             // if no errors this code path is not visited
-            if (myDiags) 
+            if (myDiags != NULL) 
             { // some error
               updateDiagsArea(myDiags);
               pstate->step_ = ExSeq_ERROR;
@@ -1047,7 +1047,7 @@ short ExSequenceTcb::work()
 
           ComDiagsArea *myDiags = NULL;
           if (!cluster_->read(myDiags, heap_)) {
-            if (myDiags) { // some error
+            if (myDiags != NULL) { // some error
               updateDiagsArea(myDiags);
               pstate->step_ = ExSeq_ERROR;
               break;

--- a/core/sql/executor/ExSequence.cpp
+++ b/core/sql/executor/ExSequence.cpp
@@ -1487,7 +1487,35 @@ void ExSequenceTcb::updateDiagsArea(  ExeErrorCode rc_)
     }
     if (!da->contains((Lng32) -rc_))
     {
-      *da << DgSqlCode(-rc_);
+      char msg[512];
+      if(rc_ == EXE_SORT_ERROR)
+      {
+        char errorMsg[100];
+        Lng32 scratchError = 0;
+        Lng32 scratchSysError = 0;
+        Lng32 scratchSysErrorDetail = 0;
+
+        if(clusterDb_)
+        {
+          clusterDb_->getScratchErrorDetail(scratchError,
+                                 scratchSysError,
+                                 scratchSysErrorDetail,
+                                 errorMsg);
+
+          str_sprintf(msg, "Sequence Scratch IO Error occurred. Scratch Error: %d, System Error: %d, System Error Detail: %d, Details: %s",
+              scratchError, scratchSysError, scratchSysErrorDetail, errorMsg);
+        }
+        else
+        {
+          str_sprintf(msg, "Sequence Scratch IO Error occurred." );
+        }
+      }
+      else
+      {
+        str_sprintf(msg, "Sequence Operator Error occurred."); 
+      }
+      
+      *da << DgString0(msg);
     }
 }
 //

--- a/core/sql/executor/ExSequence.h
+++ b/core/sql/executor/ExSequence.h
@@ -190,6 +190,7 @@ public:
 
   void updateDiagsArea(ex_queue_entry * centry);
   void updateDiagsArea( ExeErrorCode rc_);
+  void updateDiagsArea(ComDiagsArea *da);
 
   NABoolean getPartitionEnd() const
   {

--- a/core/sql/executor/cluster.cpp
+++ b/core/sql/executor/cluster.cpp
@@ -1621,7 +1621,9 @@ NABoolean Cluster::flush(ComDiagsArea *&da, CollHeap *heap) {
   //if rc != EXE_OK then it is error. 
   if(!flush(&rc)) {
     if(rc != EXE_OK) {
-      da = ComDiagsArea::allocate(heap);
+      if(da == NULL) {
+        da = ComDiagsArea::allocate(heap);
+      }
       *da << DgSqlCode(-rc);
       
       char msg[512];
@@ -1631,20 +1633,20 @@ NABoolean Cluster::flush(ComDiagsArea *&da, CollHeap *heap) {
         Lng32 scratchSysError = 0;
         Lng32 scratchSysErrorDetail = 0;
 
-        if(clusterDb_) {
+        if(clusterDb_ != NULL) {
           clusterDb_->getScratchErrorDetail(scratchError,
                                  scratchSysError,
                                  scratchSysErrorDetail,
                                  errorMsg);
 
-          str_sprintf(msg, "Scratch IO Error occurred. Scratch Error: %d, System Error: %d, System Error Detail: %d, Details: %s",
+          snprintf(msg, sizeof(msg), "Scratch IO Error occurred. Scratch Error: %d, System Error: %d, System Error Detail: %d, Details: %s",
               scratchError, scratchSysError, scratchSysErrorDetail, errorMsg);
         }
         else {
-          str_sprintf(msg, "Scratch IO Error occurred. clusterDb_ is NULL" );
+          snprintf(msg, sizeof(msg), "Scratch IO Error occurred. clusterDb_ is NULL" );
         }
       } else {
-        str_sprintf(msg, "Cluster Flush Error occurred."); 
+        snprintf(msg, sizeof(msg), "Cluster Flush Error occurred."); 
       }
       
       *da << DgString0(msg);
@@ -2378,8 +2380,10 @@ NABoolean Cluster::read(ComDiagsArea *&da, CollHeap *heap) {
   //if rc != EXE_OK then it is error. 
   if(!read(&rc)) {
     if(rc != EXE_OK) {
+      if(da == NULL) {
        da = ComDiagsArea::allocate(heap);
-       *da << DgSqlCode(-rc);
+      }
+      *da << DgSqlCode(-rc);
       
       char msg[512];
       if(rc == EXE_SORT_ERROR) {
@@ -2388,20 +2392,20 @@ NABoolean Cluster::read(ComDiagsArea *&da, CollHeap *heap) {
         Lng32 scratchSysError = 0;
         Lng32 scratchSysErrorDetail = 0;
   
-        if(clusterDb_) {
+        if(clusterDb_ != NULL) {
           clusterDb_->getScratchErrorDetail(scratchError,
                                  scratchSysError,
                                  scratchSysErrorDetail,
                                  errorMsg);
   
-          str_sprintf(msg, "Cluster::read Scratch IO Error occurred. Scratch Error: %d, System Error: %d, System Error Detail: %d, Details: %s",
+          snprintf(msg, sizeof(msg), "Cluster::read Scratch IO Error occurred. Scratch Error: %d, System Error: %d, System Error Detail: %d, Details: %s",
               scratchError, scratchSysError, scratchSysErrorDetail, errorMsg);
         }
         else {
-          str_sprintf(msg, "Cluster::read Scratch IO Error occurred. clusterDb_ is NULL" );
+          snprintf(msg, sizeof(msg), "Cluster::read Scratch IO Error occurred. clusterDb_ is NULL" );
         }
       } else {
-        str_sprintf(msg, "Cluster::read Error occurred."); 
+        snprintf(msg, sizeof(msg), "Cluster::read Error occurred."); 
       }
       
       *da << DgString0(msg);

--- a/core/sql/executor/cluster.h
+++ b/core/sql/executor/cluster.h
@@ -933,6 +933,10 @@ public:
   // flush the Cluster. If the flushing is not complete yet (I/Os pending)
   // flush() returns FALSE. Otherwise TRUE.
   NABoolean flush(ExeErrorCode * rc);
+  
+  // encapsulate error handling within flush. it is wrapper 
+  // around flush(ExeErrorCode * rc) call. Used by ExSequence.
+  NABoolean flush(ComDiagsArea *&da, CollHeap *heap);
 
   // spill a cluster. Spill is the same as flush. The only difference is,
   // that a spilled cluster still has a hash table (this is only used for
@@ -945,6 +949,10 @@ public:
   // Cluster read() reads as many buffers as possible. If it is an outer
   // Cluster, read() reads just one bufffer.
   NABoolean read(ExeErrorCode * rc);
+  
+  // encapsulate error handling within read. it is wrapper 
+  // around read(ExeErrorCode * rc) call. Used by ExSequence.
+  NABoolean read(ComDiagsArea *&da, CollHeap *heap);
  
   // create a hash table for this Cluster and chain all rows of the Cluster
   // into this hash table.


### PR DESCRIPTION
ERROR[8427] [2018-07-23 15:52:16]

will now be more descriptive 

*** ERROR[8427] Sequence Scratch IO Error occurred. Scratch Error: -10005, System Error: 13, System Error Detail: 0, Details: SQScratchFile::SQScratchFile 3

--- 0 row(s) selected.
