### PR TITLE
[TRAFODION-2952] large amount of data will cause error in sequence ge…

### DIFF
--- a/core/sql/cli/Cli.cpp
+++ b/core/sql/cli/Cli.cpp
@@ -10529,9 +10529,9 @@ static Lng32 SeqGenCliInterfaceUpdAndValidateMulti(
       cliRC = cqdCliInterface->holdAndSetCQD("traf_no_dtm_xn", "ON");
     }
 
-  Lng32 numTries = 0;
+  Lng32 numTries = 0, maxRetryNum = sga->getSGRetryNum();
   NABoolean isOk = FALSE;
-  while ((NOT isOk) && (numTries < 10))
+  while ((NOT isOk) && (numTries < maxRetryNum))
     {
       if (startLocalXn)
         {
@@ -10599,7 +10599,10 @@ static Lng32 SeqGenCliInterfaceUpdAndValidateMulti(
       
       numTries++;
       
-      DELAY(100 + numTries*25);
+      if( 100 + numTries*25 < 1000)   //MAX is 1 second
+          DELAY(100 + numTries*25);
+      else
+          DELAY(1000);
     }
 
     // could not update it after 10 tries. Return error.

--- a/core/sql/common/SequenceGeneratorAttributes.h
+++ b/core/sql/common/SequenceGeneratorAttributes.h
@@ -80,7 +80,8 @@ public:
     sgCache_(psgCache),
     sgNextValue_(psgNextValue),
     sgEndValue_(psgEndValue),
-    sgRedefTime_(psgRedefTime)
+    sgRedefTime_(psgRedefTime),
+    sgRetryNum_(250)
   {}
 
       
@@ -98,7 +99,8 @@ public:
     sgCache_(0),
     sgNextValue_(0),
     sgEndValue_(0),
-    sgRedefTime_(0)
+    sgRedefTime_(0),
+    sgRetryNum_(250)
       {}
   
   // copy ctor
@@ -117,7 +119,8 @@ public:
     sgCache_(sga.sgCache_),
     sgNextValue_(sga.sgNextValue_),
     sgEndValue_(sga.sgEndValue_),
-    sgRedefTime_(sga.sgRedefTime_)
+    sgRedefTime_(sga.sgRedefTime_),
+    sgRetryNum_(250)
       {}
   
   // ---------------------------------------------------------------------
@@ -138,6 +141,11 @@ public:
   const Int64                      &getSGNextValue()   const     { return sgNextValue_; }
   const Int64                      &getSGEndValue()   const     { return sgEndValue_; }
   const Int64                      &getSGRedefTime() const     { return sgRedefTime_; }
+  const UInt32			&getSGRetryNum() const     { return sgRetryNum_; }
+
+  void setSGRetryNum(const UInt32 v) 
+  { sgRetryNum_ = v; }
+
   void setSGStartValue(const Int64 psgStartValue)
   { sgStartValue_= psgStartValue; }
 
@@ -205,6 +213,7 @@ private:
   Int64                        sgNextValue_;
   Int64                        sgEndValue_;
   Int64                        sgRedefTime_;
+  UInt32			sgRetryNum_;
 }; // class SequenceGeneratorAttributes
 
 #endif  /* SEQUENCEGENERATORATTRIBUTES_H */

--- a/core/sql/exp/ExpSeqGen.cpp
+++ b/core/sql/exp/ExpSeqGen.cpp
@@ -50,6 +50,7 @@ SeqGenEntry::SeqGenEntry(Int64 sgUID, CollHeap * heap)
 {
   fetchNewRange_ = TRUE;
   cliInterfaceArr_ = NULL;
+  retryNum_ = 250; //default retry times
 }
 
 short SeqGenEntry::fetchNewRange(SequenceGeneratorAttributes &inSGA)
@@ -61,6 +62,8 @@ short SeqGenEntry::fetchNewRange(SequenceGeneratorAttributes &inSGA)
   sga = inSGA;
   if (sga.getSGCache() == 0)
     sga.setSGCache(1); 
+
+  sga.setSGRetryNum(getRetryNum());
   cliRC = SQL_EXEC_SeqGenCliInterface(&cliInterfaceArr_, &sga);
   if (cliRC < 0)
     return (short)cliRC;
@@ -142,6 +145,8 @@ SeqGenEntry * SequenceValueGenerator::getEntry(SequenceGeneratorAttributes &sga)
       sge = new(getHeap()) SeqGenEntry(hashVal, getHeap());
       sgQueue()->insert((char*)&hashVal, sizeof(hashVal), sge);
     }
+
+  sge->setRetryNum(getRetryNum());
 
   return sge;
 }

--- a/core/sql/exp/ExpSeqGen.h
+++ b/core/sql/exp/ExpSeqGen.h
@@ -55,6 +55,9 @@ class SeqGenEntry : public NABasicObject
 
   Int64 getSGObjectUID() { return sgUID_; }
 
+  void setRetryNum(UInt32 n) { retryNum_ = n; }
+  UInt32 getRetryNum() { return retryNum_ ; }
+
  private:
   short fetchNewRange(SequenceGeneratorAttributes &inSGA);
 
