### PR TITLE
[TRAFODION-3182] cleanup monitor log content

### DIFF
--- a/core/sqf/monitor/linux/cluster.cxx
+++ b/core/sqf/monitor/linux/cluster.cxx
@@ -2740,7 +2740,7 @@ void CCluster::HandleOtherNodeMsg (struct internal_msg_def *recv_msg,
                                  recv_msg->u.stdin_req.supplier_nid,
                                  recv_msg->u.stdin_req.supplier_pid);
                         mon_log_write(MON_CLUSTER_HANDLEOTHERNODE_8,
-                                      SQ_LOG_ERR, buf);
+                                      SQ_LOG_DEBUG, buf);
                     }
                 }
             }
@@ -2760,7 +2760,7 @@ void CCluster::HandleOtherNodeMsg (struct internal_msg_def *recv_msg,
                      "pid=%d for stdin data request.\n", method_name,
                      recv_msg->u.stdin_req.nid,
                      recv_msg->u.stdin_req.pid);
-            mon_log_write(MON_CLUSTER_HANDLEOTHERNODE_9, SQ_LOG_INFO, buf);
+            mon_log_write(MON_CLUSTER_HANDLEOTHERNODE_9, SQ_LOG_DEBUG, buf);
         }
         break;
 #endif

--- a/core/sqf/monitor/linux/redirector.cxx
+++ b/core/sqf/monitor/linux/redirector.cxx
@@ -1550,7 +1550,7 @@ void CRedirector::stdinFd(int nid, int pid, int &pipeFd, char filename[],
             sprintf(buf, "[%s], unable to obtain file info for stdin file"
                     ", file=%s. Closing stdin pipe fd=%d\n",
                     method_name, filename, pipeFd );
-            mon_log_write(MON_REDIR_STDIN_FD_1, SQ_LOG_ERR, buf);
+            mon_log_write(MON_REDIR_STDIN_FD_1, SQ_LOG_DEBUG, buf);
 
             close ( pipeFd );
             pipeFd = -1;


### PR DESCRIPTION
At field, when we want to do trafodion trouble shooting. Open mon.xxx.log file, in many times, it is flood with message related STDIN redirection entries.
These log entries are never real issues, and it is very hard to understand, so this PR is to move these log entries into DEBUG level. 
So only when an expert want to debug very complicated issue and need to turn-on the DEBUG log/trace, these info will be printed out.

I am trying to make log file more useful, this is the first attempt.