### PR TITLE
[TRAFODION-1881] A better way to solve TRAFODION-1858

### DIFF
--- a/core/sql/generator/Generator.cpp
+++ b/core/sql/generator/Generator.cpp
@@ -1657,6 +1657,7 @@ TrafDesc * Generator::createKeyDescs(Int32 numKeys,
 
 TrafDesc * Generator::createConstrKeyColsDescs(Int32 numKeys,
                                                ComTdbVirtTableKeyInfo * keyInfo,
+                                               ComTdbVirtTableColumnInfo * columnInfo,
                                                NAMemory * space)
 {
   TrafDesc * first_key_desc = NULL;
@@ -1687,6 +1688,9 @@ TrafDesc * Generator::createConstrKeyColsDescs(Int32 numKeys,
 	tgt->colname = NULL;
       
       tgt->position   = src->tableColNum;
+      ComTdbVirtTableColumnInfo * info = columnInfo +  src->tableColNum;
+      if(info->columnClass == COM_SYSTEM_COLUMN )
+        tgt->setSystemKey(TRUE);
     }
 
   return first_key_desc;
@@ -2062,7 +2066,7 @@ TrafDesc * Generator::createVirtualTableDesc
 	  curr_constr_desc->constrntsDesc()->colcount = constrInfo[i].colCount;
 
 	  curr_constr_desc->constrntsDesc()->constr_key_cols_desc =
-	    Generator::createConstrKeyColsDescs(constrInfo[i].colCount, constrInfo[i].keyInfoArray, space);
+	    Generator::createConstrKeyColsDescs(constrInfo[i].colCount, constrInfo[i].keyInfoArray, columnInfo, space);
 
 	  if (constrInfo[i].ringConstrArray)
 	    {

--- a/core/sql/generator/Generator.h
+++ b/core/sql/generator/Generator.h
@@ -1413,6 +1413,7 @@ public:
 
   static TrafDesc * createConstrKeyColsDescs(Int32 numKeys,
                                              ComTdbVirtTableKeyInfo * keyInfo,
+                                             ComTdbVirtTableColumnInfo * colInfo,
                                              NAMemory * space);
 
   static TrafDesc * createRefConstrDescStructs(

--- a/core/sql/optimizer/BindRI.cpp
+++ b/core/sql/optimizer/BindRI.cpp
@@ -409,44 +409,6 @@ void RefConstraint::getMatchOptionPredicateText(NAString &text,
   text += ")";
 }
 
-//helper function to check if the given column name is reserved hidden coloum
-//NOTE:
-//  this function hardcode the special name string for SALT, DIVSION columns
-//  if the naming convension of SALT/DIVISION column is changed,
-//  this function MUST be changed as well
-static NABoolean isHiddenColumn(const char *colname)
-{
-  int len = strlen(colname);
-  if(strcmp(colname , "_SALT_") ==0) 
-    return TRUE;
-  //check for DIVISION column
-  //pattern _DIVISION_%d_
-  //must longer than 12
-  if(len >= 12) {
-    //must end with _
-    if(colname[len-1] == '_')
-    {
-      //if begin with _DIVISION_?
-      if(strncmp(colname,"_DIVISION_",10) == 0) 
-      {
-        //middle part are number
-        int allDigit = 1;
-        for(int i = 0; i< len-11; i++)
-        {
-          if(isdigit(colname[i+10]) == 0)
-          {
-            allDigit = 0;
-            break; //not digit
-          }
-        } 
-        if(allDigit == 1)
-          return TRUE; 
-      }
-    }
-  }
-  return FALSE;
-}
-
 // Writes a row-value-constructor consisting of fully qualified column names
 // in Ansi (external) format
 void RefConstraint::getPredicateText(NAString &text, 

--- a/core/sql/optimizer/BindRI.cpp
+++ b/core/sql/optimizer/BindRI.cpp
@@ -194,13 +194,16 @@ void AbstractRIConstraint::setKeyColumns(
   while (keyColDesc)
   {
     colDesc = keyColDesc->constrntKeyColsDesc();
-    column = new (heap) NAColumn(colDesc->colname, colDesc->position, NULL, heap);
+    if( colDesc->isSystemKey() )
+      column = new (heap) NAColumn(colDesc->colname, colDesc->position, NULL, heap, NULL, SYSTEM_COLUMN);
+    else
+      column = new (heap) NAColumn(colDesc->colname, colDesc->position, NULL, heap);
     keyColumns_.insertAt(i, column);
     i++;
     keyColDesc = keyColDesc->next; 
   }
 
-  CMPASSERT(desc->colcount == (signed)i);
+  CMPASSERT(desc->colcount == (signed)i); 
 }
 
 UniqueConstraint::~UniqueConstraint()
@@ -456,8 +459,8 @@ void RefConstraint::getPredicateText(NAString &text,
   text += "(";
   for (CollIndex i = 0; i < keyColumns.entries(); i++)
     {
-      if(isHiddenColumn(keyColumns[i]->getColName()) )
-        continue;
+      if(keyColumns[i]->isSystemColumn() )
+         continue;
       if (pos > 0)
       {
         text += ",";

--- a/core/sql/sqlcat/TrafDDLdesc.h
+++ b/core/sql/sqlcat/TrafDDLdesc.h
@@ -311,9 +311,19 @@ public:
 
 class TrafConstrntKeyColsDesc : public TrafDesc {
 public:
+  enum ConsrntKeyDescFlags
+    { 
+      SYSTEM_KEY   = 0x0001
+    };
   // why almost no initializers? see note at top of file
   TrafConstrntKeyColsDesc() : TrafDesc(DESC_CONSTRNT_KEY_COLS_TYPE)
-  {}
+  {
+    constrntKeyColsDescFlags = 0;
+  }
+
+  void setSystemKey(NABoolean v) 
+  {(v ? constrntKeyColsDescFlags |= SYSTEM_KEY: constrntKeyColsDescFlags&= ~SYSTEM_KEY); };
+  NABoolean isSystemKey() { return (constrntKeyColsDescFlags & SYSTEM_KEY) != 0; };
 
   // ---------------------------------------------------------------------
   // Redefine virtual functions required for Versioning.


### PR DESCRIPTION
In my previous fix to TRAFODION-1858, I add a new method to check if a column is a system column by comparing the column name with "_SALT_", "_DIVISION_" etc, that is not a good way.
This is a new implementation, it use more robust way to tell if a column is a system column.

To check the RI, the predicate only need to check the user specified Primary Column.