### PR TITLE
[TRAFODION-3238] ODBC correct the length used for convert GBK to UTF8

### DIFF
--- a/win-odbc64/odbcclient/drvr35/Interface/odbcas_drvr.cpp
+++ b/win-odbc64/odbcclient/drvr35/Interface/odbcas_drvr.cpp
@@ -323,6 +323,7 @@ odbcas_ASSvc_GetObjRefHdl_(
 		{
 			memcpy(pConnection->m_ClusterName, curptr + msg_total_length, clusternameLength);
 			msg_total_length += clusternameLength;
+            pConnection->m_ClusterNameLength = clusternameLength;
 		}
 
 	}

--- a/win-odbc64/odbcclient/drvr35/cconnect.cpp
+++ b/win-odbc64/odbcclient/drvr35/cconnect.cpp
@@ -59,6 +59,7 @@ CConnect::CConnect(SQLHANDLE InputHandle) : CHandle(SQL_HANDLE_DBC, InputHandle)
 
     lobHandleSave = NULL;
     lobHandleLenSave = 0;
+    m_ClusterNameLength = 0;
 }
 
 CConnect::~CConnect()
@@ -3394,7 +3395,7 @@ SQLRETURN CConnect::DoEncryption(SecPwd* &pSecPwd, ProcInfo SecInfo, USER_DESC_d
 					dir[strlen(dir)-1] = '\0';
 				}
 			}
-			pSecPwd = new SecPwd(dir, file, activefile, m_ClusterName);
+        pSecPwd = new SecPwd(dir, file, activefile, m_ClusterName, m_ClusterNameLength);
 	} 
 	catch (SecurityException se) {
 		retCode = se.getErrCode();

--- a/win-odbc64/odbcclient/drvr35/cconnect.h
+++ b/win-odbc64/odbcclient/drvr35/cconnect.h
@@ -180,6 +180,7 @@ public:
 	SecPwd*			m_SecPwd;
 	ProcInfo		m_SecInfo;
     char            m_ClusterName[MAX_SQL_IDENTIFIER_LEN+1]; // seaquest cluster name
+    int             m_ClusterNameLength;
 private:
 	HANDLE						m_ConnectEvent;
 	IDL_OBJECT_def				m_RetSQLSvc_ObjRef;

--- a/win-odbc64/security_dll/native/header/secpwd.h
+++ b/win-odbc64/security_dll/native/header/secpwd.h
@@ -48,7 +48,7 @@ class SecPwd
 {  
    public:
       // cert_file - fully qualified certificate file name
-     SecPwd(const char *dir, const char* certFile, const char* activeCertFile, const char* serverName) 
+     SecPwd(const char *dir, const char* certFile, const char* activeCertFile, const char* serverName, int serverNameLength)
          throw (SecurityException);
       ~SecPwd();
 

--- a/win-odbc64/security_dll/native/source/secpwd.cpp
+++ b/win-odbc64/security_dll/native/source/secpwd.cpp
@@ -170,7 +170,8 @@ static char* buildName(const char* dir, const char* fileName, const char* server
 
 SecPwd::SecPwd(const char *dir, const char* fileName,
         const char* activeFileName,
-        const char* serverName) throw (SecurityException)
+        const char* serverName,
+        int serverNameLength) throw (SecurityException)
 : m_sec(NULL), certFile(NULL), activeCertFile(NULL)
 {
     char* dir_from_env = NULL;
@@ -224,7 +225,7 @@ SecPwd::SecPwd(const char *dir, const char* fileName,
     if (lcid == 0x804) // if local charset is gbk
     {
         serverNameGBKToUtf8 = (char *)malloc(MAX_SQL_IDENTIFIER_LEN + 1);
-        if (TranslateUTF8(TRUE, serverName, MAX_SQL_IDENTIFIER_LEN,
+        if (TranslateUTF8(TRUE, serverName, serverNameLength,
             serverNameGBKToUtf8, MAX_SQL_IDENTIFIER_LEN, &translen, transError) != SQL_SUCCESS)
         {
             free(serverNameGBKToUtf8);


### PR DESCRIPTION
When the source length is the same as the target length, conversion always fails.