### PR TITLE
TRAFODION-3165 HDFS storage option not work well if table use namespace

### DIFF
--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/TransactionManager.java
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/TransactionManager.java
@@ -3285,7 +3285,7 @@ public class TransactionManager {
           String namespacestr="";
           String fullPath = hbaseRoot + "/data/" ;
           String fullPath2 = hbaseRoot + "/data/default/";
-          if(fs.exists(new Path(fullPath2)))
+          if(fs.exists(new Path(fullPath2)) && parts.length == 1)  // no namespace in the path
             fullPath = fullPath2;
 
           if(parts.length >1) //have namespace


### PR DESCRIPTION
If the table has namespace, the path of that table in HDFS should not in /hbase/data/default, but in /hbase/data/<namespace>/