### PR TITLE
[TRAFODION-3252] odb -cp command does not support writting to bad file

### DIFF
--- a/core/conn/odb/src/odb.c
+++ b/core/conn/odb/src/odb.c
@@ -374,10 +374,14 @@ enum DBs {
 
 struct tdesc {              /* ODBC Table description for insert ops */
     SQLSMALLINT Otype;      /* ODBC Data Type */
-    SQLULEN Osize;          /* ODBC Column Size */
+    SQLSMALLINT Octype;     /* ODBC C data type */
     SQLSMALLINT Odec;       /* ODBC Decimal digits */
-    SQLCHAR *Oname;         /* ODBC Column name */
     SQLSMALLINT Onull;      /* ODBC Column nullability */
+    SQLSMALLINT OnameLen;   /* ODBC column name length */
+    SQLCHAR *Oname;         /* ODBC Column name */
+    SQLULEN Osize;          /* ODBC Column Size */
+    SQLLEN OdisplaySize;    /* ODBC column display size */
+    SQLLEN Ocdatabufl;      /* ODBC C type buffer Size */
     size_t dl;              /* Default string length */
     size_t start;           /* Start address in rowset */
     size_t pad;             /* Used to memory align ODBC buffer elements on HP-UX */
@@ -507,7 +511,8 @@ struct execute {
     char *ns;                   /* load/extract Null string */
     char *es;                   /* extract=emptystring, copy: tgtsql with positional parameters */
     char *sql;                  /* extract custom SQL */
-    char *sb;                   /* extract split by column name, load=bad file */
+    char *sb;                   /* extract split by column name */
+    char *bad;                  /* bad file */
     char *key[MAX_PK_COLS];     /* diff key column names */
     char loadcmd[3];                /* load/copy=command to use INSERT/UPSERT/UPSERT USING LOAD, IN/UP/UL */ 
 #ifdef XML
@@ -5480,11 +5485,13 @@ static void etabadd(char type, char *run, int id)
                     etab[no].parent = no;
                     etab[no].id = no;
                 }
+
+                if (etab[no].bad) {        /* bad file */
+                    if (etabout(no, etab[no].bad))
+                        goto etabadd_exit;
+                }
+
                 if ( etab[no].type == 'l' ) {   /* load job */
-                    if ( etab[no].sb ) {        /* bad file */
-                        if ( etabout ( no , etab[no].sb ) )
-                            goto etabadd_exit;
-                    }
                     if ( etab[no].ps ) {
                         cimutex(&etab[no].pmutex);
                         cicondvar(&etab[no].pcvp);
@@ -10211,11 +10218,12 @@ static int Oloadbuff(int eid)
                                 MutexUnlock(&etab[gpar].pmutex);
                             }
                         }
-                        else {                /* either multi ('L') or single ('l') threaded loaders */
-                            if (tLastRow != Orown) { /* ensure no duplicated rows in bad file */
-                                tLastRow = Orown;
-                                prec('L', (unsigned char *)(etab[eid].Orowsetl + etab[par].s*(Orown - 1)), eid);
-                            }
+
+                        if (tLastRow != Orown) { /* ensure no duplicated rows in bad file */
+                            char type = etab[eid].type;
+                            tLastRow = Orown;
+                            if (type == 'l') type = 'L';
+                            prec(type, (unsigned char *)(etab[eid].Orowsetl + etab[par].s*(Orown - 1)), eid);
                         }
                         break;
                     }
@@ -10771,17 +10779,9 @@ static int Ocopy(int eid)
     int gchild = gpar+1;        /* grand parent first child eid */
     int gptid = etab[gpar].id;  /* grand parent tid */
     SQLSMALLINT Oncol;      /* ODBC number of columns in the result set */
-    SQLULEN *Ors=0;         /* ODBC Record Display Size array pointer */
-    int *start = 0;         /* rowset columns offset */
-    unsigned int *padl = 0; /* pad used to align length indicators */
     unsigned int ucs = 0;   /* Local ucs2toutf8 conversion flag */
     SQLCHAR *Op = 0 ;       /* Orowsetl buffer pointer used during UCS-2/UTF-8 conversion */
     SQLCHAR Oname[MAXOBJ_LEN];  /* ODBC Column Name */
-    SQLSMALLINT Onamel,     /* ODBC column name length returned by SQLDescribeCol */
-                *Odt=0,     /* ODBC data type returned by SQLDescribeCol */
-                *Ocdt=0,    /* ODBC C data type used to bind source/target */
-                *Odd=0,     /* ODBC decimal digit returned by SQLDescribeCol */
-                Onull;      /* ODBC nullable returned by SQLDescribeCol */
     SQLUSMALLINT Otf = 0 ;  /* ODBC target field number */
     struct timeval tve;     /* timeval struct to define elapesd/timelines */
     long telaps = 0,        /* Elapsed time in ms */
@@ -11000,44 +11000,9 @@ static int Ocopy(int eid)
     }
     etab[eid].sp = (unsigned int)Oncol; /* save number of src/tgt table fields for prec */
 
-    /* Allocate memory for the record size array */
-    if ( (Ors = (SQLULEN *)calloc ((size_t)Oncol, sizeof(SQLULEN))) == (void *)NULL ) {
-            fprintf(stderr, "odb [Ocopy(%d)] - Error allocating record size array memory: [%d] %s\n",
-                __LINE__, errno, strerror(errno));
-        goto ocopy_exit;
-    }   
-
-    /* Allocate memory for the data type array */
-    if ( (Odt = (SQLSMALLINT *)calloc ((size_t)Oncol, sizeof(SQLSMALLINT))) == (void *)NULL ) {
-            fprintf(stderr, "odb [Ocopy(%d)] - Error allocating data types array memory: [%d] %s\n",
-                __LINE__, errno, strerror(errno));
-        goto ocopy_exit;
-    }   
-
-    /* Allocate memory for the local bind data type array */
-    if ( (Ocdt = (SQLSMALLINT *)calloc ((size_t)Oncol, sizeof(SQLSMALLINT))) == (void *)NULL ) {
-        fprintf(stderr, "odb [Ocopy(%d)] - Error allocating C data types array memory: [%d] %s\n",
-            __LINE__, errno, strerror(errno));
-        goto ocopy_exit;
-    }   
-
-    /* Allocate memory for decimals array */
-    if ( (Odd = (SQLSMALLINT *)calloc ((size_t)Oncol, sizeof(SQLSMALLINT))) == (void *)NULL ) {
-            fprintf(stderr, "odb [Ocopy(%d)] - Error allocating decimals array memory: [%d] %s\n",
-                __LINE__, errno, strerror(errno));
-        goto ocopy_exit;
-    }   
-
-    /* Allocate memory for start array */
-    if ( (start = (int *)calloc ((size_t)Oncol, sizeof(int))) == (void *)NULL ) {
-            fprintf(stderr, "odb [Ocopy(%d)] - Error allocating start array memory: [%d] %s\n",
-                __LINE__, errno, strerror(errno));
-        goto ocopy_exit;
-    }   
-
-    /* Allocate memory for pad array */
-    if ( (padl = (unsigned int *)calloc ((size_t)Oncol, sizeof(unsigned int))) == (void *)NULL ) {
-            fprintf(stderr, "odb [Ocopy(%d)] - Error allocating padl array memory: [%d] %s\n",
+    /* Allocate memory for the tdesc array */
+    if ( (etab[eid].td = (struct tdesc *)calloc ((size_t)Oncol, sizeof(struct tdesc))) == (void *)NULL ) {
+            fprintf(stderr, "odb [Ocopy(%d)] - Error allocating tdesc array memory: [%d] %s\n",
                 __LINE__, errno, strerror(errno));
         goto ocopy_exit;
     }   
@@ -11045,104 +11010,120 @@ static int Ocopy(int eid)
     /* Get Result Set columns descriptions */
     for (j = 0; j < Oncol; j++) {
         if ( !SQL_SUCCEEDED(Or=SQLDescribeCol(Ostmt, (SQLUSMALLINT)(j+1),
-                Oname, (SQLLEN)sizeof(Oname), &Onamel, &Odt[j], &Ors[j], &Odd[j], &Onull))) {
+                NULL, 0, &etab[eid].td[j].OnameLen, &etab[eid].td[j].Otype, &etab[eid].td[j].Osize,
+                &etab[eid].td[j].Odec, &etab[eid].td[j].Onull))) {
             Oerr(eid, tid, __LINE__, Ostmt, SQL_HANDLE_STMT);
             goto ocopy_exit;
         }
+
+        if ((etab[eid].td[j].Oname = (SQLCHAR*)malloc(etab[eid].td[j].OnameLen + 1)) == (void *)NULL) {
+            fprintf(stderr, "odb [Ocopy(%d)] - Error allocating etab[%d].td[%d].Oname array memory: [%d] %s\n",
+                __LINE__, eid, j, errno, strerror(errno));
+            goto ocopy_exit;
+        }
+
+        if (!SQL_SUCCEEDED(Or = SQLColAttribute(Ostmt, (SQLUSMALLINT)(j + 1), SQL_DESC_NAME, etab[eid].td[j].Oname,
+                etab[eid].td[j].OnameLen + 1, &etab[eid].td[j].OnameLen, NULL))) {
+            Oerr(eid, tid, __LINE__, Ostmt, SQL_HANDLE_STMT);
+            goto ocopy_exit;
+        }
+
         if ( etab[gpar].flg2 & 04000 ) {        /* Force Char Binding */
             if(!SQL_SUCCEEDED(Or=SQLColAttribute(Ostmt, (SQLUSMALLINT)(j+1), SQL_DESC_DISPLAY_SIZE,
-                (SQLPOINTER) NULL, (SQLSMALLINT) 0, (SQLSMALLINT *) NULL, (SQLPOINTER) &Ors[j]))) {
+                (SQLPOINTER) NULL, (SQLSMALLINT) 0, (SQLSMALLINT *) NULL, (SQLPOINTER)&etab[eid].td[j].OdisplaySize))) {
                 Oerr(eid, tid, __LINE__, Ostmt, SQL_HANDLE_STMT);
                 goto ocopy_exit;
             }
             if ( etab[eid].dbt != VERTICA ) { /* Vertica's CHAR field length is in bytes (not chars) */
-                if ( etab[eid].dbt == ORACLE && Odt[j] == SQL_TYPE_TIMESTAMP )
+                if ( etab[eid].dbt == ORACLE && etab[eid].td[j].Otype == SQL_TYPE_TIMESTAMP )
                 /* The precision of Oracle's Timestamp is always 9 */
                 {
-                    Ors[j] = SQL_TIMESTAMP_LEN + 10; /* Display Size of TIMESTAMP(9) */
+                    etab[eid].td[j].OdisplaySize = SQL_TIMESTAMP_LEN + 10; /* Display Size of TIMESTAMP(9) */
                 }
-                switch ( Odt[j] ) {
+                switch (etab[eid].td[j].Otype) {
                 case SQL_WCHAR:
                 case SQL_WVARCHAR:
                 case SQL_WLONGVARCHAR:
-                    Ors[j] *= etab[eid].bpwc;   /* Space for UTF-8 conversion */
+                    etab[eid].td[j].OdisplaySize *= etab[eid].bpwc;   /* Space for UTF-8 conversion */
                     break;
                 case SQL_CHAR:
                 case SQL_VARCHAR:
                 case SQL_LONGVARCHAR:
-                    Ors[j] *= etab[eid].bpc;
+                    etab[eid].td[j].OdisplaySize *= etab[eid].bpc;
                     break;
                 }
             }
-            Ocdt[j] = SQL_C_CHAR ;          /* Bind to char */
+            etab[eid].td[j].Octype = SQL_C_CHAR ;          /* Bind to char */
         } else {    /* Try to use "C Default" data types to minimize conversions and reduce buffer size */
-            switch ( Odt[j] ) {
+            switch ( etab[eid].td[j].Otype ) {
             case SQL_INTEGER:
             case SQL_SMALLINT:
             case SQL_BIGINT:
-                Ors[j] = sizeof (SQLBIGINT) ;
-                Ocdt[j] = SQL_C_SBIGINT ;
+                etab[eid].td[j].Osize = sizeof (SQLBIGINT) ;
+                etab[eid].td[j].Octype = SQL_C_SBIGINT ;
                 break;
             case SQL_FLOAT:
             case SQL_DOUBLE:
-                Ors[j] = sizeof (SQLDOUBLE) ;
-                Ocdt[j] = SQL_C_DOUBLE ;
+                etab[eid].td[j].Osize = sizeof (SQLDOUBLE) ;
+                etab[eid].td[j].Octype = SQL_C_DOUBLE ;
                 break;
             case SQL_TYPE_DATE:
-                Ors[j] = sizeof (SQL_DATE_STRUCT) ;
-                Ocdt[j] = SQL_C_TYPE_DATE ;
+                etab[eid].td[j].Osize = sizeof (SQL_DATE_STRUCT) ;
+                etab[eid].td[j].Octype = SQL_C_TYPE_DATE ;
                 break;
             case SQL_TYPE_TIMESTAMP:
-                Ors[j] = sizeof (SQL_TIMESTAMP_STRUCT) ;
-                Ocdt[j] = SQL_C_TYPE_TIMESTAMP ;
+                etab[eid].td[j].Osize = sizeof (SQL_TIMESTAMP_STRUCT) ;
+                etab[eid].td[j].Octype = SQL_C_TYPE_TIMESTAMP ;
                 break;
             case SQL_BINARY:
             case SQL_VARBINARY:
             case SQL_LONGVARBINARY:
-                Ocdt[j] = SQL_C_BINARY ;
+                etab[eid].td[j].Octype = SQL_C_BINARY ;
                 break;
             default:
-                Ocdt[j] = SQL_C_CHAR ;
+                etab[eid].td[j].Octype = SQL_C_CHAR ;
                 if(!SQL_SUCCEEDED(Or=SQLColAttribute(Ostmt, (SQLUSMALLINT)(j+1), SQL_DESC_DISPLAY_SIZE,
-                    (SQLPOINTER) NULL, (SQLSMALLINT) 0, (SQLSMALLINT *) NULL, (SQLPOINTER) &Ors[j]))) {
+                    (SQLPOINTER) NULL, (SQLSMALLINT) 0, (SQLSMALLINT *) NULL, (SQLPOINTER) &etab[eid].td[j].OdisplaySize))) {
                     Oerr(eid, tid, __LINE__, Ostmt, SQL_HANDLE_STMT);
                     goto ocopy_exit;
                 }
                 if ( etab[eid].dbt != VERTICA ) {   /* Vertica's CHAR field length is in bytes (not chars) */
-                    switch ( Odt[j] ) {
+                    switch ( etab[eid].td[j].Otype ) {
                     case SQL_WCHAR:
                     case SQL_WVARCHAR:
                     case SQL_WLONGVARCHAR:
-                        Ors[j] *= etab[eid].bpwc;   /* Space for UTF-8 conversion */
+                        etab[eid].td[j].OdisplaySize *= etab[eid].bpwc;   /* Space for UTF-8 conversion */
                         break;
                     case SQL_CHAR:
                     case SQL_VARCHAR:
                     case SQL_LONGVARCHAR:
-                        Ors[j] *= etab[eid].bpc;
+                        etab[eid].td[j].OdisplaySize *= etab[eid].bpc;
                         break;
                     }
                 }
                 break;
             }
         }
-        Ors[j]++;   /* buffer should contain space for NULL termination in order to avoid truncation */
+        ++etab[eid].td[j].OdisplaySize;   /* buffer should contain space for NULL termination in order to avoid truncation */
         #ifdef __hpux
             if (Ors[j] % WORDSZ )
-                padl[j] = WORDSZ - (unsigned int)Ors[j] % WORDSZ ;
+                padl[j] = WORDSZ - (unsigned int)etab[eid].td[j].OdisplaySize % WORDSZ ;
         #endif
         if ( ( j + 1 ) == (int)etab[eid].seqp ) {   /* Allocate extra space for sequence and length indicator */
             sqo = etab[eid].s ; /* record sequence offset */
             etab[eid].s += (size_t) ( sizeof(SQLBIGINT) + sizeof(SQLLEN) ) ;
         }
-        start[j] = (int)etab[eid].s;
-        etab[eid].s += (size_t)(Ors[j] + padl[j] + sizeof(SQLLEN));
+        etab[eid].td[j].start = (int)etab[eid].s;
+        etab[eid].td[j].Ocdatabufl = etab[eid].td[j].Octype == SQL_C_CHAR ? etab[eid].td[j].OdisplaySize : (SQLLEN)etab[eid].td[j].Osize;
+        etab[eid].s += (size_t)(etab[eid].td[j].Ocdatabufl + etab[eid].td[j].pad + sizeof(SQLLEN));
         if ( etab[eid].flg & 0400000 && eid == gpar )   /* Grand Parent to Describe result set */
             fprintf(stderr, "--- col #%d, name=%s type=%d (%s) size=%lu, dec=%d, nullable=%s\n",
-                j, (char *)Oname, Odt[j], expandtype(Odt[j]), (unsigned long) Ors[j], (int) Odd[j], Onull ? "yes" : "no");
+                j, (char *)Oname, etab[eid].td[j].Otype, expandtype(etab[eid].td[j].Otype), (unsigned long)etab[eid].td[j].Osize,
+                (int) etab[eid].td[j].Odec, etab[eid].td[j].Onull ? "yes" : "no");
         if ( fdmp && eid == gpar )  /* Grand Parent to initialize ODBC dump */ 
             fprintf(fdmp, "[%d] Column %d: name=%s, type=%d (%s), size=%lu, decimals=%d, nullable=%s\n",
-                tid, j, (char *)Oname, (int)Odt[j], expandtype(Odt[j]),
-                (unsigned long)Ors[j], (int)Odd[j], Onull ? "yes" : "no" ) ; 
+                tid, j, (char *)etab[eid].td[j].Oname, (int)etab[eid].td[j].Otype, expandtype(etab[eid].td[j].Otype),
+                (unsigned long)etab[eid].td[j].Ocdatabufl, (int)etab[eid].td[j].Odec, etab[eid].td[j].Onull ? "yes" : "no" ) ;
     }
 
     /* Calculate rowset if buffer size is set */
