### PR TITLE
[TRAFODION-3256] Fix error path in CLI similarity check code

### DIFF
--- a/core/sql/cli/Statement.cpp
+++ b/core/sql/cli/Statement.cpp
@@ -2073,7 +2073,9 @@ RETCODE Statement::doHiveTableSimCheck(TrafSimilarityTableInfo *si,
       char errBuf[strlen(si->tableName()) + 100 + strlen(si->hdfsRootDir())];
       snprintf(errBuf,sizeof(errBuf), "%s (fileLoc: %s)", si->tableName(), si->hdfsRootDir());
       diagsArea << DgSqlCode(-EXE_TABLE_NOT_FOUND)
-                << DgString0(errBuf);              
+                << DgString0(errBuf); 
+      NADELETEBASIC(tmpBuf, &heap_);
+      return ERROR;             
   } else {
      diagsArea << DgSqlCode(-1192)
           << DgString0("HiveClient_JNI::getRedefTime")


### PR DESCRIPTION
Add missing "return ERROR" (and an NADELETEBASIC to avoid memory leak) in method Statement::doHiveTableSimCheck.