### PR TITLE
[TRAFODION-2626] Make logs directory location configurable

### DIFF
--- a/core/dbsecurity/auth/src/authEvents.cpp
+++ b/core/dbsecurity/auth/src/authEvents.cpp
@@ -56,7 +56,7 @@ void insertAuthEvent(
 // ****************************************************************************
 // function authInitEventLog()
 //
-// This function create a new log in $TRAF_HOME/logs directory with the 
+// This function create a new log in $TRAF_LOG directory with the 
 // following name dbsecurity_<host>_<pid>.log
 //
 // It is called for standalone executables (e.g. ldapcheck) to log issues

--- a/core/rest/bin/rest
+++ b/core/rest/bin/rest
@@ -163,7 +163,7 @@ done
 
 # default log directory & file
 if [ "$REST_LOG_DIR" = "" ]; then
-  REST_LOG_DIR="$REST_HOME/logs"
+  REST_LOG_DIR="$TRAF_LOG/rest"
 fi
 if [ "$REST_LOGFILE" = "" ]; then
   REST_LOGFILE='rest.log'

--- a/core/rest/bin/rest-daemon.sh
+++ b/core/rest/bin/rest-daemon.sh
@@ -98,12 +98,12 @@ wait_until_done ()
 
 # get log directory
 if [ "$REST_LOG_DIR" = "" ]; then
-  export REST_LOG_DIR="$REST_HOME/logs"
+  export REST_LOG_DIR="$TRAF_LOG/rest"
 fi
 mkdir -p "$REST_LOG_DIR"
 
 if [ "$REST_PID_DIR" = "" ]; then
-  REST_PID_DIR="$REST_HOME/tmp"
+  REST_PID_DIR="$TRAF_VAR"
 fi
 
 #if [ "$REST_IDENT_STRING" = "" ]; then

--- a/core/rest/conf/rest-env.sh
+++ b/core/rest/conf/rest-env.sh
@@ -79,8 +79,8 @@ export REST_OPTS="-XX:+UseConcMarkSweepGC"
 # Extra ssh options.  Empty by default.
 # export REST_SSH_OPTS="-o ConnectTimeout=1 -o SendEnv=REST_CONF_DIR"
 
-# Where log files are stored.  $REST_HOME/logs by default.
-# export REST_LOG_DIR=${REST_HOME}/logs
+# Where log files are stored.  $TRAF_LOG/rest by default.
+# export REST_LOG_DIR=$TRAF_LOG/rest
 
 # Enable remote JDWP debugging of major rest processes. Meant for Core Developers 
 # export REST_RESET_OPTS="$REST_RESET_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8072"

--- a/core/rest/src/main/asciidoc/_chapters/troubleshooting.adoc
+++ b/core/rest/src/main/asciidoc/_chapters/troubleshooting.adoc
@@ -34,8 +34,8 @@
 == Logs
 The key process logs are as follows...(replace <user> with the user that started the service, <instance> for the server instance and <hostname> for the machine name)
  
-* $REST_INSTALL_DIR/logs/rest-<user>-<instance>-rest-<hostname>.log
-* $REST_INSTALL_DIR/logs/rest-<user>-<instance>-rest-<hostname>.out
+* $TRAF_LOG/rest/rest-<user>-<instance>-rest-<hostname>.log
+* $TRAF_LOG/rest/rest-<user>-<instance>-rest-<hostname>.out
 
 The logs are your best resource when troubleshooting the REST server.
 

--- a/core/sqf/.gitignore
+++ b/core/sqf/.gitignore
@@ -51,11 +51,7 @@ Linux-x86_64/
 /logs/
 /sqcert/
 /sql/scripts/sqconfig.db
-/sql/scripts/*.log
-/sql/scripts/*.out
 /sql/scripts/sqshell.env
-/sql/scripts/sq*.exit_status
-/sql/scripts/stdout_*
 /tmp/
 
 # sql regressions

--- a/core/sqf/conf/log4cxx.monitor.mon.config
+++ b/core/sqf/conf/log4cxx.monitor.mon.config
@@ -22,7 +22,7 @@
 #
 
 # Define some default values that can be overridden by system properties
-trafodion.log.dir=${TRAF_HOME}/logs
+trafodion.log.dir=${TRAF_LOG}
 trafodion.log.filename.suffix=${TRAFODION_LOG_FILENAME_SUFFIX}
 
 # Logging Threshold

--- a/core/sqf/conf/log4cxx.monitor.psd.config
+++ b/core/sqf/conf/log4cxx.monitor.psd.config
@@ -22,7 +22,7 @@
 #
 
 # Define some default values that can be overridden by system properties
-trafodion.log.dir=${TRAF_HOME}/logs
+trafodion.log.dir=${TRAF_LOG}
 trafodion.log.filename.suffix=${TRAFODION_LOG_FILENAME_SUFFIX}
 
 # Logging Threshold

--- a/core/sqf/conf/log4cxx.monitor.trafns.config
+++ b/core/sqf/conf/log4cxx.monitor.trafns.config
@@ -22,7 +22,7 @@
 #
 
 # Define some default values that can be overridden by system properties
-trafodion.log.dir=${TRAF_HOME}/logs
+trafodion.log.dir=${TRAF_LOG}
 trafodion.log.filename.suffix=${TRAFODION_LOG_FILENAME_SUFFIX}
 
 # Logging Threshold

--- a/core/sqf/conf/log4cxx.monitor.wdg.config
+++ b/core/sqf/conf/log4cxx.monitor.wdg.config
@@ -22,7 +22,7 @@
 #
 
 # Define some default values that can be overridden by system properties
-trafodion.log.dir=${TRAF_HOME}/logs
+trafodion.log.dir=${TRAF_LOG}
 trafodion.log.filename.suffix=${TRAFODION_LOG_FILENAME_SUFFIX}
 
 # Logging Threshold

--- a/core/sqf/conf/log4cxx.trafodion.auth.config
+++ b/core/sqf/conf/log4cxx.trafodion.auth.config
@@ -23,7 +23,7 @@
 
 # Define some default values that can be overridden by system properties
 trafodion.root.logger=INFO, authAppender
-trafodion.log.dir=${TRAF_HOME}/logs
+trafodion.log.dir=${TRAF_LOG}
 trafodion.log.filename.suffix=${TRAFODION_LOG_FILENAME_SUFFIX}
 
 # Define the root logger to the system property "trafodion.root.logger".

--- a/core/sqf/conf/log4cxx.trafodion.masterexe.config
+++ b/core/sqf/conf/log4cxx.trafodion.masterexe.config
@@ -22,7 +22,7 @@
 #
 
 # Define some default values that can be overridden by system properties
-trafodion.log.dir=${TRAF_HOME}/logs
+trafodion.log.dir=${TRAF_LOG}
 trafodion.log.filename.suffix=${TRAFODION_LOG_FILENAME_SUFFIX}
 
 # Logging Threshold

--- a/core/sqf/conf/log4cxx.trafodion.sql.config
+++ b/core/sqf/conf/log4cxx.trafodion.sql.config
@@ -22,7 +22,7 @@
 #
 
 # Define some default values that can be overridden by system properties
-trafodion.log.dir=${TRAF_HOME}/logs
+trafodion.log.dir=${TRAF_LOG}
 trafodion.log.filename.suffix=${TRAFODION_LOG_FILENAME_SUFFIX}
 
 # Logging Threshold

--- a/core/sqf/conf/log4cxx.trafodion.sscp.config
+++ b/core/sqf/conf/log4cxx.trafodion.sscp.config
@@ -22,7 +22,7 @@
 #
 
 # Define some default values that can be overridden by system properties
-trafodion.log.dir=${TRAF_HOME}/logs
+trafodion.log.dir=${TRAF_LOG}
 trafodion.log.filename.suffix=${TRAFODION_LOG_FILENAME_SUFFIX}
 
 # Logging Threshold

--- a/core/sqf/conf/log4cxx.trafodion.ssmp.config
+++ b/core/sqf/conf/log4cxx.trafodion.ssmp.config
@@ -22,7 +22,7 @@
 #
 
 # Define some default values that can be overridden by system properties
-trafodion.log.dir=${TRAF_HOME}/logs
+trafodion.log.dir=${TRAF_LOG}
 trafodion.log.filename.suffix=${TRAFODION_LOG_FILENAME_SUFFIX}
 
 # Logging Threshold

--- a/core/sqf/conf/log4cxx.trafodion.tm.config
+++ b/core/sqf/conf/log4cxx.trafodion.tm.config
@@ -22,7 +22,7 @@
 #
 
 # Define some default values that can be overridden by system properties
-trafodion.log.dir=${TRAF_HOME}/logs
+trafodion.log.dir=${TRAF_LOG}
 trafodion.log.filename.suffix=${TRAFODION_LOG_FILENAME_SUFFIX}
 
 # Logging Threshold

--- a/core/sqf/conf/log4j.dtm.config
+++ b/core/sqf/conf/log4j.dtm.config
@@ -22,7 +22,7 @@
 #
 
 # Define some default values that can be overridden by system properties
-dtm.log.dir=${trafodion.root}/logs
+dtm.log.dir=${TRAF_LOG}
 dtm.log.file=trafodion.dtm.log
 
 # Logging Threshold

--- a/core/sqf/conf/log4j.sql.config
+++ b/core/sqf/conf/log4j.sql.config
@@ -22,7 +22,7 @@
 #
 
 # Define some default values that can be overridden by system properties
-trafodion.sql.log=${trafodion.root}/logs/trafodion.sql.java.log
+trafodion.sql.log=${TRAF_LOG}/trafodion.sql.java.log
 
 # Logging Threshold
 log4j.threshhold=ALL

--- a/core/sqf/export/share/man/man1/sqcore.1
+++ b/core/sqf/export/share/man/man1/sqcore.1
@@ -40,7 +40,7 @@ across the cluster, and move them to the head node.
 .SH USAGE
 .TP 7
 .BI -d
-Head node directory where the core files are to be moved. (Default $TRAF_HOME/logs)
+Head node directory where the core files are to be moved. (Default $TRAF_LOG)
 .TP
 .BI -h
 will display help.

--- a/core/sqf/monitor/linux/monitor.cxx
+++ b/core/sqf/monitor/linux/monitor.cxx
@@ -1574,26 +1574,26 @@ int main (int argc, char *argv[])
     // We create a standard output file here.
     if ( IsRealCluster )
     {
-        snprintf(fname, sizeof(fname), "%s/logs/trafns.%s.log",
-                 getenv("TRAF_HOME"), Node_name);
+        snprintf(fname, sizeof(fname), "%s/trafns.%s.log",
+                 getenv("TRAF_LOG"), Node_name);
     }
     else
     {
-        snprintf(fname, sizeof(fname), "%s/logs/trafns.%d.%s.log",
-                 getenv("TRAF_HOME"), MyPNID, Node_name);
+        snprintf(fname, sizeof(fname), "%s/trafns.%d.%s.log",
+                 getenv("TRAF_LOG"), MyPNID, Node_name);
     }
 #else
     // Without mpi daemon the monitor has no default standard output.
     // We create a standard output file here.
     if ( IsRealCluster )
     {
-        snprintf(fname, sizeof(fname), "%s/logs/sqmon.%s.log",
-                 getenv("TRAF_HOME"), Node_name);
+        snprintf(fname, sizeof(fname), "%s/sqmon.%s.log",
+                 getenv("TRAF_LOG"), Node_name);
     }
     else
     {
-        snprintf(fname, sizeof(fname), "%s/logs/sqmon.%d.%s.log",
-                 getenv("TRAF_HOME"), MyPNID, Node_name);
+        snprintf(fname, sizeof(fname), "%s/sqmon.%d.%s.log",
+                 getenv("TRAF_LOG"), MyPNID, Node_name);
     }
 #endif
     remove(fname);

--- a/core/sqf/monitor/linux/monlogging.cxx
+++ b/core/sqf/monitor/linux/monlogging.cxx
@@ -209,18 +209,18 @@ void CMonLog::writeAltLog(int eventType, posix_sqlog_severity_t severity, char *
     char   logFileDir[PATH_MAX];
     char  *logFileDirPtr;
     char   logFilePrefix[MAX_FILE_NAME];
-    char  *rootDir;
+    char  *logDir;
 
     if ( useAltLog_ )
     {
-        rootDir = getenv("TRAF_HOME");
-        if (rootDir == NULL)
+        logDir = getenv("TRAF_LOG");
+        if (logDir == NULL)
         {
             logFileDirPtr = NULL;
         }
         else
         {
-            sprintf(logFileDir, "%s/logs", rootDir);
+            sprintf(logFileDir, "%s", logDir);
             logFileDirPtr = logFileDir;
         }
 

--- a/core/sqf/monitor/linux/pnode.cxx
+++ b/core/sqf/monitor/linux/pnode.cxx
@@ -1256,8 +1256,9 @@ void CNode::StartNameServerProcess( void )
     char name[MAX_PROCESS_NAME];
     char stdout[MAX_PROCESS_PATH];
     
+    const char *logpath = getenv("TRAF_LOG");
     snprintf( name, sizeof(name), "$TNS%d", MyNode->GetZone() );
-    snprintf( stdout, sizeof(stdout), "stdout_TNS%d", MyNode->GetZone() );
+    snprintf( stdout, sizeof(stdout), "%s/stdout_TNS%d", logpath, MyNode->GetZone() );
 
     if (trace_settings & (TRACE_INIT | TRACE_RECOVERY))
     {
@@ -1319,8 +1320,9 @@ void CNode::StartWatchdogProcess( void )
     char stdout[MAX_PROCESS_PATH];
     CProcess * watchdogProcess;
     
+    const char *logpath = getenv("TRAF_LOG");
     snprintf( name, sizeof(name), "$WDG%d", MyNode->GetZone() );
-    snprintf( stdout, sizeof(stdout), "stdout_WDG%d", MyNode->GetZone() );
+    snprintf( stdout, sizeof(stdout), "%s/stdout_WDG%d", logpath, MyNode->GetZone() );
 
     // The following variables are used to retrieve the proper startup and keepalive environment variable
     // values, and to use as arguments for the lower level ioctl calls that interface with the watchdog 
@@ -1402,8 +1404,9 @@ void CNode::StartPStartDProcess( void )
     char stdout[MAX_PROCESS_PATH];
     CProcess * pstartdProcess;
     
+    const char *logpath = getenv("TRAF_LOG");
     snprintf( name, sizeof(name), "$PSD%d", MyNode->GetZone() );
-    snprintf( stdout, sizeof(stdout), "stdout_PSD%d", MyNode->GetZone() );
+    snprintf( stdout, sizeof(stdout), "%s/stdout_PSD%d", logpath, MyNode->GetZone() );
 
     strcpy(path,getenv("PATH"));
     strcat(path,":");
@@ -1579,8 +1582,9 @@ void CNode::StartSMServiceProcess( void )
     if (trace_settings & (TRACE_INIT | TRACE_RECOVERY))
        trace_printf("%s@%d" " - Creating SMService Process\n", method_name, __LINE__);
 
+    const char *logpath = getenv("TRAF_LOG");
     snprintf( name, sizeof(name), "$SMS%03d", MyNode->GetZone() );
-    snprintf( stdout, sizeof(stdout), "stdout_SMS%03d", MyNode->GetZone() );
+    snprintf( stdout, sizeof(stdout), "%s/stdout_SMS%03d", logpath, MyNode->GetZone() );
 
     strcpy(path,getenv("PATH"));
     strcat(path,":");

--- a/core/sqf/monitor/linux/redirector.cxx
+++ b/core/sqf/monitor/linux/redirector.cxx
@@ -61,6 +61,8 @@ using namespace std;
 #include "ptpclient.h"
 #endif
 
+#define MAX_FILE_NAME 256
+
 #ifndef NAMESERVER_PROCESS
 extern CNode *MyNode;
 extern sigset_t SigSet;
@@ -908,7 +910,10 @@ CRedirectStdout::CRedirectStdout(int nid, int pid, const char *filename, int sou
     // Add eyecatcher sequence as a debugging aid
     memcpy(&eyecatcher_, "REDE", 4);
 
-    fd_ = open(filename, O_CREAT | O_APPEND | O_WRONLY | O_NONBLOCK,
+    char   filepath[MAX_FILE_NAME];
+    snprintf(filepath, MAX_FILE_NAME, "%s/%s", getenv("TRAF_LOG"), filename);
+
+    fd_ = open(filepath, O_CREAT | O_APPEND | O_WRONLY | O_NONBLOCK,
                S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
     if( fd_ == -1 )
     {

--- a/core/sqf/monitor/linux/shell.cxx
+++ b/core/sqf/monitor/linux/shell.cxx
@@ -4542,7 +4542,7 @@ int node_up( int nid, char *node_name, bool nowait )
 
         // remove shared segment on the node
         char cmd[256];
-        sprintf(cmd, "pdsh -w %s \"sqipcrm %s >> $TRAF_HOME/logs/node_up_%s.log\"", node_name, node_name, node_name);
+        sprintf(cmd, "pdsh -w %s \"sqipcrm %s >> $TRAF_LOG/node_up_%s.log\"", node_name, node_name, node_name);
         system(cmd);
 
         // Start a monitor process on the node
@@ -6140,10 +6140,10 @@ void write_startup_log( char *msg )
     char fname[PATH_MAX];
     char msgString[MAX_BUFFER] = { 0 };
 
-    char *tmpDir = getenv( "TRAF_HOME" );
+    char *tmpDir = getenv( "TRAF_LOG" );
     if ( tmpDir )
     {
-        snprintf( fname, sizeof(fname), "%s/sql/scripts/startup.log", tmpDir );
+        snprintf( fname, sizeof(fname), "%s/mon_startup.log", tmpDir );
     }
     else
     {

--- a/core/sqf/sqenvcom.sh
+++ b/core/sqf/sqenvcom.sh
@@ -147,6 +147,7 @@ else
 fi
 export TRAF_HOME=$PWD
 export TRAF_VAR=${TRAF_VAR:-$TRAF_HOME/tmp}
+export TRAF_LOG=${TRAF_LOG:-$TRAF_HOME/logs}
 export TRAF_CONF=${TRAF_CONF:-$TRAF_HOME/conf}
 
 # normal installed location, can be overridden in .trafodion

--- a/core/sqf/sql/scripts/ckillall
+++ b/core/sqf/sql/scripts/ckillall
@@ -23,7 +23,7 @@
 #
 
 function LogIt {
-    echo  "`date`: $1" >> $TRAF_HOME/logs/startup.log
+    echo  "`date`: $1" >> $TRAF_LOG/startup.log
 }
 
 lv_prog_name="ckillall"

--- a/core/sqf/sql/scripts/cleanlogs
+++ b/core/sqf/sql/scripts/cleanlogs
@@ -33,42 +33,41 @@ function usage() {
    echo ""
    echo "$prog { all | dcs | rest | core }"
    echo "    all  --- Remove files from core, dcs and rest logs folder"
-   echo "    dcs  --- Remove files from $DCS_INSTALL_DIR/logs folder"
-   echo "    rest --- Remove files from $REST_INSTALL_DIR/logs folder"
-   echo "    core --- Remove log files residing in $TRAF_HOME/logs folder"
+   echo "    dcs  --- Remove files from $TRAF_LOG/dcs folder"
+   echo "    rest --- Remove files from $TRAF_LOG/rest folder"
+   echo "    core --- Remove log files residing in $TRAF_LOG folder"
 }
 
 function core_logs() {
  if [[ ! -z $L_PDSH ]]; then
-   $L_PDSH "rm -f ${TRAF_HOME}/logs/*.err"
-   $L_PDSH "rm -f ${TRAF_HOME}/logs/*.log"
-   $L_PDSH "rm -f ${TRAF_HOME}/logs/*log.[0-9]*"
-   $L_PDSH "rm -f ${TRAF_HOME}/sql/scripts/stdout_*"
+   $L_PDSH "rm -f ${TRAF_LOG}/*.err"
+   $L_PDSH "rm -f ${TRAF_LOG}/*.log"
+   $L_PDSH "rm -f ${TRAF_LOG}/*log.[0-9]*"
+   $L_PDSH "rm -f ${TRAF_LOG}/stdout_*"
  else
-   rm -f ${TRAF_HOME}/logs/*
-   rm -f ${TRAF_HOME}/sql/scripts/stdout_*
+   rm -f ${TRAF_LOG}/*
  fi
 }
 
 function dcs_logs() {
  if [[ ! -z $L_PDSH ]]; then
-   $L_PDSH "rm -f ${DCS_INSTALL_DIR}/logs/*.log"
-   $L_PDSH "rm -f ${DCS_INSTALL_DIR}/logs/*.log.[0-9]*"
-   $L_PDSH "rm -f ${DCS_INSTALL_DIR}/logs/*.out"
-   $L_PDSH "rm -f ${DCS_INSTALL_DIR}/logs/*.out.[0-9]*"
+   $L_PDSH "rm -f ${TRAF_LOG}/dcs/*.log"
+   $L_PDSH "rm -f ${TRAF_LOG}/dcs/*.log.[0-9]*"
+   $L_PDSH "rm -f ${TRAF_LOG}/dcs/*.out"
+   $L_PDSH "rm -f ${TRAF_LOG}/dcs/*.out.[0-9]*"
  else
-   rm -f ${DCS_INSTALL_DIR}/logs/*
+   rm -f ${TRAF_LOG}/dcs/*
  fi
 }
 
 function rest_logs() {
  if [[ ! -z $L_PDSH ]]; then
-   $L_PDSH "rm -f ${REST_INSTALL_DIR}/logs/*.log"
-   $L_PDSH "rm -f ${REST_INSTALL_DIR}/logs/*.log.[0-9]*"
-   $L_PDSH "rm -f ${REST_INSTALL_DIR}/logs/*.out"
-   $L_PDSH "rm -f ${REST_INSTALL_DIR}/logs/*.out.[0-9]*"
+   $L_PDSH "rm -f ${TRAF_LOG}/rest/*.log"
+   $L_PDSH "rm -f ${TRAF_LOG}/rest/*.log.[0-9]*"
+   $L_PDSH "rm -f ${TRAF_LOG}/rest/*.out"
+   $L_PDSH "rm -f ${TRAF_LOG}/rest/*.out.[0-9]*"
  else
-   rm -f ${REST_INSTALL_DIR}/logs/*
+   rm -f ${TRAF_LOG}/rest/*
  fi
 }
 

--- a/core/sqf/sql/scripts/cresumeall
+++ b/core/sqf/sql/scripts/cresumeall
@@ -23,7 +23,7 @@
 #
 
 function LogIt {
-    echo  "`date`: $1" >> $TRAF_HOME/logs/startup.log
+    echo  "`date`: $1" >> $TRAF_LOG/startup.log
 }
 
 lv_prog_name="cresumeall"

--- a/core/sqf/sql/scripts/csuspendall
+++ b/core/sqf/sql/scripts/csuspendall
@@ -23,7 +23,7 @@
 #
 
 function LogIt {
-    echo  "`date`: $1" >> $TRAF_HOME/logs/startup.log
+    echo  "`date`: $1" >> $TRAF_LOG/startup.log
 }
 
 lv_prog_name="csuspendall"

--- a/core/sqf/sql/scripts/genms
+++ b/core/sqf/sql/scripts/genms
@@ -206,6 +206,7 @@ restinstalldir=$REST_INSTALL_DIR
 echo "REST_INSTALL_DIR=$restinstalldir"
 
 echo "TRAF_VAR=$TRAF_VAR"
+echo "TRAF_LOG=$TRAF_LOG"
 echo "TRAF_CONF=$TRAF_CONF"
 
 if [[ ! -z "$PID_MAX" ]]; then

--- a/core/sqf/sql/scripts/gensq.pl
+++ b/core/sqf/sql/scripts/gensq.pl
@@ -197,7 +197,7 @@ sub printInitialLines {
 #    printScript(1, "   echo\n");
 #    printScript(1, "else\n");
 #    printScript(1, "   echo \"Aborting startup.\"\n");
-#    printScript(1, "   more \$TRAF_HOME/logs/sqcheckmon.log\n");
+#    printScript(1, "   more \$TRAF_LOG/sqcheckmon.log\n");
 #    printScript(1, "   exit 1\n");
 #    printScript(1, "fi\n");
 

--- a/core/sqf/sql/scripts/gomon.cold
+++ b/core/sqf/sql/scripts/gomon.cold
@@ -69,7 +69,7 @@ else
 
    if [[ $monitor_ready -lt 1 ]]; then
       echo "Aborting startup!"
-      cat $TRAF_HOME/logs/sqcheckmon.log
+      cat $TRAF_LOG/sqcheckmon.log
       exit 1
    else
 

--- a/core/sqf/sql/scripts/hbcheck
+++ b/core/sqf/sql/scripts/hbcheck
@@ -29,8 +29,8 @@ if [ -z $JAVA_HOME ]; then
     exit 1;
 fi
 
-mkdir -p $TRAF_HOME/logs
-lv_stderr_file="$TRAF_HOME/logs/hbcheck.log"
+mkdir $TRAF_LOG
+lv_stderr_file="$TRAF_LOG/hbcheck.log"
 echo "Stderr being written to the file: ${lv_stderr_file}"
 for interval in 5 10 15 30
 do

--- a/core/sqf/sql/scripts/ilh_hbase_repair
+++ b/core/sqf/sql/scripts/ilh_hbase_repair
@@ -54,7 +54,7 @@ fi
 
 lv_starttime=`date`
 
-lv_stderr_file="$TRAF_HOME/logs/hbase_hbck_repair.log"
+lv_stderr_file="$TRAF_LOG/hbase_hbck_repair.log"
 echo "Stderr being written to the file: ${lv_stderr_file}"
 ${HBASE_HOME}/bin/hbase hbck -repair > ${lv_stderr_file} 2>${lv_stderr_file}
 

--- a/core/sqf/sql/scripts/krb5check
+++ b/core/sqf/sql/scripts/krb5check
@@ -32,7 +32,7 @@ function msg
 WAIT_INTERVAL=300
 REPORT_INTERVAL=12
 LOCK_FILE=$TRAF_VAR/krb5check
-LOG_FILE=$TRAF_HOME/logs/krb5check
+LOG_FILE=$TRAF_LOG/krb5check
 CACHE_FILE=""
 HOST_NAME=`hostname -f`
 getKeytab

--- a/core/sqf/sql/scripts/krb5functions
+++ b/core/sqf/sql/scripts/krb5functions
@@ -114,7 +114,7 @@ function getStatus
 
 function getLogFile
 {
-  LOG_FILE=$TRAF_HOME/logs/krb5check
+  LOG_FILE=$TRAF_LOG/krb5check
 }
 
 function getLockFile

--- a/core/sqf/sql/scripts/krb5service
+++ b/core/sqf/sql/scripts/krb5service
@@ -47,7 +47,7 @@
 #   stop    - stops the ticket renewal service
 #
 # Location attributes (see krb5functions to change these values):
-#  [LOG_FILE]  : $TRAF_HOME/logs/krb5check - log where all events are stored
+#  [LOG_FILE]  : $TRAF_LOG/krb5check - log where all events are stored
 #    (the log file is recreated each time the krb5service is started)
 #  [LOCK_FILE] : $TRAF_VAR/krb5check - file to keep track of krb5check process
 #    (acts as a semiphore to prevent multiple occurrances from running)
@@ -228,7 +228,7 @@ if [ $doStart -eq 1 ]; then
   fi
 
   # remove log, may want to handle log garbage collection differently 
-  rm $TRAF_HOME/logs/krb5check 
+  rm $TRAF_LOG/krb5check 
 
   # kick off a process that wakes up once in a while and check for 
   # ticket expirations

--- a/core/sqf/sql/scripts/sqcheckmon
+++ b/core/sqf/sql/scripts/sqcheckmon
@@ -29,7 +29,7 @@ let lv_sleep_time=5
 let lv_first_time=1
 
 while [ $lv_sqmonitor_up '==' 0 ]; do
-    sqshell -a <<EOF >$TRAF_HOME/logs/sqcheckmon.log 2>&1
+    sqshell -a <<EOF >$TRAF_LOG/sqcheckmon.log 2>&1
 EOF
     let lv_sqshell_ret=$?
     if [ $lv_sqshell_ret '==' 0 ]; then

--- a/core/sqf/sql/scripts/sqcore
+++ b/core/sqf/sql/scripts/sqcore
@@ -34,7 +34,7 @@ function Usage {
     echo "Usage: $0 [ -d <directory> | -q | -r | -h  ]"
     echo 
     echo "-d        Head node directory where the users cluster core files are to be moved"
-    echo "          The default location is \$TRAF_HOME/logs"
+    echo "          The default location is \$TRAF_LOG"
     echo "-q        Quiet mode (no prompts)"
     echo "-r        Remove all of a users cluster core files (excluding head node)"
     echo "-h        Help"
@@ -93,7 +93,7 @@ declare -i SQ_REMOVE=0
 declare -i ERR_FLAG=0
 head=`headnode`
 current=`uname -n`
-to_path=$TRAF_HOME/logs
+to_path=$TRAF_LOG
 
 GetOpts $@
 

--- a/core/sqf/sql/scripts/sqgen
+++ b/core/sqf/sql/scripts/sqgen
@@ -178,7 +178,7 @@ while [ $# != 0 ]
   done
 
 export SQETC_DIR=$TRAF_HOME/etc
-export SQLOG_DIR=$TRAF_HOME/logs
+export SQLOG_DIR=$TRAF_LOG
 mkdir -p $SQETC_DIR
 mkdir -p $SQLOG_DIR
 mkdir -p $MPI_TMPDIR

--- a/core/sqf/sql/scripts/sqsmdstats
+++ b/core/sqf/sql/scripts/sqsmdstats
@@ -279,7 +279,7 @@ function generateOutput
 # **************************************************************************
 # FUNCTION: adjustSavedFiles
 # removes old versions of saved files, only retain $archiveCount versions
-# copies final list of files to $TRAF_HOME/logs/sqsmdstats_logs directory
+# copies final list of files to $TRAF_LOG/sqsmdstats_logs directory
 #   on all nodes
 function adjustSavedFiles
 {
@@ -499,7 +499,7 @@ fi
  
 # set up script location, name of results file, etc.
 if [ "$scriptAndLogLoc" = "" ]; then
-   scriptAndLogLoc=$TRAF_HOME/logs/sqsmdstats_logs
+   scriptAndLogLoc=$TRAF_LOG/sqsmdstats_logs
 fi
 
 resultsFile=$scriptAndLogLoc/sqsmdstats_details_$scriptStartTime.log

--- a/core/sqf/sql/scripts/sqstart
+++ b/core/sqf/sql/scripts/sqstart
@@ -25,7 +25,7 @@
 #Trafodion startup Script. 
 
 function LogIt {
-    echo  "`date`: $1" >> $TRAF_HOME/logs/startup.log
+    echo  "`date`: $1" >> $TRAF_LOG/startup.log
 }
 
 function Usage {
@@ -154,7 +154,7 @@ function TrafodionStartProcesses {
         echoLog
         echoLog "Please check the Trafodion shell log file : $SQMON_LOG"
         echoLog
-        echoLog "For additional information, please check the monitor mon.*.log file in $TRAF_HOME/logs"
+        echoLog "For additional information, please check the monitor mon.*.log file in $TRAF_LOG"
         echoLog
         echoLog "Trafodion Startup (from $PWD) Failed"
         echoLog
@@ -369,9 +369,9 @@ fi
 
 
 
-SQLOG_DIR=$TRAF_HOME/logs
+SQLOG_DIR=$TRAF_LOG
 SQMON_LOG=$SQLOG_DIR/sqmon.log
-SQSTART_EXIT_STATUS=./sqstart.exit_status
+SQSTART_EXIT_STATUS=$TRAF_VAR/sqstart.exit_status
 
 if [[ -z $SQSCRIPTS_DIR ]]; then
     SQSCRIPTS_DIR=$TRAF_HOME/sql/scripts
@@ -428,11 +428,11 @@ if [[ -z ${TRAF_AGENT} ]]; then
     $SQPDSHA "cd $TRAF_HOME/sql/scripts; utilConfigDb -u"
 
     echoLog "Executing sqipcrm (output to sqipcrm.out)"
-    sqipcrm > sqipcrm.out
+    sqipcrm > $TRAF_LOG/sqipcrm.out 2>&1
 fi
 
 echoLog "Executing cleanZKNodes (output to cleanZKNodes.out)"
-cleanZKNodes > cleanZKNodes.out 2>&1
+cleanZKNodes > $TRAF_LOG/cleanZKNodes.out 2>&1
 
 echoLog "Checking whether HBase is up"
 hbcheck 4 30

--- a/core/sqf/sql/scripts/sqstop
+++ b/core/sqf/sql/scripts/sqstop
@@ -35,7 +35,7 @@ function Usage {
 }
 
 function LogIt {
-    echo  "`date`: $1" >> $TRAF_HOME/logs/startup.log
+    echo  "`date`: $1" >> $TRAF_LOG/startup.log
 }
 
 function echoLog {
@@ -44,10 +44,10 @@ function echoLog {
 }
 
 script_name=`/bin/basename $0`
-SQLOG_DIR=$TRAF_HOME/logs
+SQLOG_DIR=$TRAF_LOG
 SQMON_LOG=$SQLOG_DIR/sqmon.log
 SQGOMON_FILE=$TRAF_HOME/sql/scripts/gomon.cold
-SQSTOP_EXIT_STATUS=$TRAF_HOME/sql/scripts/sqstop.exit_status
+SQSTOP_EXIT_STATUS=$TRAF_VAR/sqstop.exit_status
 
 if [ $# -eq 0 ]; then
     shutdowntype=normal
@@ -227,7 +227,7 @@ if (test -n "${CLUSTERNAME}"); then
 					unbindip=`echo "$match_ip_interface"|awk '{print $2}'`
 					unbindlb=`echo "$match_ip_interface"|awk '{print $NF}'`
 					echoLog "pdsh $cmd_timeout -S -w $curnode sudo ip addr del $unbindip dev $myinterface label $unbindlb"
-					pdsh $cmd_timeout -S -w $curnode sudo ip addr del $unbindip dev $myinterface label $unbindlb >> $TRAF_HOME/logs/ndcsunbind.log
+					pdsh $cmd_timeout -S -w $curnode sudo ip addr del $unbindip dev $myinterface label $unbindlb >> $TRAF_LOG/ndcsunbind.log
 				fi
 	       done
 	   done
@@ -242,7 +242,7 @@ if (test -n "${CLUSTERNAME}"); then
 					unbindip=`echo "$match_ip_interface"|awk '{print $2}'`
 					unbindlb=`echo "$match_ip_interface"|awk '{print $NF}'`
 					echoLog "pdsh $cmd_timeout -S -w $curnode sudo ip addr del $unbindip dev $myinterface label $unbindlb"
-					pdsh $cmd_timeout -S -w $curnode sudo ip addr del $unbindip dev $myinterface label $unbindlb >> $TRAF_HOME/logs/ndcsunbind.log
+					pdsh $cmd_timeout -S -w $curnode sudo ip addr del $unbindip dev $myinterface label $unbindlb >> $TRAF_LOG/ndcsunbind.log
 			   fi
 		   done
 	   done

--- a/core/sqf/sql/scripts/traf_authentication_setup
+++ b/core/sqf/sql/scripts/traf_authentication_setup
@@ -189,7 +189,7 @@ function copy_config
 # =============================================================================
 function enable_authorization
 {
-  logLoc=$TRAF_HOME/logs
+  logLoc=$TRAF_LOG
   rm $logLoc/authEnable.log > /dev/null 2>&1
   #gdb sqlci
   sqlci >> "$logLoc/authEnable.log" 2>&1 <<eof
@@ -216,7 +216,7 @@ eof
 # =============================================================================
 function disable_authorization
 {
-  logLoc=$TRAF_HOME/logs
+  logLoc=$TRAF_LOG
   rm $logLoc/authDisable.log > /dev/null 2>&1
   sqlci >> "$logLoc/authDisable.log" 2>&1 <<eof
    values (current_timestamp);
@@ -243,7 +243,7 @@ eof
 # =============================================================================
 function status_authorization
 {
-  logLoc=$TRAF_HOME/logs
+  logLoc=$TRAF_LOG
   rm $logLoc/authStatus.log > /dev/null 2>&1
   sqlci >> "$logLoc/authStatus.log" 2>&1 <<eof
    values (current_timestamp);

--- a/core/sqf/src/seabed/src/util.cpp
+++ b/core/sqf/src/seabed/src/util.cpp
@@ -1249,11 +1249,11 @@ void sb_util_write_log(char *pp_buf) {
 
     strncpy(gv_ms_save_log, pp_buf, sizeof(gv_ms_save_log) - 1);
     gv_ms_save_log[sizeof(gv_ms_save_log) - 1] = '\0';
-    lp_root = getenv("TRAF_HOME");
+    lp_root = getenv("TRAF_LOG");
     if (lp_root == NULL)
         lp_log_file_dir = NULL;
     else {
-        sprintf(la_log_file_dir, "%s/logs", lp_root);
+        sprintf(la_log_file_dir, "%s", lp_root);
         lp_log_file_dir = la_log_file_dir;
     }
     SBX_log_write(SBX_LOG_TYPE_LOGFILE |        // log_type

--- a/core/sqf/src/seabed/test/gostart
+++ b/core/sqf/src/seabed/test/gostart
@@ -23,6 +23,6 @@
 date
 rm -f core.* > /dev/null 2>&1
 sqipcrm
-if [ ! -d $TRAF_HOME/logs ]; then
-	mkdir $TRAF_HOME/logs
+if [ ! -d $TRAF_LOG ]; then
+	mkdir $TRAF_LOG
 fi

--- a/core/sqf/src/tm/tminfo.cpp
+++ b/core/sqf/src/tm/tminfo.cpp
@@ -1507,7 +1507,7 @@ int32 TM_Info::restart_tm_process(int32 pv_nid)
 {
     char la_buf_tm_name[20];
     char la_prog[MS_MON_MAX_PROCESS_PATH];
-    char la_out_file[128];
+    char la_out_file[MS_MON_MAX_PROCESS_PATH];
     int lv_server_nid = pv_nid;
     int lv_server_pid;
     int32 lv_oid = 0;
@@ -1528,7 +1528,8 @@ int32 TM_Info::restart_tm_process(int32 pv_nid)
     }
 
     strcpy(la_prog, "tm");
-    sprintf(la_out_file, "stdout_dtm_%d", pv_nid);
+    const char *la_logpath = ms_getenv_str("TRAF_LOG");
+    sprintf(la_out_file, "%s/stdout_dtm_%d", la_logpath, pv_nid);
 
     sprintf (la_buf_tm_name, "$tm%d", pv_nid);
 

--- a/core/sqf/sysinstall/etc/init.d/trafodion
+++ b/core/sqf/sysinstall/etc/init.d/trafodion
@@ -48,7 +48,7 @@ fi
 TRAF_USER=${TRAF_USER:-"trafodion"}
 TRAF_SUDO_CMD=${TRAF_SUDO_CMD:-"su ${TRAF_USER} --login "}
 TRAF_SHELL_CMD=${TRAF_SHELL_CMD:-sqshell}
-TRAF_OUT=${TRAF_VAR:-/var}/log/trafodion/${TRAF_SHELL_CMD}.log
+TRAF_OUT=${TRAF_LOG}/${TRAF_SHELL_CMD}.log
 TRAF_NODE_NAME=`uname -n`
 
 

--- a/core/sqf/tools/sqtools.sh
+++ b/core/sqf/tools/sqtools.sh
@@ -327,7 +327,7 @@ function run_util {
 # check the startup log and sort the interesting even chronologically
 function sqchksl {
     setup_sqpdsh
-    eval '$SQPDSHA "cd $TRAF_HOME/sql/scripts; grep Executing startup.log 2>/dev/null" 2>/dev/null | sort -k4 -k5'
+    eval '$SQPDSHA "cd $TRAF_LOG; grep Executing mon_startup.log 2>/dev/null" 2>/dev/null | sort -k4 -k5'
 }
 
 function sqchkopt {
@@ -371,7 +371,7 @@ function sqsecheck {
 }
 
 function sqchkmpi {
-    pdsh $MY_NODES "cd $TRAF_HOME/logs; egrep -i '(mpi bug|ibv_create)' *.log" 2>/dev/null
+    pdsh $MY_NODES "cd $TRAF_LOG; egrep -i '(mpi bug|ibv_create)' *.log" 2>/dev/null
 }
 
 #### Log Collection functions
@@ -430,24 +430,23 @@ function sqsavelogs {
     
     sqcollectmonmemlog 2>/dev/null
 
-    cp -p $TRAF_HOME/logs/master_exec*.log ${lv_copy_to_dir}
-    cp -p $TRAF_HOME/logs/mon.*.log ${lv_copy_to_dir}
-    cp -p $TRAF_HOME/logs/monmem.*.log ${lv_copy_to_dir}
-    cp -p $TRAF_HOME/logs/pstart*.log ${lv_copy_to_dir}
-    cp -p $TRAF_HOME/logs/smstats.*.log ${lv_copy_to_dir}
-    cp -p $TRAF_HOME/logs/sqmo*.log ${lv_copy_to_dir}
-    cp -p $TRAF_HOME/logs/trafodion.*log* ${lv_copy_to_dir}
-    cp -p $TRAF_HOME/logs/tm*.log ${lv_copy_to_dir}
-    cp -p $TRAF_HOME/logs/wdt.*.log ${lv_copy_to_dir}
+    cp -p $TRAF_LOG/master_exec*.log ${lv_copy_to_dir}
+    cp -p $TRAF_LOG/mon.*.log ${lv_copy_to_dir}
+    cp -p $TRAF_LOG/monmem.*.log ${lv_copy_to_dir}
+    cp -p $TRAF_LOG/pstart*.log ${lv_copy_to_dir}
+    cp -p $TRAF_LOG/smstats.*.log ${lv_copy_to_dir}
+    cp -p $TRAF_LOG/sqmo*.log ${lv_copy_to_dir}
+    cp -p $TRAF_LOG/trafodion.*log* ${lv_copy_to_dir}
+    cp -p $TRAF_LOG/tm*.log ${lv_copy_to_dir}
+    cp -p $TRAF_LOG/wdt.*.log ${lv_copy_to_dir}
 
     cp -p $TRAF_VAR/monitor.map.[0-9]*.* ${lv_copy_to_dir}
     cp -p $TRAF_VAR/monitor.trace* ${lv_copy_to_dir}
 
     lv_stdout_dir_name=${lv_copy_to_dir}/stdout_${lv_node}
     mkdir -p ${lv_stdout_dir_name}
-    cp -p $TRAF_HOME/sql/scripts/startup.log ${lv_copy_to_dir}/startup.${lv_node}.log
-    cp -p $TRAF_HOME/sql/scripts/stdout_* ${lv_stdout_dir_name}
-    cp -p $TRAF_HOME/sql/scripts/hs_err_pid*.log ${lv_stdout_dir_name}
+    cp -p $TRAF_LOG/startup.log ${lv_copy_to_dir}/startup.${lv_node}.log
+    cp -p $TRAF_LOG/stdout_* ${lv_stdout_dir_name}
 
     lv_config_dir_name=${lv_copy_to_dir}/sqconfig_db
     cp -p $TRAF_HOME/sql/scripts/sqconfig.db ${lv_config_dir_name}/${lv_node}_sqconfig.db
@@ -692,7 +691,7 @@ function sqcollectmonmemlog {
     if [ $monpid_x ]; then
       monpid=`printf "%d" 0x$monpid_x`
       nodename=`uname -n`
-      monmemlog $monpid nowait > $TRAF_HOME/logs/monmem.${nodename}.${monpid}.log
+      monmemlog $monpid nowait > $TRAF_LOG/monmem.${nodename}.${monpid}.log
     fi
 }
 
@@ -1002,7 +1001,7 @@ function cdw {
     cd $TRAF_HOME
 }
 function cdl {
-    cd $TRAF_HOME/logs
+    cd $TRAF_LOG
 }
 function cdb {
     cd $TRAF_HOME/export/bin${SQ_MBTYPE}

--- a/core/sql/arkcmp/CmpErrLog.cpp
+++ b/core/sql/arkcmp/CmpErrLog.cpp
@@ -133,19 +133,19 @@ void CmpErrLog::openLogFile()
   // On Linux determine the log location based off of TRAF_HOME environment
   // variable.
   char logFilePath[MAX_LOGFILE_NAME_LEN+1];
-  char *sqroot = getenv("TRAF_HOME");
+  char *sqlogs = getenv("TRAF_LOG");
 
   // Use a generated path for the logfile if 3 conditions are met:
-  //   1. TRAF_HOME is set in the environment.
+  //   1. TRAF_LOG is set in the environment.
   //   2. The first character of the logfile starts with a character or digit.
   //   3. The complete path can fit into the size of the "logFilePath" buffer.
-  if ((sqroot != NULL) && 
+  if ((sqlogs != NULL) &&
       (isalnum(logFileName[0])) &&
-      (strlen(sqroot) + strlen(logFileName) < sizeof(logFilePath) - 7))
+      (strlen(sqlogs) + strlen(logFileName) < sizeof(logFilePath) - 2))
   {
     // Create the full path to the log file in the logFilePath buffer.
-    snprintf(logFilePath, sizeof(logFilePath), "%s/logs/%s",
-             sqroot, logFileName);
+    snprintf(logFilePath, sizeof(logFilePath), "%s/%s",
+             sqlogs, logFileName);
 
     // Call renameBigLogFile() to check the size and rename the file
     // if it is too big.

--- a/core/sql/executor/JavaObjectInterface.cpp
+++ b/core/sql/executor/JavaObjectInterface.cpp
@@ -307,15 +307,14 @@ int JavaObjectInterface::createJVM(LmJavaOptions *options)
 
   if (!isDefinedInOptions(options, "-XX:HeapDumpPath="))
     {
-      char *mySqRoot = getenv("TRAF_HOME");
+      char *mySqLogs = getenv("TRAF_LOG");
       int len;
-      if (mySqRoot != NULL)
+      if (mySqLogs != NULL)
         {
-          len = strlen(mySqRoot); 
+          len = strlen(mySqLogs); 
           oomDumpDir = new char[len+50];
           strcpy(oomDumpDir, "-XX:HeapDumpPath="); 
-          strcat(oomDumpDir, mySqRoot);
-          strcat(oomDumpDir, "/logs");
+          strcat(oomDumpDir, mySqLogs);
           jvm_options[numJVMOptions].optionString = (char *)oomDumpDir;
           jvm_options[numJVMOptions].extraInfo = NULL;
           numJVMOptions++;

--- a/core/sql/exp/ExpLOBaccess.cpp
+++ b/core/sql/exp/ExpLOBaccess.cpp
@@ -3950,7 +3950,7 @@ void ExLobGlobals::traceMessage(const char *logMessage, ExLobCursor *cursor,
 
 //Enable envvar TRACE_LOB_ACTIONS to enable tracing. 
 //The output file will be in 
-//$TRAF_HOME/logs directory on each node
+//$TRAF_LOG directory on each node
 
 void lobDebugInfo(const char *logMessage,Int32 errorcode,
                          Int32 line, NABoolean lobTrace)

--- a/core/sql/export/NAAbort.cpp
+++ b/core/sql/export/NAAbort.cpp
@@ -237,7 +237,7 @@ void assert_botch_abend( const char *f, Int32 l, const char * m, const char *c)
   SQLMXLoggingArea::logSQLMXAssertionFailureEvent(f, l, m, c, tidPtr); // Any executor thread can log a failure
 
   // Log the message to stderr. On Linux stderr is mapped to a file
-  // under $TRAF_HOME/logs and our output will be prefixed with a
+  // under $TRAF_LOG and our output will be prefixed with a
   // timestamp and process ID.
   cerr << "Executor assertion failure in file " << f
        << " on line " << l << '\n';

--- a/core/sql/regress/newregr/mvqr/installMvqrSQ
+++ b/core/sql/regress/newregr/mvqr/installMvqrSQ
@@ -143,7 +143,7 @@ cat > $qmmscr <<EOF
   sqshell -a <<eof
   set  {process \\\$$qmmName} PERSIST_RETRIES=10,60
   set  {process \\\$$qmmName} PERSIST_ZONES=0
-  exec {name \\\$$qmmName, nid 3, nowait, out stdout_$qmmName} tdm_arkqmm
+  exec {name \\\$$qmmName, nid 3, nowait, out $TRAF_LOG/stdout_$qmmName} tdm_arkqmm
   exit
 eof
 EOF
@@ -152,7 +152,7 @@ cat > $qmmscr <<EOF
   sqshell -a <<eof
   set  {process \\\$$qmmName} PERSIST_RETRIES=10,60
   set  {process \\\$$qmmName} PERSIST_ZONES=0
-  exec {name \\\$$qmmName, nid 0, nowait, out stdout_$qmmName} tdm_arkqmm
+  exec {name \\\$$qmmName, nid 0, nowait, out $TRAF_LOG/stdout_$qmmName} tdm_arkqmm
   exit
 eof
 EOF

--- a/core/sql/regress/privs1/Utils.java
+++ b/core/sql/regress/privs1/Utils.java
@@ -44,7 +44,7 @@ public class Utils
    static boolean log = false;
    static String logFileName = "udr_tools.log";
    static String logLocation = null;
-   static String sqRoot = null;
+   static String Logs = null;
    static String userName = null;
 
    Utils () 
@@ -53,8 +53,8 @@ public class Utils
        log = Boolean.getBoolean("debugOn");
      
      if (log) { 
-       sqRoot = System.getenv("TRAF_HOME");
-       logLocation = sqRoot + "/logs/";
+       Logs = System.getenv("TRAF_LOG");
+       logLocation = sqLogs + "/";
      }
    }
 

--- a/core/sql/regress/udr/EXPECTED002
+++ b/core/sql/regress/udr/EXPECTED002
@@ -6560,7 +6560,7 @@ the                                                        611
 >>
 >>-- copy a file with known content to the log directory and see whether
 >>-- we get the correct results
->>sh cp $$scriptsdir$$/udr/TEST002.sample_events $$TRAF_HOME$$/logs/master_exec_regr_999_99999.log;
+>>sh cp $$scriptsdir$$/udr/TEST002.sample_events $$TRAF_LOG$$/master_exec_regr_999_99999.log;
 >>
 >>select count(*) as num_events,
 +>       max(log_file_line) as num_lines,
@@ -6597,7 +6597,7 @@ LOG_TS                      SEVERITY    COMPONENT                               
 --- 8 row(s) selected.
 >>-- lines 20, 30 and 31 have parse errors and are also displayed
 >>
->>sh rm $$TRAF_HOME$$/logs/master_exec_regr_999_99999.log;
+>>sh rm $$TRAF_LOG$$/master_exec_regr_999_99999.log;
 >>
 >>-- some negative test cases
 >>prepare s from select * from udf(event_log_reader(10));

--- a/core/sql/regress/udr/TEST002
+++ b/core/sql/regress/udr/TEST002
@@ -175,7 +175,7 @@ where x.log_file_line <100;
 
 -- copy a file with known content to the log directory and see whether
 -- we get the correct results
-sh cp $$scriptsdir$$/udr/TEST002.sample_events $$TRAF_HOME$$/logs/master_exec_regr_999_99999.log;
+sh cp $$scriptsdir$$/udr/TEST002.sample_events $$TRAF_LOG$$/master_exec_regr_999_99999.log;
 
 select count(*) as num_events,
        max(log_file_line) as num_lines,
@@ -191,7 +191,7 @@ where log_file_name = 'master_exec_regr_999_99999.log'
 order by log_file_line;
 -- lines 20, 30 and 31 have parse errors and are also displayed
 
-sh rm $$TRAF_HOME$$/logs/master_exec_regr_999_99999.log;
+sh rm $$TRAF_LOG$$/master_exec_regr_999_99999.log;
 
 -- some negative test cases
 prepare s from select * from udf(event_log_reader(10));

--- a/core/sql/regress/udr/Utils.java
+++ b/core/sql/regress/udr/Utils.java
@@ -44,7 +44,7 @@ public class Utils
    static boolean log = false;
    static String logFileName = "udr_tools.log";
    static String logLocation = null;
-   static String sqRoot = null;
+   static String sqLogs = null;
    static String userName = null;
 
    Utils () 
@@ -53,8 +53,8 @@ public class Utils
        log = Boolean.getBoolean("debugOn");
      
      if (log) { 
-       sqRoot = System.getenv("TRAF_HOME");
-       logLocation = sqRoot + "/logs/";
+       sqLogs = System.getenv("TRAF_LOG");
+       logLocation = sqLogs + "/";
      }
    }
 

--- a/core/sql/sqlcomp/PrivMgr.cpp
+++ b/core/sql/sqlcomp/PrivMgr.cpp
@@ -1068,7 +1068,7 @@ void PrivMgr::setFlags()
 //   QRLogger generates a message calls the log method in 
 //      sqf/commonLogger/CommonLogger (.h & .cpp) 
 //   CommonLogger interfaces with the log4cxx code which eventually puts
-//      a message into a log file called ../sqf/logs/master_exec_0_pid.log.  
+//      a message into a log file called $TRAF_LOG/master_exec_0_pid.log.  
 //      A new master log is created for each new SQL process started.
 //
 // Sometimes it is amazing that things actually work with all these levels

--- a/core/sql/sqludr/SqlUdrPredefLogReader.cpp
+++ b/core/sql/sqludr/SqlUdrPredefLogReader.cpp
@@ -533,7 +533,7 @@ void ReadCppEventsUDFInterface::processData(UDRInvocationInfo &info,
 
     logrootdir = getenv("TRAF_LOG");
     if (strlen(logrootdir) > 1000)
-	throw UDRException(38001, "TRAF_HOME is longer than 1000 characters");
+	throw UDRException(38001, "TRAF_LOG is longer than 1000 characters");
     std::string logDirName(logrootdir);
 
     switch (logLocationIndex) 
@@ -545,6 +545,7 @@ void ReadCppEventsUDFInterface::processData(UDRInvocationInfo &info,
       break ;
     case 2:
       logDirName += "/rest";
+      break ;
     default:
       throw UDRException(38001, "Internal error in determining logroot directory");
     }

--- a/core/sql/sqludr/SqlUdrPredefLogReader.cpp
+++ b/core/sql/sqludr/SqlUdrPredefLogReader.cpp
@@ -530,36 +530,27 @@ void ReadCppEventsUDFInterface::processData(UDRInvocationInfo &info,
   {
     char* logrootdir = NULL;
     char* confrootdir = NULL;
+
+    logrootdir = getenv("TRAF_LOG");
+    if (strlen(logrootdir) > 1000)
+	throw UDRException(38001, "TRAF_HOME is longer than 1000 characters");
+    std::string logDirName(logrootdir);
+
     switch (logLocationIndex) 
     {
-    case 0: // sqroot, for all logs other than dcs
-      logrootdir = getenv("TRAF_HOME");
-      if (strlen(logrootdir) > 1000)
-	throw UDRException(38001, "TRAF_HOME is longer than 1000 characters");
+    case 0: // no sub-directory
       break ;
     case 1:
-      logrootdir = getenv("DCS_INSTALL_DIR");
-      if (!logrootdir)
-	throw UDRException(38001, "DCS_INSTALL_DIR not set");
-      else if (strlen(logrootdir) > 1000)
-	throw UDRException(38001, "DCS_INSTALL_DIR is longer than 1000 characters");
+      logDirName += "/dcs";
       break ;
     case 2:
-      logrootdir = getenv("REST_INSTALL_DIR");
-      if (!logrootdir)
-	throw UDRException(38001, "REST_INSTALL_DIR not set");
-      else if (strlen(logrootdir) > 1000)
-	throw UDRException(38001, "REST_INSTALL_DIR is longer than 1000 characters");
-      break ;
+      logDirName += "/rest";
     default:
       throw UDRException(38001, "Internal error in determining logroot directory");
     }
       
-    std::string logDirName(logrootdir);
     std::string logFileName;
     std::string eventLogFileName(logrootdir);
-    
-    logDirName += "/logs";
     
     if (doTrace)
     {

--- a/core/sql/src/main/java/org/trafodion/sql/OrcFileReader.java
+++ b/core/sql/src/main/java/org/trafodion/sql/OrcFileReader.java
@@ -52,8 +52,8 @@ public class OrcFileReader
 	*/
     	String confFile = System.getProperty("trafodion.log4j.configFile");
     	if (confFile == null) {
-    		System.setProperty("trafodion.sql.log", System.getenv("TRAF_HOME") + "/logs/trafodion.sql.java.log");
-    		confFile = System.getenv("TRAF_HOME") + "/conf/log4j.sql.config";
+    		System.setProperty("trafodion.sql.log", System.getenv("TRAF_LOG") + "/trafodion.sql.java.log");
+    		confFile = System.getenv("TRAF_CONF") + "/log4j.sql.config";
     	}
     	PropertyConfigurator.configure(confFile);
 	m_conf = TrafConfiguration.create(TrafConfiguration.HDFS_CONF);

--- a/core/sql/src/main/java/org/trafodion/sql/SequenceFileReader.java
+++ b/core/sql/src/main/java/org/trafodion/sql/SequenceFileReader.java
@@ -57,7 +57,7 @@ public class SequenceFileReader {
   static { 
     String confFile = System.getProperty("trafodion.log4j.configFile");
     if (confFile == null) {
-   	System.setProperty("trafodion.sql.log", System.getenv("TRAF_HOME") + "/logs/trafodion.sql.java.log");
+   	System.setProperty("trafodion.sql.log", System.getenv("TRAF_LOG") + "/trafodion.sql.java.log");
     	confFile = System.getenv("TRAF_CONF") + "/log4j.sql.config";
     }
     PropertyConfigurator.configure(confFile);

--- a/core/sql/ustat/hs_globals.cpp
+++ b/core/sql/ustat/hs_globals.cpp
@@ -3803,12 +3803,12 @@ NABoolean HSGlobalsClass::isAuthorized(NABoolean isShowStats)
 // the fully-qualified table names.
 void HSGlobalsClass::initJITLogData()
 {
-  char* sqroot = getenv("TRAF_HOME");
-  if (!sqroot)
+  char* sqlogs = getenv("TRAF_LOG");
+  if (!sqlogs)
     return;
   
-  NAString filePath = sqroot;
-  filePath.append("/logs/jit_ulog_params");
+  NAString filePath = sqlogs;
+  filePath.append("/jit_ulog_params");
   FILE* jitParamFile = fopen(filePath.data(), "r");
   if (!jitParamFile)
     return;

--- a/dcs/bin/dcs
+++ b/dcs/bin/dcs
@@ -168,7 +168,7 @@ done
 
 # default log directory & file
 if [ "$DCS_LOG_DIR" = "" ]; then
-  DCS_LOG_DIR="$DCS_HOME/logs"
+  DCS_LOG_DIR="$TRAF_LOG/dcs"
 fi
 if [ "$DCS_LOGFILE" = "" ]; then
   DCS_LOGFILE='dcs.log'

--- a/dcs/bin/dcs-daemon.sh
+++ b/dcs/bin/dcs-daemon.sh
@@ -97,12 +97,12 @@ wait_until_done ()
 
 # get log directory
 if [ "$DCS_LOG_DIR" = "" ]; then
-  export DCS_LOG_DIR="$DCS_HOME/logs"
+  export DCS_LOG_DIR="$TRAF_LOG/dcs"
 fi
 mkdir -p "$DCS_LOG_DIR"
 
 if [ "$DCS_PID_DIR" = "" ]; then
-  DCS_PID_DIR="$DCS_HOME/tmp"
+  DCS_PID_DIR="$TRAF_VAR"
 fi
 
 #DCS_IDENT_STRING can be set in environment to uniquely identify dcs instances

--- a/dcs/conf/dcs-env.sh
+++ b/dcs/conf/dcs-env.sh
@@ -92,8 +92,8 @@ export DCS_ZOOKEEPER_OPTS=
 # Extra ssh options.  Empty by default.
 # export DCS_SSH_OPTS="-o ConnectTimeout=1 -o SendEnv=DCS_CONF_DIR"
 
-# Where log files are stored.  $DCS_HOME/logs by default.
-# export DCS_LOG_DIR=${DCS_HOME}/logs
+# Where log files are stored.  $TRAF_LOG/dcs by default.
+# export DCS_LOG_DIR=$TRAF_LOG/dcs
 
 # Enable remote JDWP debugging of major dcs processes. Meant for Core Developers 
 # export DCS_MASTER_OPTS="$DCS_MASTER_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8070"

--- a/dcs/src/main/asciidoc/_chapters/troubleshooting.adoc
+++ b/dcs/src/main/asciidoc/_chapters/troubleshooting.adoc
@@ -34,9 +34,9 @@
 == Logs
 The key process logs are as follows...(replace <user> with the user that started the service, <instance> for the server instance and <hostname> for the machine name)
  
-* DcsMaster: $DCS_HOME/logs/dcs-<user>-<instance>-master-<hostname>.log
-* DcsServer: $DCS_HOME/logs/dcs-<user>-<instance>-server-<hostname>.log
-* ZooKeeper: $DCS_HOME/logs/dcs-<user>-<instance>-zookeeper-<hostname>.log
+* DcsMaster: $TRAF_LOG/dcs/dcs-<user>-<instance>-master-<hostname>.log
+* DcsServer: $TRAF_LOG/dcs/dcs-<user>-<instance>-server-<hostname>.log
+* ZooKeeper: $TRAF_LOG/dcs/dcs-<user>-<instance>-zookeeper-<hostname>.log
 
 [[trouble-resources]]
 == Resources 
@@ -155,7 +155,7 @@ Additionally, the utility <<trouble-tools-builtin-zkcli,zkcli>> may help investi
 
 [[trouble-ha]]
 == High Availability
-On Linux cluster, if you run into issues please check dcs log files located in $DCS_INSTALL_DIR/logs folder. 
+On Linux cluster, if you run into issues please check dcs log files located in $TRAF_LOG/dcs folder. 
 
 Validate that the interace is set up correctly. This command should only show one additional interface for HA configuration
 ----

--- a/docs/provisioning_guide/src/asciidoc/_chapters/activate.adoc
+++ b/docs/provisioning_guide/src/asciidoc/_chapters/activate.adoc
@@ -145,4 +145,4 @@ If processes are not running as expected, then:
  
 If problems persist please review logs:
 
-* `$TRAF_HOME/logs`: {project-name} logs.
+* `$TRAF_LOG`: {project-name} logs.

--- a/docs/src/site/markdown/management.md
+++ b/docs/src/site/markdown/management.md
@@ -59,4 +59,4 @@ If processes are not running as expected, then:
 If problems persist please review logs:
 
 * **```$TRAF_HOME/sql/local_hadoop/\*/log```**: Hadoop, HBase, and Hive logs.
-* **```$TRAF_HOME/logs```**: Trafodion logs.
+* **```$TRAF_LOG```**: Trafodion logs.

--- a/install/ambari-installer/traf-mpack/common-services/TRAFODION/2.1/configuration/dcs-env.xml
+++ b/install/ambari-installer/traf-mpack/common-services/TRAFODION/2.1/configuration/dcs-env.xml
@@ -110,8 +110,8 @@ export DCS_OPTS="-XX:+UseConcMarkSweepGC"
 # Extra ssh options.  Empty by default.
 # export DCS_SSH_OPTS="-o ConnectTimeout=1 -o SendEnv=DCS_CONF_DIR"
 
-# Where log files are stored.  $DCS_HOME/logs by default.
-# export DCS_LOG_DIR=${DCS_HOME}/logs
+# Where log files are stored.  $TRAF_LOG/dcs by default.
+# export DCS_LOG_DIR=$TRAF_LOG/dcs
 
 # Enable remote JDWP debugging of major dcs processes. Meant for Core Developers 
 # export DCS_MASTER_OPTS="$DCS_MASTER_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8070"

--- a/wms/bin/wms
+++ b/wms/bin/wms
@@ -172,7 +172,7 @@ fi
 
 # default log directory & file
 if [ "$WMS_LOG_DIR" = "" ]; then
-  WMS_LOG_DIR="$WMS_HOME/logs"
+  WMS_LOG_DIR="$TRAF_LOG/wms"
 fi
 if [ "$WMS_LOGFILE" = "" ]; then
   WMS_LOGFILE='wms.log'

--- a/wms/bin/wms-daemon.sh
+++ b/wms/bin/wms-daemon.sh
@@ -98,7 +98,7 @@ wait_until_done ()
 
 # get log directory
 if [ "$WMS_LOG_DIR" = "" ]; then
-  export WMS_LOG_DIR="$WMS_HOME/logs"
+  export WMS_LOG_DIR="$TRAF_LOG/wms"
 fi
 mkdir -p "$WMS_LOG_DIR"
 

--- a/wms/conf/wms-env.sh
+++ b/wms/conf/wms-env.sh
@@ -86,8 +86,8 @@ export WMS_OPTS="-XX:+UseConcMarkSweepGC"
 # Extra ssh options.  Empty by default.
 # export WMS_SSH_OPTS="-o ConnectTimeout=1 -o SendEnv=WMS_CONF_DIR"
 
-# Where log files are stored.  $WMS_HOME/logs by default.
-# export WMS_LOG_DIR=${WMS_HOME}/logs
+# Where log files are stored.  $TRAF_LOG/wms by default.
+# export WMS_LOG_DIR=$TRAF_LOG/wms
 
 # Enable remote JDWP debugging of major wms processes. Meant for Core Developers 
 # export WMS_MASTER_OPTS="$WMS_MASTER_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8070"


### PR DESCRIPTION
Makes path to log directory independent of TRAF_HOME. The default location
is still $TRAF_HOME/logs. The DCS and REST log directories are now
sub-directories of the main TRAF_LOG directory.

Changes were pretty straight-forward, except the monitor stdout_* files.  Someone familiar with foundation should have a look.

Tested in local_hadoop environment, with TRAF_LOG set to alternate path and normal logs directory blocked.