### PR TITLE
[TRAFODION-3270] Handle incompatible types in key expressions

### DIFF
--- a/core/sql/generator/GenPreCode.cpp
+++ b/core/sql/generator/GenPreCode.cpp
@@ -113,7 +113,7 @@ static void generateKeyExpr(const ValueIdSet & externalInputs,
 			    Generator* generator,
                             NABoolean replicatePredicates = FALSE)
   {
-  ItemExpr * keyExpr;
+  BiRelat * keyExpr;
   CollIndex keyCount = listOfKeyColumns.entries();
 
   for (CollIndex keyNum = 0; keyNum < keyCount; keyNum++)
@@ -130,6 +130,9 @@ static void generateKeyExpr(const ValueIdSet & externalInputs,
 						ieKeyVal);
 
       // Bind it so potential incompatible data type issues are handled
+      const NAType & keyType = listOfKeyColumns[keyNum].getType();      
+      if (keyType.supportsSQLnull())
+        keyExpr->setSpecialNulls(TRUE);  // allow NULL ieKeyVal for nullable keys
       keyExpr->bindNode(generator->getBindWA());
 
       // Synthesize its type for and assign a ValueId to it.

--- a/core/sql/generator/GenPreCode.cpp
+++ b/core/sql/generator/GenPreCode.cpp
@@ -129,6 +129,9 @@ static void generateKeyExpr(const ValueIdSet & externalInputs,
 						ieKeyCol,
 						ieKeyVal);
 
+      // Bind it so potential incompatible data type issues are handled
+      keyExpr->bindNode(generator->getBindWA());
+
       // Synthesize its type for and assign a ValueId to it.
       keyExpr->synthTypeAndValueId();
 


### PR DESCRIPTION
If we have a join predicate of incompatible types and nested join is chosen, we get an assertion failure in the Generator in debug builds.

This changes fixes that, by adding logic to handle incompatible types when generating key expressions.