### PR TITLE
[TRAFODION-3225] Obscure cores seen in RMS and logger related code wh…

### DIFF
--- a/core/sql/bin/SqlciMain.cpp
+++ b/core/sql/bin/SqlciMain.cpp
@@ -216,6 +216,7 @@ _callable void removeProcess()
     {
       statsGlobals->removeProcess(cliGlobals->myPin());
       statsGlobals->releaseStatsSemaphore(cliGlobals->getSemId(), cliGlobals->myPin());
+      statsGlobals->logProcessDeath(cliGlobals->myCpu(), cliGlobals->myPin(), "Normal process death");
     }
     else if (error == 4011)
     {

--- a/core/sql/cli/Globals.cpp
+++ b/core/sql/cli/Globals.cpp
@@ -206,6 +206,7 @@ void CliGlobals::init( NABoolean espProcess,
       }
       else
       {
+        bool reincarnated;
         error = statsGlobals_->getStatsSemaphore(semId_, myPin_);
 
         statsHeap_ = (NAHeap *)statsGlobals_->
@@ -221,10 +222,12 @@ void CliGlobals::init( NABoolean espProcess,
 	  NAHeap("Process Stats Heap", statsGlobals_->getStatsHeap(),
 		 8192,
 		 0);
-	statsGlobals_->addProcess(myPin_, statsHeap_);
+	reincarnated = statsGlobals_->addProcess(myPin_, statsHeap_);
         processStats_ = statsGlobals_->getExProcessStats(myPin_);
         processStats_->setStartTime(myStartTime_);
 	statsGlobals_->releaseStatsSemaphore(semId_, myPin_);
+        if (reincarnated)
+           statsGlobals_->logProcessDeath(myCpu_, myPin_, "Process reincarnated before RIP");
       }
     }
     // create a default context and make it the current context
@@ -298,6 +301,7 @@ CliGlobals::~CliGlobals()
     error = statsGlobals_->getStatsSemaphore(semId_, myPin_);
     statsGlobals_->removeProcess(myPin_);
     statsGlobals_->releaseStatsSemaphore(semId_, myPin_);
+    statsGlobals_->logProcessDeath(myCpu_, myPin_, "Normal process death");
     sem_close((sem_t *)semId_);
   }
 }

--- a/core/sql/executor/ex_esp_frag_dir.cpp
+++ b/core/sql/executor/ex_esp_frag_dir.cpp
@@ -131,6 +131,7 @@ ExEspFragInstanceDir::ExEspFragInstanceDir(CliGlobals *cliGlobals,
     }
     else
     {
+      bool reincarnated;
       cliGlobals_->setStatsGlobals(statsGlobals_);
       cliGlobals_->setSemId(semId_);
       error = statsGlobals_->getStatsSemaphore(semId_, pid_);
@@ -142,12 +143,14 @@ ExEspFragInstanceDir::ExEspFragInstanceDir(CliGlobals *cliGlobals,
       // We need to set up the cliGlobals, since addProcess will call getRTSSemaphore
       // and it uses these members
       cliGlobals_->setStatsHeap(statsHeap_);
-      statsGlobals_->addProcess(pid_, statsHeap_);
+      reincarnated = statsGlobals_->addProcess(pid_, statsHeap_);
       ExProcessStats *processStats = 
            statsGlobals_->getExProcessStats(pid_);
       processStats->setStartTime(cliGlobals_->myStartTime());
       cliGlobals_->setExProcessStats(processStats);
       statsGlobals_->releaseStatsSemaphore(semId_, pid_);
+      if (reincarnated)
+         statsGlobals_->logProcessDeath(cpu_, pid_, "Process reincarnated before RIP");
     }
   }
   cliGlobals_->setStatsHeap(statsHeap_);
@@ -191,6 +194,7 @@ ExEspFragInstanceDir::~ExEspFragInstanceDir()
     int error = statsGlobals_->getStatsSemaphore(semId_, pid_);
     statsGlobals_->removeProcess(pid_);
     statsGlobals_->releaseStatsSemaphore(semId_, pid_);
