### PR TITLE
TRAFODION-3194 update

### DIFF
--- a/core/sql/regress/privs2/EXPECTED135
+++ b/core/sql/regress/privs2/EXPECTED135
@@ -568,7 +568,9 @@ End of MXCI Session
 --- SQL operation failed with errors.
 >>revoke all on t135_t1 from sql_user3;
 
---- SQL operation complete.
+*** ERROR[1025] Request failed.  Dependent object TRAFODION.T135SCH_USER3.T135_V1_USER3 exists.
+
+--- SQL operation failed with errors.
 >>
 >>sh sqlci -i "TEST135(user3_drops)" -u sql_user3;
 >>drop table t135_t3 cascade;

--- a/core/sql/sqlcomp/PrivMgrPrivileges.h
+++ b/core/sql/sqlcomp/PrivMgrPrivileges.h
@@ -231,7 +231,6 @@ protected:
    PrivStatus convertPrivsToDesc( 
      const ComObjectType objectType,
      const bool isAllSpecified,
-     const bool isGrant,
      const bool isWGOSpecified,
      const bool isGOFSpecified,
      const std::vector<PrivType> privsList,


### PR DESCRIPTION
Fixed issue where revoke all on object did not actually revoke the privilege.
Also fixed an issue where setting up default privileges did not set the
correct default bits for object type.