### PR TITLE
[TRAFODION-2626] Fix DCS API for $TRAF_LOG

### DIFF
--- a/dcs/bin/dcs
+++ b/dcs/bin/dcs
@@ -277,7 +277,7 @@ if [ "x$JAVA_LIBRARY_PATH" != "x" ]; then
 fi
 DCS_OPTS="$DCS_OPTS -Ddcs.user.program.home=$DCS_USER_PROGRAM_HOME"
 DCS_OPTS="$DCS_OPTS -Ddcs.conf.dir=$DCS_CONF_DIR"
-DCS_OPTS="$DCS_OPTS -Ddcs.trafodion.home=$TRAF_HOME"
+DCS_OPTS="$DCS_OPTS -Ddcs.trafodion.log=$TRAF_LOG"
 
 # Exec unless DCS_NOEXEC is set.
 if [ "${DCS_NOEXEC}" != "" ]; then

--- a/dcs/src/main/jamon/org/trafodion/dcs/tmpl/server/ServerStatusTmpl.jamon
+++ b/dcs/src/main/jamon/org/trafodion/dcs/tmpl/server/ServerStatusTmpl.jamon
@@ -38,7 +38,7 @@ java.net.InetAddress;
   String metrics = server.getMetrics();
   int masterInfoPort = server.getConfiguration().getInt("dcs.master.info.port", 40010);
   int serverInfoPort = server.getConfiguration().getInt("dcs.server.info.port", 40030);