@@ -11168,7 +11149,7 @@ static int Ocopy(int eid)
         goto ocopy_exit;
     }
 
-    /* Allocate memory for children rowset and status array */
+    /* Allocate memory for children rowset and status array and pass td to children */
     for ( i = echild ; i < echild + nchild ; i++ ) {
         if ( (etab[i].Orowsetl = (SQLCHAR *)calloc (etab[eid].r, etab[eid].s)) == (void *)NULL ||
             (etab[i].Ostatusl = (SQLUSMALLINT *)calloc (etab[eid].r, sizeof(SQLUSMALLINT))) == (void *)NULL ) {
@@ -11176,6 +11157,8 @@ static int Ocopy(int eid)
                     __LINE__, i, errno, strerror(errno));
             goto ocopy_exit;
         }
+        etab[i].td = etab[eid].td;
+        etab[i].sp = etab[eid].sp;
     }
     rbl = etab[eid].r * etab[eid].s ;
 
@@ -11247,8 +11230,9 @@ static int Ocopy(int eid)
 
     /* Bind Source */
     for (j = 0; j < Oncol; j++) {
-        if (!SQL_SUCCEEDED(Or=SQLBindCol(Ostmt, (SQLUSMALLINT)j + 1, Ocdt[j],
-                &etab[eid].Orowsetl[start[j]], Ors[j], (SQLLEN *)&etab[eid].Orowsetl[start[j]+Ors[j]+padl[j]]))) {
+        if (!SQL_SUCCEEDED(Or=SQLBindCol(Ostmt, (SQLUSMALLINT)j + 1, etab[eid].td[j].Octype,
+                &etab[eid].Orowsetl[etab[eid].td[j].start], etab[eid].td[j].Ocdatabufl,
+            (SQLLEN *)&etab[eid].Orowsetl[etab[eid].td[j].start + etab[eid].td[j].Ocdatabufl + etab[eid].td[j].pad]))) {
             Oerr(eid, tid, __LINE__, Ostmt, SQL_HANDLE_STMT);
             goto ocopy_exit;
         }
@@ -11263,9 +11247,9 @@ static int Ocopy(int eid)
             Otf++;
         for ( i = echild ; i < echild + nchild ; i++ ) {
             if (!SQL_SUCCEEDED(Or=SQLBindParameter(thps[etab[i].id].Os, Otf,
-                    SQL_PARAM_INPUT, Ocdt[k], Odt[k], Ors[k], Odd[k],
-                    &etab[i].Orowsetl[start[k]], Ors[k],
-                    (SQLLEN *)&etab[i].Orowsetl[start[k]+Ors[k]+padl[k]]))) {
+                    SQL_PARAM_INPUT, etab[eid].td[k].Octype, etab[eid].td[k].Otype, etab[eid].td[k].Osize,
+                    etab[eid].td[k].Odec, &etab[i].Orowsetl[etab[eid].td[k].start], etab[eid].td[k].Ocdatabufl,
+                    (SQLLEN *)&etab[i].Orowsetl[etab[eid].td[k].start + etab[eid].td[k].Ocdatabufl + etab[eid].td[k].pad]))) {
                 Oerr(i, etab[i].id, __LINE__, thps[etab[i].id].Os, SQL_HANDLE_STMT);
                 goto ocopy_exit;
             }
@@ -11400,10 +11384,9 @@ static int Ocopy(int eid)
                         case SQL_WCHAR:
                         case SQL_WVARCHAR:
                         case SQL_WLONGVARCHAR:
-                            if ( ucs2toutf8 ( Op + start[k] ,
-                                        (SQLLEN *)(Op + start[k] + Ors[k] + padl[k]),
-                                        Ors[k],
-                                        etab[eid].bucs2 ) ) {
+                            if ( ucs2toutf8 ( Op + etab[eid].td[k].start ,
+                                        (SQLLEN *)(Op + etab[eid].td[k].start + etab[eid].td[k].Ocdatabufl + etab[eid].td[k].pad),
+                                    etab[eid].td[k].Ocdatabufl, etab[eid].bucs2 ) ) {
                                     fprintf(stderr, "odb [Ocopy(%d)] - Error converting UCS-2 column %s\n",
                                         __LINE__, (char *)etab[eid].td[k].Oname);
                             }
@@ -11608,20 +11591,18 @@ static int Ocopy(int eid)
     if (Ocmd) 
         if (!etab[eid].tgtsql)
             free ( Ocmd );
-    if ( Ors )
-        free ( Ors ) ;
-    if ( Odt ) 
-        free ( Odt ) ;
-    if ( Ocdt ) 
-        free ( Ocdt ) ;
-    if ( Odd ) 
-        free ( Odd ) ;
-    if ( start )
-        free ( start ) ;
-    if ( padl )
-        free ( padl ) ;
+
+    if (etab[eid].td) {
+        for (j = 0; j < (int)etab[eid].sp; ++j) {
+            if (etab[eid].td[j].Oname)
+                free(etab[eid].td[j].Oname);
+        }
+        free(etab[eid].td);
+    }
+
     if ( etab[eid].Orowsetl )
         free (etab[eid].Orowsetl);
+
     return(fexst);
 }
 
@@ -12237,6 +12218,55 @@ static void Ocompare(int eid)
         free ( etab[eid].Orowsetl2 );
 }
 
