### PR TITLE
[TRAFODION-2626] Fix regressions

### DIFF
--- a/core/sqf/monitor/linux/redirector.cxx
+++ b/core/sqf/monitor/linux/redirector.cxx
@@ -61,8 +61,6 @@ using namespace std;
 #include "ptpclient.h"
 #endif
 
-#define MAX_FILE_NAME 256
-
 #ifndef NAMESERVER_PROCESS
 extern CNode *MyNode;
 extern sigset_t SigSet;
@@ -910,10 +908,7 @@ CRedirectStdout::CRedirectStdout(int nid, int pid, const char *filename, int sou
     // Add eyecatcher sequence as a debugging aid
     memcpy(&eyecatcher_, "REDE", 4);
 
-    char   filepath[MAX_FILE_NAME];
-    snprintf(filepath, MAX_FILE_NAME, "%s/%s", getenv("TRAF_LOG"), filename);
-
-    fd_ = open(filepath, O_CREAT | O_APPEND | O_WRONLY | O_NONBLOCK,
+    fd_ = open(filename, O_CREAT | O_APPEND | O_WRONLY | O_NONBLOCK,
                S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
     if( fd_ == -1 )
     {

--- a/core/sqf/monitor/linux/shell.cxx
+++ b/core/sqf/monitor/linux/shell.cxx
@@ -4950,6 +4950,7 @@ bool persist_process_start( CPersistConfig *persistConfig )
     char programNameAndArgs[MAX_PROCESS_PATH+MAX_VALUE_SIZE_INT];
     char infile[MAX_PROCESS_PATH];
     char outfile[MAX_PROCESS_PATH];
+    char outpath[MAX_PROCESS_PATH];
     char persistRetries[MAX_PERSIST_VALUE_STR];
     char persistZones[MAX_VALUE_SIZE_INT];
     int nid;
@@ -5014,6 +5015,7 @@ bool persist_process_start( CPersistConfig *persistConfig )
                 sprintf( programNameAndArgs, "%s"
                        , persistConfig->GetProgramName() );
             }
+            snprintf(outpath, MAX_FILE_NAME, "%s/%s", getenv("TRAF_LOG"), outfile);
             pid = start_process( &i
                                , process_type
                                , processName
@@ -5021,7 +5023,7 @@ bool persist_process_start( CPersistConfig *persistConfig )
                                , priority
                                , nowait
                                , infile
-                               , outfile
+                               , outpath
                                , programNameAndArgs );
                                //, (char *)persistConfig->GetProgramName() );
             if (pid > 0)
@@ -5072,6 +5074,7 @@ bool persist_process_start( CPersistConfig *persistConfig )
             sprintf( programNameAndArgs, "%s"
                    , persistConfig->GetProgramName() );
         }
+        snprintf(outpath, MAX_FILE_NAME, "%s/%s", getenv("TRAF_LOG"), outfile);
         pid = start_process( &nid
                            , process_type
                            , processName
@@ -5079,7 +5082,7 @@ bool persist_process_start( CPersistConfig *persistConfig )
                            , priority
                            , nowait
                            , infile
-                           , outfile
+                           , outpath
                            , programNameAndArgs );
         if (pid > 0)
         {
@@ -5127,6 +5130,7 @@ bool persist_process_start( CPersistConfig *persistConfig )
             sprintf( programNameAndArgs, "%s"
                    , persistConfig->GetProgramName() );
         }
+        snprintf(outpath, MAX_FILE_NAME, "%s/%s", getenv("TRAF_LOG"), outfile);
         pid = start_process( &nid
                            , process_type
                            , processName
@@ -5134,7 +5138,7 @@ bool persist_process_start( CPersistConfig *persistConfig )
                            , priority
                            , nowait
                            , infile
-                           , outfile
+                           , outpath
                            , programNameAndArgs );
         if (pid > 0)
         {

--- a/core/sql/regress/privs1/Utils.java
+++ b/core/sql/regress/privs1/Utils.java
@@ -54,7 +54,7 @@ public class Utils
      
      if (log) { 
        Logs = System.getenv("TRAF_LOG");
-       logLocation = sqLogs + "/";
+       logLocation = Logs + "/";
      }
    }
 


### PR DESCRIPTION
* Fix a wrong variable name in regression test code.
* Revert the original changes to monitor redirector that caused loss of some stdout data.
* Change monitor shell to put persistent process logs in TRAF_LOG.