-  String trafodionHome = server.getTrafodionHome();
+  String trafodionLog = server.getTrafodionLog();
   boolean trafodionLogs = server.getConfiguration().getBoolean(Constants.DCS_MASTER_TRAFODION_LOGS, Constants.DEFAULT_DCS_MASTER_TRAFODION_LOGS);
   String masterIP = server.getMasterHostName(); 
     try{
@@ -63,7 +63,7 @@ java.net.InetAddress;
   <a href="http://<% masterIP %>:<% masterInfoPort %>">Home</a>,
   <a href="/logs/">Dcs local logs</a>
   <%java>
-   if(! trafodionHome.isEmpty()) { 
+   if(! trafodionLog.isEmpty()) { 
      if(trafodionLogs) { 
   </%java>
 , <a href="/TrafodionLogs/">Trafodion local logs</a>

--- a/dcs/src/main/jamon/org/trafodion/dcs/tmpl/servermt/ServerStatusTmpl.jamon
+++ b/dcs/src/main/jamon/org/trafodion/dcs/tmpl/servermt/ServerStatusTmpl.jamon
@@ -38,7 +38,7 @@ java.net.InetAddress;
   String metrics = server.getMetrics();
   int masterInfoPort = server.getConfiguration().getInt("dcs.master.info.port", 40010);
   int serverInfoPort = server.getConfiguration().getInt("dcs.server.info.port", 40030);
-  String trafodionHome = server.getTrafodionHome();
+  String trafodionLog = server.getTrafodionLog();
   boolean trafodionLogs = server.getConfiguration().getBoolean(Constants.DCS_MASTER_TRAFODION_LOGS, Constants.DEFAULT_DCS_MASTER_TRAFODION_LOGS);
   String masterIP = server.getMasterHostName();
   try{
@@ -63,7 +63,7 @@ java.net.InetAddress;
   <a href="http://<% masterIP %>:<% masterInfoPort %>">Home</a>,
   <a href="/logs/">Dcs local logs</a>
   <%java>
-   if(! trafodionHome.isEmpty()) { 
+   if(! trafodionLog.isEmpty()) { 
      if(trafodionLogs) { 
   </%java>
 , <a href="/TrafodionLogs/">Trafodion local logs</a>

--- a/dcs/src/main/java/org/trafodion/dcs/Constants.java
+++ b/dcs/src/main/java/org/trafodion/dcs/Constants.java
@@ -427,7 +427,7 @@ public final class Constants {
     public static final String DEFAULT_DCS_CLOUD_COMMAND = "nova list | grep -v '^+' | grep -w `hostname` | sed 's/.*=\\([0-9.]*\\), \\([0-9.]*\\).*$/\\1,\\2/'";
 
     /** User program feature is enabled */
-    public static final String DCS_TRAFODION_HOME = "dcs.trafodion.home";
+    public static final String DCS_TRAFODION_LOG = "dcs.trafodion.log";
 
     /** The sys_shell script name */
     public static final String SYS_SHELL_SCRIPT_NAME = "sys_shell.py";

--- a/dcs/src/main/java/org/trafodion/dcs/http/HttpServer.java
+++ b/dcs/src/main/java/org/trafodion/dcs/http/HttpServer.java
@@ -236,10 +236,10 @@ public class HttpServer implements FilterContainer {
       setContextAttributes(logContext);
       defaultContexts.put(logContext, true);
     }
-    logDir = System.getProperty(Constants.DCS_TRAFODION_HOME);
+    logDir = System.getProperty(Constants.DCS_TRAFODION_LOG);
     if (logDir != null) {
       Context logContext = new Context(parent, "/TrafodionLogs");
-      logContext.setResourceBase(logDir + "/logs");
+      logContext.setResourceBase(logDir);
       logContext.addServlet(DefaultServlet.class, "/");
       logContext.getInitParams().put(
             "org.mortbay.jetty.servlet.Default.aliases", "true");

--- a/dcs/src/main/java/org/trafodion/dcs/master/DcsMaster.java
+++ b/dcs/src/main/java/org/trafodion/dcs/master/DcsMaster.java
@@ -84,7 +84,7 @@ public class DcsMaster implements Runnable {
     private String parentZnode;
     private ExecutorService pool = null;
     private JVMShutdownHook jvmShutdownHook;
-    private static String trafodionHome;
+    private static String trafodionLog;
     private CountDownLatch isLeader = new CountDownLatch(1);
     private int epoch = 1;
 
@@ -110,7 +110,7 @@ public class DcsMaster implements Runnable {
                 Constants.DEFAULT_DCS_MASTER_PORT_RANGE);
         parentZnode = conf.get(Constants.ZOOKEEPER_ZNODE_PARENT,
                 Constants.DEFAULT_ZOOKEEPER_ZNODE_PARENT);
-        trafodionHome = System.getProperty(Constants.DCS_TRAFODION_HOME);
+        trafodionLog = System.getProperty(Constants.DCS_TRAFODION_LOG);
         jvmShutdownHook = new JVMShutdownHook();
         Runtime.getRuntime().addShutdownHook(jvmShutdownHook);
         thrd = new Thread(this);
@@ -318,8 +318,8 @@ public class DcsMaster implements Runnable {
         return metrics.toString();
     }
 
-    public String getTrafodionHome() {
-        return trafodionHome;
+    public String getTrafodionLog() {
+        return trafodionLog;
     }
 
     public ZkClient getZkClient() {

--- a/dcs/src/main/java/org/trafodion/dcs/server/DcsServer.java
+++ b/dcs/src/main/java/org/trafodion/dcs/server/DcsServer.java
@@ -85,7 +85,7 @@ public final class DcsServer implements Runnable {
     private ServerManager serverManager;
     private ExecutorService pool=null;
     private JVMShutdownHook jvmShutdownHook;
-	private static String trafodionHome;
+	private static String trafodionLog;
     
     private class JVMShutdownHook extends Thread {
     	public void run() {
@@ -127,7 +127,7 @@ public final class DcsServer implements Runnable {
 			System.exit(1);
 		}
 		
-		trafodionHome = System.getProperty(Constants.DCS_TRAFODION_HOME);
+		trafodionLog = System.getProperty(Constants.DCS_TRAFODION_LOG);
 
 		try {
 			zkc = new ZkClient();	   
@@ -236,8 +236,8 @@ public final class DcsServer implements Runnable {
 		return serverManager.getUserProgramHome();
 	}
 	
-	public String getTrafodionHome() {
-		return trafodionHome;
+	public String getTrafodionLog() {
+		return trafodionLog;
 	}
 	
 	public static void main(String [] args) {

--- a/dcs/src/main/java/org/trafodion/dcs/servermt/DcsServer.java
+++ b/dcs/src/main/java/org/trafodion/dcs/servermt/DcsServer.java
@@ -86,7 +86,7 @@ public final class DcsServer implements Runnable {
     private ServerManager serverManager;
     private ExecutorService pool=null;
     private JVMShutdownHook jvmShutdownHook;
-    private static String trafodionHome;
+    private static String trafodionLog;
     
     private class JVMShutdownHook extends Thread {
         public void run() {
@@ -131,7 +131,7 @@ public final class DcsServer implements Runnable {
             System.exit(1);
         }
         
-        trafodionHome = System.getProperty(Constants.DCS_TRAFODION_HOME);
+        trafodionLog = System.getProperty(Constants.DCS_TRAFODION_LOG);
 
         try {
             zkc = new ZkClient();       
@@ -250,8 +250,8 @@ public final class DcsServer implements Runnable {
         return serverManager.getUserProgramHome();
     }
     
-    public String getTrafodionHome() {
-        return trafodionHome;
+    public String getTrafodionLog() {
+        return trafodionLog;
     }
     
     public static void main(String [] args) {

--- a/dcs/src/main/resources/dcs-webapps/master/servers.jsp
+++ b/dcs/src/main/resources/dcs-webapps/master/servers.jsp
@@ -54,7 +54,7 @@
   String zkQuorumServers = master.getZKQuorumServersString();
   String zkParentZnode = master.getZKParentZnode(); 
   String metrics = master.getMetrics();
-  String trafodionHome = master.getTrafodionHome();
+  String trafodionLog = master.getTrafodionLog();
   boolean trafodionLogs = conf.getBoolean(Constants.DCS_MASTER_TRAFODION_LOGS, Constants.DEFAULT_DCS_MASTER_TRAFODION_LOGS);
   boolean trafodionQueryTools = conf.getBoolean(Constants.DCS_MASTER_TRAFODION_QUERY_TOOLS, Constants.DEFAULT_DCS_MASTER_TRAFODION_QUERY_TOOLS);
   String type = request.getParameter("type");
@@ -100,7 +100,7 @@
 <h1 id="page_title">DcsMaster: <%= masterIP %>:<%= masterInfoPort %></h1>
 <p id="links_menu">
   <a href="http://<%= masterIP %>:<%= masterInfoPort %>?pagesize=<%= pageSize %>">Home</a>,
-  <a href="/logs/">Dcs local logs</a><% if(! trafodionHome.isEmpty()) { %><% if(trafodionLogs) { %>, <a href="/TrafodionLogs/">Trafodion local logs</a><% } %><% if(trafodionQueryTools) { %>, <a href="repository.jsp?type=<%= Constants.TRAFODION_REPOS_CATALOG_SCHEMA %>">Trafodion query tools</a><% } %><% } %>
+  <a href="/logs/">Dcs local logs</a><% if(! trafodionLog.isEmpty()) { %><% if(trafodionLogs) { %>, <a href="/TrafodionLogs/">Trafodion local logs</a><% } %><% if(trafodionQueryTools) { %>, <a href="repository.jsp?type=<%= Constants.TRAFODION_REPOS_CATALOG_SCHEMA %>">Trafodion query tools</a><% } %><% } %>
 </p>
 <hr id="head_rule" />
 <h2>Attributes</h2>


### PR DESCRIPTION
Previous change allowed configuration of log location, but did not
take into account retrieving logs via DCS web interface.

Link to trafodion logs is not exposed by default, but this change was tested
with that option enabled, as well as default.