### PR TITLE
[TRAFODION-3243] Avoid dereference of deleted NAString in UPDATE STATISTICS

### DIFF
--- a/core/sql/ustat/hs_globals.cpp
+++ b/core/sql/ustat/hs_globals.cpp
@@ -1497,11 +1497,11 @@ HSColGroupStruct::HSColGroupStruct()
 
 HSColGroupStruct::~HSColGroupStruct()
   {
+    freeISMemory();  // do this first, as it dereferences colNames for logging
     delete clistr;
     delete colNames;
     delete groupHist;
     delete next;
-    freeISMemory();
   }
 
 /**


### PR DESCRIPTION
In the HSColGroupStruct destructor, move the call to HSColGroupStruct::freeISMemory up to the front, before the "delete colNames" statement. The freeISMemory method dereferences colNames. Before this fix, this could cause cores.