+    statsGlobals_->logProcessDeath(cpu_, pid_, "Normal process death");
     sem_close((sem_t *)semId_);
   }
 }

--- a/core/sql/qmscommon/QRLogger.cpp
+++ b/core/sql/qmscommon/QRLogger.cpp
@@ -41,6 +41,7 @@
 #include "seabed/fserr.h"
 
 BOOL gv_QRLoggerInitialized_ = FALSE;
+QRLogger *gv_QRLoggerInstance_ = NULL;
 
 using namespace log4cxx;
 using namespace log4cxx::helpers;
@@ -99,8 +100,9 @@ QRLogger::QRLogger()
 // **************************************************************************
 QRLogger& QRLogger::instance()
 {
-  static QRLogger onlyInstance_;
-  return onlyInstance_;
+  if (gv_QRLoggerInstance_ == NULL)
+     gv_QRLoggerInstance_ = new QRLogger();
+  return *gv_QRLoggerInstance_;
 }
 
 

--- a/core/sql/qmscommon/QRLogger.h
+++ b/core/sql/qmscommon/QRLogger.h
@@ -28,6 +28,8 @@
 #include "NAString.h"
 #include "CommonLogger.h"
 
+class QRLogger;
+extern QRLogger *gv_QRLoggerInstance_;
 // -----  these categories are currently not used
 // qmscomon
 extern std::string CAT_SQL_COMP_QR_COMMON;

--- a/core/sql/runtimestats/SqlStats.h
+++ b/core/sql/runtimestats/SqlStats.h
@@ -329,7 +329,7 @@ class StatsGlobals
 public:
   StatsGlobals(void *baseAddr, short envType, Lng32 maxSegSize);
   static void* operator new (size_t size, void* loc = 0);
-  void addProcess(pid_t pid, NAHeap *heap);
+  bool addProcess(pid_t pid, NAHeap *heap);
   void removeProcess(pid_t pid, NABoolean calledDuringAdd = FALSE);
   ProcessStats *checkProcess(pid_t pid);
   void setStatsArea(pid_t pid, ExStatisticsArea *stats)
@@ -345,6 +345,8 @@ public:
     else
       return NULL;
   }
+
+  void logProcessDeath(short cpu, pid_t pid, const char *reason);
 
   StmtStats *addQuery(pid_t pid, char *queryId, Lng32 queryIdLen, void *backRef,
                      Lng32 fragId, char *sourceStr = NULL, Lng32 sourceStrLen = 0,

--- a/core/sql/runtimestats/sscpipc.cpp
+++ b/core/sql/runtimestats/sscpipc.cpp
@@ -93,7 +93,9 @@ SscpGlobals::SscpGlobals(NAHeap *sscpheap, StatsGlobals *statsGlobals)
        NAHeap("Process Stats Heap", statsGlobals_->getStatsHeap(),
                8192,
                0);
-  statsGlobals_->addProcess(myPin_, statsHeap);
+  bool reincarnated = statsGlobals_->addProcess(myPin_, statsHeap);
+  if (reincarnated)
+     statsGlobals_->logProcessDeath(myCpu, myPin_, "Process reincarnated before RIP");
 
   statsGlobals_->releaseStatsSemaphore(semId_, myPin_);
   CliGlobals *cliGlobals = GetCliGlobals();


### PR DESCRIPTION
…en Trafodion is stressed

Process de-registration is now logged to understand the spate of cores seen during
stress testing

Cleanup dangling semaphore incorrectly detected the problem due to pid recycling and
hence de-registered the process and its query fragment from the shared segment

When the RMS semaphore is held for more than 10 seconds, it is assumed to be in a
deadlock situation and hence the process holding the semaphore is core dumped for
further analysis.

Create a global logger instance instead of a function static variable
to help in debugging when problems with QRlogger is reported.