+/* decode_buf
+ * decode contents in buf to string and save in buf
+ *
+ * ibuf: input buffer
+ * type: input buffer C type
+ * obuf: output buffer
+ * size: output buffer dispaly size
+ * return obuf
+ */
+static char* decode_buf(char *ibuf, SQLSMALLINT type, char *obuf, SQLULEN size) {
+    switch (type)
+    {
+    case SQL_C_SHORT:
+    case SQL_C_SSHORT:
+        snprintf(obuf, size, "%hd", *((unsigned short*)ibuf));
+        return obuf;
+    case SQL_C_USHORT:
+        snprintf(obuf, size, "%hu", *((unsigned short*)ibuf));
+        return obuf;
+    case SQL_C_LONG:
+        snprintf(obuf, size, "%ld", *((long*)ibuf));
+        return obuf;
+    case SQL_C_ULONG:
+        snprintf(obuf, size, "%lu", *((unsigned long*)ibuf));
+        return obuf;
+    case SQL_C_FLOAT:
+        snprintf(obuf, size, "%f", *((float*)ibuf));
+        return obuf;
+    case SQL_C_DOUBLE:
+        snprintf(obuf, size, "%lf", *((double*)ibuf));
+        return obuf;
+    case SQL_C_STINYINT:
+        snprintf(obuf, size, "%hhd", *((char*)ibuf));
+        return obuf;
+    case SQL_C_UTINYINT:
+        snprintf(obuf, size, "%hhu", *((unsigned char*)ibuf));
+        return obuf;
+    case SQL_C_SBIGINT:
+        snprintf(obuf, size, "%lld", *((long long*)ibuf));
+        return obuf;
+    case SQL_C_UBIGINT:
+        snprintf(obuf, size, "%llu", *((long long*)ibuf));
+        return obuf;
+    default:
+        strncpy(obuf, ibuf, size);
+        return obuf;
+    }
+}
+
 /* prec:
  * print rows 
  *
@@ -12253,8 +12283,13 @@ static void prec(char type, unsigned char *podbc, int eid)
     unsigned int nfields = (unsigned int)etab[eid].cmt; /* Initialize number of fields */
     unsigned char *p = 0;       /* pointer to string to print */
     SQLLEN Ofl = 0;             /* Field Length */