@@ -68,6 +71,8 @@ class SeqGenEntry : public NABasicObject
   Int64 cachedCurrValue_;
 
   void * cliInterfaceArr_;
+
+  UInt32 retryNum_;
 };
 
 class SequenceValueGenerator : public NABasicObject
@@ -80,11 +85,15 @@ class SequenceValueGenerator : public NABasicObject
 
   HashQueue * sgQueue() { return sgQueue_;}
   CollHeap * getHeap() { return heap_; }
+  void setRetryNum(UInt32 n) { retryNum_ = n; }
+  UInt32 getRetryNum() { return retryNum_; }
 
  private:
   CollHeap * heap_;
 
   HashQueue * sgQueue_;
+
+  UInt32 retryNum_;
 };
 
 

--- a/core/sql/exp/exp_function.cpp
+++ b/core/sql/exp/exp_function.cpp
@@ -736,6 +736,7 @@ ExFunctionSequenceValue::ExFunctionSequenceValue(OperatorTypeEnum oper_type,
 						 Space * space)
   : ex_function_clause(oper_type, 1, attr, space),
     sga_(sga),
+    retryNum_(),
     flags_(0)
 {
 };
@@ -7622,6 +7623,7 @@ ExFunctionSequenceValue::eval(char *op_data[], CollHeap *heap,
   char * result =  op_data[0];
 
   SequenceValueGenerator * seqValGen = getExeGlobals()->seqGen();
+  seqValGen->setRetryNum(getRetryNum());
   Int64 seqVal = 0;
   if (isCurr())
     rc = seqValGen->getCurrSeqVal(sga_, seqVal);

--- a/core/sql/exp/exp_function.h
+++ b/core/sql/exp/exp_function.h
@@ -4055,6 +4055,10 @@ public:
 
   NABoolean isCurr() { return ((flags_ & IS_CURR) != 0); }
 
+  void setRetryNum(UInt32 n) { retryNum_ = n; }
+
+  UInt32 getRetryNum() { return retryNum_; }
+
  private:
 enum
   {
@@ -4064,7 +4068,8 @@ enum
   SequenceGeneratorAttributes sga_;
 
   UInt32 flags_;
-  char filler1_[4];
+
+  UInt32 retryNum_;
   // ---------------------------------------------------------------------
 };
 

--- a/core/sql/generator/GenItemFunc.cpp
+++ b/core/sql/generator/GenItemFunc.cpp
@@ -2889,6 +2889,8 @@ short SequenceValue::codeGen(Generator * generator)
      *naTable_->getSGAttributes(),
      space);
 
+  sv->setRetryNum(CmpCommon::getDefaultLong(TRAF_SEQUENCE_RETRY_TIMES));
+
   if (cacheSize > 0)
     ((SequenceGeneratorAttributes*)naTable_->getSGAttributes())->setSGCache(origCacheSize);
 

--- a/core/sql/sqlcomp/DefaultConstants.h
+++ b/core/sql/sqlcomp/DefaultConstants.h
@@ -2946,6 +2946,12 @@ enum DefaultConstants
   // this is used to change cache size of sequence numbers for a session.
   // It overwrites the cache size that was specified during sequence creation.
   TRAF_SEQUENCE_CACHE_SIZE,
+ 
+  // this is used to set the retry time if two concurrent update of sequence
+  // conflict, and how many times will retry
+  // by default it is 250, when you saw error 1583, you can try to increase
+  // this settings
+  TRAF_SEQUENCE_RETRY_TIMES,
 
   TRAF_LOAD_MAX_HFILE_SIZE,
 

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -2954,6 +2954,8 @@ XDDkwd__(SUBQUERY_UNNESTING,			"ON"),
   DD_____(TRAF_SAMPLE_TABLE_LOCATION,                  "/user/trafodion/sample/"),
   DDint__(TRAF_SEQUENCE_CACHE_SIZE,        "-1"),
 
+  DDint__(TRAF_SEQUENCE_RETRY_TIMES,        "250"),
+
   DDkwd__(TRAF_SIMILARITY_CHECK,			"ROOT"),
 
   DDkwd__(TRAF_STORE_OBJECT_DESC,                    "OFF"),   


### PR DESCRIPTION
…nerating

Currently, the sequence next range value is NOT protected by DTM, but a retry logic. 
If multiple processes try to use the same sequence, when the cache is used, all of them try to get the next range and go into race. So one may get a range that another get. The logic is any one get the next range will check the updated timestamp, if it is itself, then it is good for him. Otherwise, the range is got by someone else. So the code wait and retry.

For the use case described in JIRA TRAFODION-2952, there are 48 partitioned table and want to do a load of 4 billion rows. It is high concurrency, and many times conflict. 
The that large load, it is very frequent to fail, since the retry time is hardcoded to 10.

This patch introduce a CQD to control the retry number. It is set to a higher number by default, so in most cases, users don't need to modify this. But if still run into issue, one can change the CQD.