### PR TITLE
[TRAFODION-3264] eliminate unneeded function call in Lob-related functions

### DIFF
--- a/core/sql/executor/ExExeUtilLoad.cpp
+++ b/core/sql/executor/ExExeUtilLoad.cpp
@@ -2653,15 +2653,6 @@ short ExExeUtilLobExtractTcb::work()
 	  
 	case GET_NO_CHILD_HANDLE_:
 	  {
-	    ex_expr::exp_return_type exprRetCode =
-	      lobTdb().inputExpr_->eval(NULL, 
-					workAtp_);
-	    if (exprRetCode == ex_expr::EXPR_ERROR)
-	      {
-		step_ = CANCEL_;
-		break;
-	      }
-	    
 	    step_ = GET_LOB_HANDLE_;
 	  }
 	  break;
@@ -3458,14 +3449,6 @@ short ExExeUtilLobUpdateTcb::work()
           break;
         case GET_HANDLE_:
           {
-            ex_expr::exp_return_type exprRetCode =
-	      lobTdb().inputExpr_->eval(NULL, 
-					workAtp_);
-	    if (exprRetCode == ex_expr::EXPR_ERROR)
-              {	      
-                step_ = CANCEL_;
-                break;
-              }
             if (ExpLOBoper::genLOBhandleFromHandleString
 		    (lobTdb().getHandle(),
 		     lobTdb().getHandleLen(),


### PR DESCRIPTION
in file core/sql/executor/ExExeUtilLoad.cpp, lines like:
```
	    ex_expr::exp_return_type exprRetCode =	
	      lobTdb().inputExpr_->eval(NULL, 	
					workAtp_);
```
call function eval(), with first parameter NULL.

Then code in ex_expr::evalClauses() accesses NULL pointer, so the server aborts.

As @sandhyasun said, this invocation is unneeded, so remove these code.