+    SQLLEN bufl = 20;
+    SQLCHAR *tbuf = (SQLCHAR*)malloc(bufl);
+    if (!tbuf) {
+        fprintf(stderr, "prec(%d): alloc memory for tbuf failed\n", __LINE__);
+    }
 
-    if ( type == 'L' ) {
+    if ( type == 'L' || type == 'C' ) {
         gpar = etab[eid].parent;
         /* nfields = (unsigned int)etab[gpar].sp ; */
         /* fix jira 2034, write to bad_record if load with parameter 'bad', etab[gpar].sp equals 0 always */
@@ -12262,7 +12297,7 @@ static void prec(char type, unsigned char *podbc, int eid)
     }
     MutexLock(&etab[gpar].pmutex);      /* lock mutex */
     if ( !(etab[gpar].flg2 & 0200) ) {
-        if ( type != 'L' ) {
+        if ( type != 'L' && type != 'C' ) {
             fputs(islower(etab[eid].td[0].Oname[0]) ? "dtype" : "DTYPE", etab[eid].fo);
             for ( i = 0 ; i < nfields ; i++ ) {
                 fputc(etab[eid].fs, etab[eid].fo);
@@ -12272,7 +12307,7 @@ static void prec(char type, unsigned char *podbc, int eid)
             etab[gpar].flg2 |= 0200 ;
         }
     }
-    if ( type == 'L' ) {
+    if ( type == 'L' || type == 'C' ) {
         if ( etab[eid].fo == stderr ) {
             fputs(">>> ", stderr);
         }
@@ -12281,15 +12316,36 @@ static void prec(char type, unsigned char *podbc, int eid)
         fputc(etab[eid].fs, etab[eid].fo);
     }
     for ( i = 0 ; i < nfields ; i++ ) {
+        SQLULEN cdatal;
+        if (type == 'C') {
+            cdatal = etab[eid].td[i].Ocdatabufl;
+        }
+        else {
+            cdatal = etab[eid].td[i].Osize;
+        }
         if ( i )
             fputc(etab[eid].fs, etab[eid].fo);
-        if ( *((char *)podbc + etab[eid].td[i].start + etab[eid].td[i].Osize + etab[eid].td[i].pad ) == SQL_NULL_DATA ) {
+        if ( *((char *)podbc + etab[eid].td[i].start + cdatal + etab[eid].td[i].pad ) == SQL_NULL_DATA ) {
             fputs(etab[eid].ns ? etab[eid].ns : "", etab[eid].fo);
-        } else if ( *(SQLLEN *)(podbc + etab[eid].td[i].start + etab[eid].td[i].Osize + etab[eid].td[i].pad ) == 0 ) {
+        } else if ( *(SQLLEN *)(podbc + etab[eid].td[i].start + cdatal + etab[eid].td[i].pad ) == 0 ) {
             fputs(etab[eid].es ? etab[eid].es : "", etab[eid].fo);
         } else {
             p = podbc + etab[eid].td[i].start;
-            Ofl = *(SQLLEN *)( p + etab[eid].td[i].Osize + etab[eid].td[i].pad ) ; 
+            Ofl = *(SQLLEN *)(p + cdatal + etab[eid].td[i].pad);
+
+            if (type == 'C') {
+                if (bufl < etab[eid].td[i].OdisplaySize) {
+                    bufl = etab[eid].td[i].OdisplaySize + 1;
+                    tbuf = (SQLCHAR*)realloc(tbuf, bufl);
+                    if (!tbuf) {
+                        fprintf(stderr, "prec(%d): alloc memory for tbuf failed\n", __LINE__);
+                    }
+                }
+
+                Ofl = etab[eid].td[i].OdisplaySize;
+                p = decode_buf(p, etab[eid].td[i].Octype, tbuf, Ofl);
+            }
+
             for ( ; *p && Ofl ; p++, Ofl-- )
                 fputc( *p , etab[eid].fo );
         }
@@ -14020,8 +14076,8 @@ static int Otcol(int eid, SQLHDBC *Ocn)
                 } else if ( type == 'l' && !strcmp(&str[n], "map") ) {
                     etab[no].map = &str[l];
                     etab[no].flg |= 01000000 ;  /* complex load. Use Oload */
-                } else if ( type == 'l' && !strcmp(&str[n], "bad") ) {
-                    etab[no].sb = &str[l];
+                } else if ( (type == 'l' || type == 'c') && !strcmp(&str[n], "bad") ) {
+                    etab[no].bad = &str[l];
                 } else if ( type == 'c' && !strcmp(&str[n], "errdmp") ) {
                     if ( !(strcmp(&str[l], "stdout") ) ) {
                         etab[no].fdmp = stdout ;


### PR DESCRIPTION
**New Feature Description:** Now, the odb's -cp command supports "bad" option. For example, you can use below command to specify where to store the records that can't be loaded to Trafodion.
`./odb64luo -d dsn1:dsn2 -u user1:user2 -p passwd1:passwd2 -cp src=tb1:tgt=tb2:bad=badf`
The bad file records the 'bad' records in the CSV format. 

**Changes In odb:** New field ' **Octype**' to remember the C data type has been added to the '**struct tdesc**' to decode the batch buffer if failed to load the data to the target table later. Some variables were used for multiple purposes, now add new variables to separate it.

**Verification:** No new issue was introduced by running the odb regression test set. The new feature also works fine by current test cases. 