### PR TITLE
[TRAFODION-3237] Fix incorrect PCode optimization

### DIFF
--- a/core/sql/exp/ExpPCodeOptimizations.cpp
+++ b/core/sql/exp/ExpPCodeOptimizations.cpp
@@ -4340,8 +4340,9 @@ NABoolean PCodeCfg::localCSE(INSTLIST** parent, PCodeBlock* tailBlock,
               (((ex_conv_clause*)clauseHead)->treatAllSpacesAsZero() ==
                ((ex_conv_clause*)clauseTail)->treatAllSpacesAsZero()));
             if ( match ) {
-               if ( ((ex_conv_clause*)clauseHead)->getInstruction() ==
-                    CONV_DATETIME_DATETIME )
+               ConvInstruction instr = ((ex_conv_clause*)clauseHead)->getInstruction();
+               if ((instr == CONV_DATETIME_DATETIME) ||
+                   ((instr >= CONV_INTERVALY_INTERVALMO) && (instr <= CONV_INTERVAL_ASCII)))
                {
                   Attributes *tgtH = ((ex_conv_clause*)clauseHead)->getOperand(0);
                   Attributes *tgtT = ((ex_conv_clause*)clauseTail)->getOperand(0);

--- a/core/sql/regress/core/EXPECTED038.LINUX
+++ b/core/sql/regress/core/EXPECTED038.LINUX
@@ -4944,6 +4944,39 @@ CREATE TABLE TRAFODION.SCH.T038FC2
 
 --- SQL operation complete.
 >>
+>>-- test for the bug fixed by JIRA TRAFODION-3237
+>>
+>>create table t038traf3237 (
++>c9 interval day(7) to second default NULL,
++>c10 interval day(13) to second(0) default NULL
++>);
+
+--- SQL operation complete.
+>>
+>>insert into t038traf3237 values (
++>interval '0 00:00:00' day(7) to second,
++>interval '0 00:00:00' day(13) to second(0));
+
+--- 1 row(s) inserted.
+>>
+>>insert into t038traf3237
++>select
++>c9 + interval '1' day,
++>c10 + interval '1' day -- gives incorrect result without TRAFODION-3237 fix
++>from t038traf3237;
+
+--- 1 row(s) inserted.
+>>
+>>select * from t038traf3237;
+
+C9 C10
+----------
+
+ 0 00:00:00.000000 0 00:00:00
+ 1 00:00:00.000000 1 00:00:00
+
+--- 2 row(s) selected.
+>>
 >>log;
 >>
 >>create table t038aqr( a int not null, b int not null, primary key(a) );

--- a/core/sql/regress/core/TEST038
+++ b/core/sql/regress/core/TEST038
@@ -1241,6 +1241,25 @@ from T038fcl
 
 showddl T038fc2;
 
+-- test for the bug fixed by JIRA TRAFODION-3237
+
+create table t038traf3237 (
+c9 interval day(7) to second default NULL,
+c10 interval day(13) to second(0) default NULL
+);
+
+insert into t038traf3237 values (
+interval '0 00:00:00' day(7) to second,
+interval '0 00:00:00' day(13) to second(0));
+
+insert into t038traf3237 
+select 
+c9 + interval '1' day,
+c10 + interval '1' day -- gives incorrect result without TRAFODION-3237 fix 
+from t038traf3237;
+
+select * from t038traf3237;
+
 log;
 
 ?section aqr
@@ -1304,5 +1323,7 @@ drop table T038sf;
 drop table T038nvl;
 drop table T038fcl;
 drop table T038fc2;
+
+drop table T038traf3237;
 
 


### PR DESCRIPTION
When an interval literal was referenced twice or more in an INSERT/SELECT in expressions with different INTERVAL types, the PCode optimizer was incorrectly treating the code to produce the interval literal value as a common subexpression, so the INSERT/SELECT would insert incorrect values. 

This has been fixed. The PCode optimizer common subexpression elimination logic now checks for commonality in datatype, scale and precision for INTERVAL conversions.

A test case that demonstrates the problem (with correct behavior with the fix) has been added to core/TEST038.

