### PR TITLE
[TRAFODION-3223] Don't scale down for non-Puts when estimating row counts

### DIFF
--- a/core/sql/executor/ex_frag_rt.cpp
+++ b/core/sql/executor/ex_frag_rt.cpp
@@ -133,7 +133,8 @@ ExRtFragTable::ExRtFragTable(ExMasterStmtGlobals *glob,
 			     ExFragDir *fragDir,
 			     char  *generatedObject) :
      fragmentEntries_(glob->getDefaultHeap(),fragDir->getNumEntries()),
-     outstandingServiceRequests_(glob->getDefaultHeap())
+     outstandingServiceRequests_(glob->getDefaultHeap()),
+     displayInGui_(FALSE)
 {
   glob_                     = glob;
   fragDir_                  = fragDir;

--- a/core/sql/regress/tools/regress-filter-linux
+++ b/core/sql/regress/tools/regress-filter-linux
@@ -35,10 +35,18 @@ if [ "$fil" = "" ]; then
   exit 1
 fi
 SYSKEY=`grep '\<SYSKEY\>' $fil | egrep -v '(--|^>>|^\*\*)'`
+# A SYSKEY can be as few as 15 decimal digits. The high order 15 bits
+# are an XOR of the low 15 bits of the node id and the linux thread ID,
+# while the low 49 bits are taken from JULIANTIMESTAMP. It is possible
+# for the high order bits to be zero (e.g. node id 0, linux TID 16384),
+# in which case all the decimal digits come from JULIANTIMESTAMP. At
+# present, JULIANTIMESTAMP yields 15 decimal digits and will until it
+# wraps many many years from now. See the code in function
+# generateUniqueValueFast in sqlshare/CatSQLShare.cpp.
 if [ "$SYSKEY" = "" ]; then
   SYSKEY='@syskey@'
 else
-  SYSKEY='[0-9]\{16,20\}\>'
+  SYSKEY='[0-9]\{15,20\}\>'
 fi
 #       123456789 123456789
 


### PR DESCRIPTION
The estimateRowCount code in HBaseClient.java tried to scale down row counts by the proportion of non-Put cells in the file. That is, it was trying to estimate row count from cell count, in part by discounting the effect of Delete tombstone cells. It was doing this on the basis of a sample of 500 rows in one HFile.

We find, however, that with time-ordered data that is aged out, the Delete cells are not uniformly distributed but instead tend to clump in one place. If we are unlucky and get an HFile that begins with 500 Delete tombstones, we will incorrectly assume most of the table consists of deleted rows and drastically underestimate the number of rows.

Drastically underestimating can be very bad. It is much better to overestimate. So the code that attempted to scale down row count based on the number of non-Put cells has been deleted. Also, if we find that the number of Puts in our sample is very small (< 50), we will instead ignore the sample and use the total number of entries.

The changes described above are in HBaseClient.java.

There are two other small, unrelated changes in this pull request as well:

1. The regression test filter for filtering out SYSKEYS has been changed. The current minimum number of decimal digits in a SYSKEY is 15; the filter was assuming they were at least 16 digits. This would lead to regression failures if someone was very unlucky and got just the wrong Linux thread ID for their process.

2. An uninitialized member of class ExRtFragTable is now initialized. This is a long-standing bug; the changes for pull request https://github.com/apache/trafodion/pull/1724 made it observable. For random parallel queries, the Executor GUI might come up at run time if the uninitialized value happened to be non-zero.