### PR TITLE
[TRAFODION-3171] Refactor Hive sequence file reading to use the new i…

### DIFF
--- a/core/sql/src/main/java/org/trafodion/sql/HDFSClient.java
+++ b/core/sql/src/main/java/org/trafodion/sql/HDFSClient.java
@@ -286,7 +286,7 @@ public class HDFSClient
                             
               buf_.put(byteArray, 0, readLen);
               buf_.put(recDelimiter_);
-              lenRemain_ -= (readLen+1);
+              lenRemain -= (readLen+1);
               totalReadLen += (readLen+1);
           } else {
               // Reset the position because the row can't be copied to buffer


### PR DESCRIPTION
…mplementation

Fix for the following exception seen while accessing hive sequence file with the new implementation
*** ERROR[8447] An error occurred during hdfs access. Error Detail: SETUP_HDFS_SCAN java.util.concurrent.ExecutionException: java.nio.BufferOverflowException
java.util.concurrent.FutureTask.report(FutureTask.java:122)
java.util.concurrent.FutureTask.get(FutureTask.java:192)
org.trafodion.sql.HDFSClient.trafHdfsReadBuffer(HDFSClient.java:424)
org.trafodion.sql.HdfsScan.trafHdfsRead(HdfsScan.java:215) Caused by
java.nio.BufferOverflowException
java.nio.DirectByteBuffer.put(DirectByteBuffer.java:363)
org.trafodion.sql.HDFSClient.sequenceFileRead(HDFSClient.java:301)
org.trafodion.sql.HDFSClient$HDFSRead.call(HDFSClient.java:217)
java.util.concurrent.FutureTask.run(FutureTask.java:266)
java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
java.lang.Thread.run(Thread.java:748) [2018-08-21 15:56:00]