### PR TITLE
[TRAFODION-3241]support both jdk1.7 and jdk1.8

### DIFF
--- a/core/conn/jdbcT4/Makefile
+++ b/core/conn/jdbcT4/Makefile
@@ -27,8 +27,8 @@ all: build_all
 
 build_all: LICENSE NOTICE 
 	@if [ ! -f target/*.jar ]; then \
-		echo "$(MAVEN) package -DskipTests"; \
-		set -o pipefail && $(MAVEN) package -DskipTests | tee build_jdbct4.log | grep --line-buffered -E -e '^\[[^WId]' -e '^\[INFO\] B[Uu][Ii][Ll][Dd]' -e 'to compile'; \
+		echo "$(MAVEN) install -DskipTests"; \
+		set -o pipefail && $(MAVEN) install -DskipTests | tee build_jdbct4.log | grep --line-buffered -E -e '^\[[^WId]' -e '^\[INFO\] B[Uu][Ii][Ll][Dd]' -e 'to compile'; \
 		cp target/jdbcT4-${TRAFODION_VER}.jar ${TRAF_HOME}/export/lib; \
 		mkdir -p ../clients; \
 		mv target/jdbcT4-${TRAFODION_VER}.zip ../clients; \

--- a/core/conn/jdbcT4/Makefile
+++ b/core/conn/jdbcT4/Makefile
@@ -26,17 +26,20 @@ include ../../macros.gmk #top level
 all: build_all
 
 build_all: LICENSE NOTICE 
-	echo "$(MAVEN) package -DskipTests"
-	set -o pipefail && $(MAVEN) package -DskipTests | tee build_jdbct4.log | grep --line-buffered -E -e '^\[[^WId]' -e '^\[INFO\] B[Uu][Ii][Ll][Dd]' -e 'to compile'
-	cp target/jdbcT4-${TRAFODION_VER}.jar ${TRAF_HOME}/export/lib
-	mkdir -p ../clients
-	mv target/jdbcT4-${TRAFODION_VER}.zip ../clients
-	#ln -sf ${TRAF_HOME}/export/lib/jdbcT4-${TRAFODION_VER}.jar ${TRAF_HOME}/export/lib/jdbcT4.jar
-	`cd ${TRAF_HOME}/export/lib;ln -sf jdbcT4-${TRAFODION_VER}.jar jdbcT4.jar`
+	@if [ ! -f target/*.jar ]; then \
+		echo "$(MAVEN) package -DskipTests"; \
+		set -o pipefail && $(MAVEN) package -DskipTests | tee build_jdbct4.log | grep --line-buffered -E -e '^\[[^WId]' -e '^\[INFO\] B[Uu][Ii][Ll][Dd]' -e 'to compile'; \
+		cp target/jdbcT4-${TRAFODION_VER}.jar ${TRAF_HOME}/export/lib; \
+		mkdir -p ../clients; \
+		mv target/jdbcT4-${TRAFODION_VER}.zip ../clients; \
+		cd ${TRAF_HOME}/export/lib;ln -sf jdbcT4-${TRAFODION_VER}.jar jdbcT4.jar; \
+	fi
 
 clean:
-	-$(MAVEN) clean | grep ERROR
-	$(RM) build_jdbct4.log ${TRAF_HOME}/export/lib/jdbcT4*.jar
+	@if [ -f target/*.jar ]; then \
+		$(MAVEN) clean | grep ERROR; \
+		$(RM) build_jdbct4.log ${TRAF_HOME}/export/lib/jdbcT4*.jar; \
+	fi
 
 LICENSE: ../../../licenses/LICENSE-clients
 	cp -f $? $@

--- a/core/conn/jdbcT4/Makefile
+++ b/core/conn/jdbcT4/Makefile
@@ -26,7 +26,7 @@ include ../../macros.gmk #top level
 all: build_all
 
 build_all: LICENSE NOTICE 
-	@if [ ! -f target/*.jar ]; then \
+	@if [ ! -f target/jdbcT4-${TRAFODION_VER}.jar ]; then \
 		echo "$(MAVEN) install -DskipTests"; \
 		set -o pipefail && $(MAVEN) install -DskipTests | tee build_jdbct4.log | grep --line-buffered -E -e '^\[[^WId]' -e '^\[INFO\] B[Uu][Ii][Ll][Dd]' -e 'to compile'; \
 		cp target/jdbcT4-${TRAFODION_VER}.jar ${TRAF_HOME}/export/lib; \
@@ -36,7 +36,7 @@ build_all: LICENSE NOTICE
 	fi
 
 clean:
-	@if [ -f target/*.jar ]; then \
+	@if [ -d target ]; then \
 		$(MAVEN) clean | grep ERROR; \
 		$(RM) build_jdbct4.log ${TRAF_HOME}/export/lib/jdbcT4*.jar; \
 	fi

--- a/core/conn/jdbcT4/pom.xml
+++ b/core/conn/jdbcT4/pom.xml
@@ -213,6 +213,15 @@
    </plugins>
   </build>
 <profiles>
+    <profile>
+        <id>disable-javadoc-doclint</id>
+        <activation>
+            <jdk>[1.8,)</jdk>
+        </activation>
+        <properties>
+            <javadoc.opts>-Xdoclint:none</javadoc.opts>
+        </properties>
+    </profile>
 	<profile>
       <id>apache-release</id>
       <activation>
@@ -259,7 +268,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9</version>
+		<version>2.9</version>
+		<configuration>
+                  <docfilessubdirs>true</docfilessubdirs>
+                  <additionalparam>${javadoc.opts}</additionalparam>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/core/rest/Makefile
+++ b/core/rest/Makefile
@@ -34,7 +34,7 @@ all: build_all
 build_all: build_chk
 	echo "$(MAVEN) site package -DskipTests"
 	echo "### For full Maven output, see file build_rest.log"
-	set -o pipefail && $(MAVEN) site package -DskipTests | tee build_rest.log | grep --line-buffered -E -e '^\[[^WId]' -e '^\[INFO\] B[Uu][Ii][Ll][Dd]' -e 'to compile'
+	set -o pipefail && $(MAVEN) site package -DskipTests -Pjdbc | tee build_rest.log | grep --line-buffered -E -e '^\[[^WId]' -e '^\[INFO\] B[Uu][Ii][Ll][Dd]' -e 'to compile'
 	$(RM) $(VFILE)
 
 build_chk:

--- a/core/rest/pom.xml
+++ b/core/rest/pom.xml
@@ -536,6 +536,15 @@
   </dependencies>
   
   <profiles>
+    <profile>
+        <id>disable-javadoc-doclint</id>
+        <activation>
+            <jdk>[1.8,)</jdk>
+        </activation>
+        <properties>
+            <javadoc.opts>-Xdoclint:none</javadoc.opts>
+        </properties>
+    </profile>
     <!-- JDBC drivers needed for compile, but not site docs
          This allows turning off dependency on command line (-P '!jdbc') -->
     <profile>
@@ -640,6 +649,7 @@
         <version>${maven.javadoc.plugin.version}</version>
         <configuration>
           <docfilessubdirs>true</docfilessubdirs>
+	  <additionalparam>${javadoc.opts}</additionalparam>
         </configuration>
         <reportSets>
           <reportSet>

--- a/dcs/Makefile
+++ b/dcs/Makefile
@@ -32,10 +32,12 @@ GENVERS			    =./genvers
 all: build_all
 
 build_all: build_chk
-	echo "$(MAVEN) site package -DskipTests"
-	echo "### For full Maven output, see file build_dcs.log"
-	set -o pipefail && $(MAVEN) site package -DskipTests | tee build_dcs.log | grep --line-buffered -E -e '^\[[^WId]' -e '^\[INFO\] B[Uu][Ii][Ll][Dd]' -e 'to compile'
-	$(RM) $(VFILE)
+	@if [ ! -f target/*.jar ]; then \
+		echo "$(MAVEN) site package -DskipTests"; \
+		echo "### For full Maven output, see file build_dcs.log"; \
+		set -o pipefail && $(MAVEN) site package -DskipTests -Pjdbc | tee build_dcs.log | grep --line-buffered -E -e '^\[[^WId]' -e '^\[INFO\] B[Uu][Ii][Ll][Dd]' -e 'to compile'; \
+		$(RM) $(VFILE); \
+	fi
 
 build_chk:
 	$(GENVERS) > $(VFILE)
@@ -43,7 +45,9 @@ build_chk:
 	@if [ $(TRAF_HOME)/export/include/SCMBuildStr.h -nt target/$(BLD_TRAFODION_DCS_TARNAME) ]; then echo "update manifest"; $(RM) -f target/$(BLD_TRAFODION_DCS_TARNAME); fi
 
 clean:
-	-$(MAVEN) clean | grep ERROR
+	@if [ -f target/*.jar ]; then \
+		-$(MAVEN) clean | grep ERROR; \
+	fi
 	$(RM) build_dcs.log
 	$(RM) $(VFILE)
 	$(RM) ../${DISTRIBUTION_DIR}/$(BLD_TRAFODION_DCS_TARNAME)

--- a/dcs/pom.xml
+++ b/dcs/pom.xml
@@ -127,11 +127,11 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.5.1</version>
-        <inherited>true</inherited>
-        <configuration>
-            <source>1.7</source>
-            <target>1.7</target>
-        </configuration>
+	<inherited>true</inherited>
+	<configuration>
+	  <source>${source.version}</source>
+	  <target>${target.version}</target>
+	</configuration>
     </plugin>
     <plugin>
       <groupId>org.codehaus.mojo</groupId>
@@ -527,6 +527,8 @@
     <surefire.skipSecondPart>true</surefire.skipSecondPart>
 	<surefire.firstPartGroups>org.trafodion.dcs.SmallTests</surefire.firstPartGroups>
 	<surefire.secondPartGroups>org.trafodion.dcs.MediumTests, org.trafodion.dcs.LargeTests</surefire.secondPartGroups>
+	<source.version>1.7</source.version>
+	<target.version>1.7</target.version>
   	
   </properties>
     
@@ -655,6 +657,17 @@
     <!-- JDBC drivers needed for compile, but not site docs 
 	 This allows turning off dependency on command line (-P '!jdbc') -->
     <profile>
+        <id>disable-javadoc-doclint</id>
+        <activation>
+            <jdk>[1.8,)</jdk>
+        </activation>
+        <properties>
+            <javadoc.opts>-Xdoclint:none</javadoc.opts>
+	    <source.version>1.8</source.version>
+	    <target.version>1.8</target.version>
+        </properties>
+    </profile>
+    <profile>
       <id>jdbc</id>
       <activation>
         <activeByDefault>true</activeByDefault>
@@ -741,7 +754,8 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>${maven.javadoc.plugin.version}</version>
         <configuration>
-          <docfilessubdirs>true</docfilessubdirs>
+		<docfilessubdirs>true</docfilessubdirs>
+		<additionalparam>${javadoc.opts}</additionalparam>
         </configuration>
         <reportSets>
           <reportSet>


### PR DESCRIPTION
Previously, it doesnot support jdk1.8 because of site. Here use profile as a solution. By the way, to accelerate to the compilation speed, add if-else in Makefile that if you want to re-compile, please do make clean first. With my experiences, most of the time if the error is not in DCS/JDBC, you might not want to recompile this module.