### PR TITLE
[TRAFODION-3201] fix wrong understanding of code in TRAFODION-3175

### DIFF
--- a/core/sql/executor/ExExeUtilCli.cpp
+++ b/core/sql/executor/ExExeUtilCli.cpp
@@ -46,8 +46,6 @@ OutputInfo::OutputInfo(Lng32 numEntries)
   : numEntries_(numEntries)
 {
   
-   ex_assert( numEntries <= MAX_OUTPUT_ENTRIES, "try to fetch more than max rows allowed");
-  
    for (Int32 i = 0; i < numEntries_; i++)
     {
       data_[i] = NULL;

--- a/core/sql/executor/ExExeUtilCli.cpp
+++ b/core/sql/executor/ExExeUtilCli.cpp
@@ -46,6 +46,8 @@ OutputInfo::OutputInfo(Lng32 numEntries)
   : numEntries_(numEntries)
 {
   
+   ex_assert( numEntries <= MAX_OUTPUT_ENTRIES, "try to fetch more than max columns allowed");
+
    for (Int32 i = 0; i < numEntries_; i++)
     {
       data_[i] = NULL;


### PR DESCRIPTION
I had a wrong understanding of the outputInfo class, so a wrong 'fix' in TRAFODION-3175
it can save as many rows , the numEntries is for columns, not rows