### PR TITLE
[TRAFODION-3209] The variable of won't be initialized before a new statement

### DIFF
--- a/win-odbc64/odbcclient/drvr35/cstmt.cpp
+++ b/win-odbc64/odbcclient/drvr35/cstmt.cpp
@@ -897,6 +897,7 @@ SQLRETURN CStmt::SendSQLCommand(BOOL SkipProcess, SQLCHAR *StatementText,
         setDiagRowCount(-1, -1);
 
         InitParamColumnList();
+        m_NumResultCols = 0;
 
         if (m_StmtState == STMT_EXECUTED)
         {


### PR DESCRIPTION
Windows ODBC won't initialize the variable before a new statement while Linux ODBC have this operation.