### PR TITLE
[TRAFODION-3229] Update *Syntax Descriptions* for *FLOAT* in *Trafodion SQL Reference Manual*

### DIFF
--- a/docs/sql_reference/src/asciidoc/_chapters/sql_functions_and_expressions.adoc
+++ b/docs/sql_reference/src/asciidoc/_chapters/sql_functions_and_expressions.adoc
@@ -5364,7 +5364,7 @@ This function returns 0 for the second input argument, since it is a valid IPV6 
 >>SELECT IS_IPV6('10.0.5.9'), IS_IPV6('::1') from dual;
 (EXPR)   (EXPR)
 -------- -------
-1         0
+0        1
 ```
 [[inet_aton_function]]
 == INET_ATON Function
@@ -5393,7 +5393,7 @@ See <<expressions,Expressions>>.
 
 (EXPR)
 -----------
-167773449
+151322634
 ```
 <<<
 [[inet_ntoa_function]]
@@ -5427,7 +5427,7 @@ representation of the IP address.
 
 (EXPR)
 -------------
-'10.0.5.9'
+9.5.0.10
 ```
 [[isnull_function]]
 == ISNULL Function

--- a/docs/sql_reference/src/asciidoc/_chapters/sql_language_elements.adoc
+++ b/docs/sql_reference/src/asciidoc/_chapters/sql_language_elements.adoc
@@ -1148,7 +1148,8 @@ floating-point numbers and
 designates from 1 through 52 bits of _precision_.
 The range is from +/- 2.2250738585072014e-308 through +/-1.7976931348623157e+308 stored in 8 bytes.
 +
-An IEEE FLOAT _precision_ data type is stored as an IEEE DOUBLE, that is, in 8 bytes, with the specified precision.
+An IEEE FLOAT _precision_ data type is stored as an IEEE DOUBLE, that is, in 8 bytes, with the specified precision. Trafodion always gives maximum precision no matter what the user specifies.
+
 +
 The default _precision_ is 52.
 

--- a/docs/sql_reference/src/asciidoc/_chapters/sql_statements.adoc
+++ b/docs/sql_reference/src/asciidoc/_chapters/sql_statements.adoc
@@ -660,7 +660,7 @@ drops the specified column from _table_, including the column’s data. you cann
 +
 alters the data-type of a column in an existing Trafodion table. The following conditions have to be met, else SQL error 1404 will be returned.
 
-** the old (existing) column datatype and new column datatype must be VARCHAR (variable length string datatype).
+** the old (existing) column datatype and new column datatype must be compatible.
 ** new column length must be greater than or equal to old column length.
 ** old and new character sets must be the same.
 ** altered columns cannot be part of primary key or secondary index key.
@@ -10401,3 +10401,4 @@ VALUES (1+2, 3+4), (5, (select count (*) from t));
 
 --- 2 row(s) selected.
 ```
+datatype 


### PR DESCRIPTION
IS_IPV6:
```
SQL>SELECT IS_IPV6('10.0.5.9'), IS_IPV6('::1') from dual;

(EXPR) (EXPR)
------ ------
     0      1

--- 1 row(s) selected.
```

INET_ATON:
```
SQL>SELECT INET_ATON('10.0.5.9') from dual;

(EXPR)
----------
 151322634

--- 1 row(s) selected.
```

INET_NTOA:
```
SQL>SELECT INET_NTOA(167773449) from dual;

(EXPR)
---------------
9.5.0.10       

--- 1 row(s) selected.
```

ALTER TABLE Statement:
```
SQL>showddl float_1;

 
CREATE TABLE TRAFODION.SCH.FLOAT_1
  ( 
    A                                DOUBLE PRECISION DEFAULT NULL NOT
      SERIALIZED
  )
 ATTRIBUTES ALIGNED FORMAT 
;
 
-- GRANT SELECT, INSERT, DELETE, UPDATE, REFERENCES ON TRAFODION.SCH.FLOAT_1 TO DB__ROOT WITH GRANT OPTION;

--- SQL operation complete.
```

```
SQL>alter table FLOAT_1 alter column a REAL;

--- SQL operation complete.
```