### PR TITLE
[TRAFODION-2404] enhance the regexpr performance

### DIFF
--- a/core/sql/exp/exp_clause_derived.h
+++ b/core/sql/exp/exp_clause_derived.h
@@ -41,9 +41,12 @@
 #ifndef EXP_CLAUSE_DERIVED_H
 #define EXP_CLAUSE_DERIVED_H
 
+#include <sys/types.h>
+#include <regex.h>
 #include "exp_clause.h"
 #include "exp_like.h"
 #include <byteswap.h>
+#include "NAStringDef.h"
 
 
 #define instrAndText(a) a, #a
@@ -2546,6 +2549,7 @@ public:
   // Construction
   //
   ExRegexpClauseChar() {};
+  ~ExRegexpClauseChar() {  };
   ExRegexpClauseChar(OperatorTypeEnum oper_type, 
 			    short num_operands,
 			    Attributes ** attr,
@@ -2583,6 +2587,10 @@ public:
 
   virtual short getClassSize() { return (short)sizeof(*this); }
   // ---------------------------------------------------------------------
+
+  regex_t reg;
+
+  NAString rpattern_;
 
 private:
 

--- a/core/sql/exp/exp_clause_derived.h
+++ b/core/sql/exp/exp_clause_derived.h
@@ -2548,8 +2548,8 @@ class  ExRegexpClauseChar : public ExRegexpClauseBase {
 public:
   // Construction
   //
-  ExRegexpClauseChar() {};
-  ~ExRegexpClauseChar() {  };
+  ExRegexpClauseChar() { rpattern_ = ""; };
+  ~ExRegexpClauseChar() { if(rpattern_ != "") regfree(&reg); };
   ExRegexpClauseChar(OperatorTypeEnum oper_type, 
 			    short num_operands,
 			    Attributes ** attr,
@@ -2590,7 +2590,7 @@ public:
 
   regex_t reg;
 
-  NAString rpattern_;
+  NAString rpattern_; //previous pattern
 
 private:
 

--- a/core/sql/exp/exp_like.cpp
+++ b/core/sql/exp/exp_like.cpp
@@ -498,11 +498,10 @@ ex_expr::exp_return_type ExRegexpClauseChar::eval(char *op_data[],
   NABoolean matchFlag = true;
   Lng32 len1 = getOperand(1)->getLength(op_data[-MAX_OPERANDS+1]);
   Lng32 len2 = getOperand(2)->getLength(op_data[-MAX_OPERANDS+2]);
-  regex_t reg;
+  char * pattern;
   regmatch_t pm[1];
   const size_t nmatch = 1;
   Lng32 cflags, z;
-  char * pattern;
   char *srcStr= new (exHeap) char[len1+1];
   char ebuf[128];
 
@@ -513,8 +512,12 @@ ex_expr::exp_return_type ExRegexpClauseChar::eval(char *op_data[],
 
   str_cpy_all(pattern, op_data[2], len2);
   str_cpy_all(srcStr, op_data[1], len1);
-
-  z = regcomp(&reg, pattern, cflags);
+  if(rpattern_ != pattern)
+  {
+    if(rpattern_ != "") regfree(&reg);
+    rpattern_ = pattern;
+    z = regcomp(&reg, pattern, cflags);
+  }
 
   if (z != 0){
     //ERROR
@@ -538,7 +541,6 @@ ex_expr::exp_return_type ExRegexpClauseChar::eval(char *op_data[],
   
 
   *(Lng32 *)op_data[0] = (Lng32)matchFlag;
-  regfree(&reg);
 
   NADELETEBASIC(pattern, exHeap);
   NADELETEBASIC(srcStr, exHeap);

--- a/core/sql/exp/exp_like.cpp
+++ b/core/sql/exp/exp_like.cpp
@@ -501,7 +501,7 @@ ex_expr::exp_return_type ExRegexpClauseChar::eval(char *op_data[],
   char * pattern;
   regmatch_t pm[1];
   const size_t nmatch = 1;
-  Lng32 cflags, z;
+  Lng32 cflags, z = 0;
   char *srcStr= new (exHeap) char[len1+1];
   char ebuf[128];
 
@@ -521,6 +521,7 @@ ex_expr::exp_return_type ExRegexpClauseChar::eval(char *op_data[],
 
   if (z != 0){
     //ERROR
+    memset(ebuf, 0, sizeof(ebuf));
     regerror(z, &reg,ebuf, sizeof(ebuf));
     ExRaiseSqlError(exHeap, diagsArea, (ExeErrorCode)8452);
     **diagsArea << DgString0(ebuf);


### PR DESCRIPTION
Previously, each time evaluate a row, it needs to invoke the regcomp(), by this change, only when the pattern is changed, invoke the regcomp()