### PR TITLE
[TRAFODION-3230] The number of error message is less than the failed input rows

### DIFF
--- a/core/conn/odb/src/odb.c
+++ b/core/conn/odb/src/odb.c
@@ -10087,6 +10087,7 @@ static int Oloadbuff(int eid)
                 lcr += (unsigned long)etab[eid].Oresl;
             break;
         default:
+            Oi = 1; //the record number need to be initialize for next loop
             /* Loop through the ODBC error stack for this statement handle. */
             while ( ( Or = SQLGetDiagRec(SQL_HANDLE_STMT, thps[tid].Os, Oi, Ostate, &Onative, Otxt,
                 (SQLSMALLINT)embs, &Oln) ) != SQL_NO_DATA ) {


### PR DESCRIPTION
the parameter of SQLGetDiagRec need to be initialized