### PR TITLE
[TRAFODION-3191] Correct Syntax Descriptions for *DEFAULT_DEGREE_OF_PARALLELISM* in *Trafodion CQD Reference Guide*

### DIFF
--- a/docs/cqd_reference/src/asciidoc/_chapters/operational_controls.adoc
+++ b/docs/cqd_reference/src/asciidoc/_chapters/operational_controls.adoc
@@ -143,7 +143,7 @@ are considered to match if their selectivities match. +
 A query cache setting of *'16384'* means a maximum of 16,384 KB of compiler memory can be used for keeping previously compiled plans
 before evicting the oldest unused plan(s) to make room for the latest cacheable plan.
 | *Values*                    |
-*Up through 4294967295*: Kilobytes of memory allocated to query cache. +
+*Up through 200,000*: Kilobytes of memory allocated to query cache. +
 *'0'*: Turns off query plan caching. +
  +
 The default value is *'16384'* (16 MB).

--- a/docs/cqd_reference/src/asciidoc/_chapters/query_plans.adoc
+++ b/docs/cqd_reference/src/asciidoc/_chapters/query_plans.adoc
@@ -40,11 +40,11 @@ The optimizer may also decide to run the query with no parallelism if the resour
 | *Values*                    |
 Unsigned Integer. +
  +
-The default value is *'16'*.
+The default value is *2*.
 | *Usage*                     | For systems running at higher levels of concurrency with workloads that include a large 
 number of small queries, reducing the default degree of parallelism may help achieve higher throughput. +
  +
-With the default of 16, for 32-node systems, adaptive segmentation can use two 16-node virtual segments to execute queries that 
+If the degree of parallelism is 16, for 32-node systems, adaptive segmentation can use two 16-node virtual segments to execute queries that 
 do not require a degree of parallelism of 32.  This default setting can, for example, be changed to 8 for a 16-node system, 
 to allow adaptive segmentation to leverage a lower degree of parallelism.
 


### PR DESCRIPTION
![default_degree_of_parallelism](https://user-images.githubusercontent.com/20532956/44711292-97254b00-aae0-11e8-9422-d2eea875b69e.png)

![cqd query_cache](https://user-images.githubusercontent.com/20532956/44711659-76a9c080-aae1-11e8-8659-9c42ec7db922.jpg)
