### PR TITLE
[TRAFODION-3180] At times establishing a JDBC/ODBC connection takes o…

### DIFF
--- a/core/sqf/src/seabed/src/sockstream.cpp
+++ b/core/sqf/src/seabed/src/sockstream.cpp
@@ -431,6 +431,7 @@ SB_Trans::Sock_Stream::create(const char           *pp_name,
         pp_sock->set_nonblock();
         pp_sock->event_init(lp_stream->ip_sock_eh);
     }
+    SB_Trans::Trans_Stream::delete_streams(true);
     return lp_stream;
 }
 

--- a/core/sqf/src/seabed/src/stream.cpp
+++ b/core/sqf/src/seabed/src/stream.cpp
@@ -610,6 +610,7 @@ void SB_Trans::Trans_Stream::delete_streams(bool pv_ref_zero) {
                                            "Not deleting stream=%s, stream-ref=%d\n",
                                            lp_stream->get_name(),
                                            lv_stream_ref);
+                    lv_del_q.add(&lp_stream->iv_del_link);
                 }
             } else {
                 if (gv_ms_trace_ref)
@@ -633,6 +634,7 @@ void SB_Trans::Trans_Stream::delete_streams(bool pv_ref_zero) {
                                        "Not deleting stream=%s, stream-ref=%d\n",
                                        lp_stream->get_name(),
                                        lv_stream_ref);
+                lv_del_q.add(&lp_stream->iv_del_link);
             }
         }
     }


### PR DESCRIPTION
…bservably long time

When the sock stream is in use, socket close is kept pending in a queue till it can
be closed. But, the sockets from this queue is never closed. Added code
to close the sockets from this queue at the time of creating the socket stream next
time.