### PR TITLE
[TRAFODION-3710] odb don't report error message.

### DIFF
--- a/core/conn/odb/src/odb.c
+++ b/core/conn/odb/src/odb.c
@@ -40,6 +40,7 @@ char *odbauth = "Trafodion Dev <trafodion-development@lists.launchpad.net>";
 #define MAX_ARGS    11          /* Max arguments for interactive mode */
 #define ARG_LENGTH  128         /* Max argument length in interactive mode */
 #define LINE_CHUNK  51200       /* size of memory chunks allocated to store lines */
+#define ERR_MSG_LEN 512         /* size of error message buffer */
 #define MAX_VNLEN   32          /* Max variable name length */
 #define MAX_PK_COLS 16          /* Max number of PK elements */
 #define MAXCOL_LEN  128         /* Max table column name length */
@@ -2864,7 +2865,7 @@ static void setan ( int eid, int tid, int nrag, char *rag[], char *ql )
  */
 static void Oerr(int eid, int tid, unsigned int line, SQLHANDLE Ohandle, SQLSMALLINT Otype)
 {
-    size_t bs=LINE_CHUNK;   /* Memory needed for the error message */
+    size_t bs=ERR_MSG_LEN;   /* Memory needed for the error message */
     SQLSMALLINT Oi=1, 
                 Oln=0;
     SQLINTEGER Onat=0;
@@ -9961,7 +9962,7 @@ oloadJson_exit:
  */
 static int Oloadbuff(int eid)
 {
-    size_t embs=LINE_CHUNK;     /* Error message buffer size */
+    size_t embs=ERR_MSG_LEN;     /* Error message buffer size */
     SQLRETURN Or=0;             /* ODBC return value */
     SQLCHAR Ostate[6];          /* ODBC state */
     SQLSMALLINT Oi=1;           /* ODBC error index */


### PR DESCRIPTION
**root cause:** SQLGetDiagRec expected an error message buffer length parameter which type is signed short, but odb defined a macro LINE_CHUNK as 51200 and this macro will be pass to SQLGetDiagRec as error message buffer length parameter,  51200 is a negative value for signed short, so no error message returned.
**solution:** define a new macro ERR_MSG_LEN with a small value for SQLGetDiagRec function.