### PR TITLE
[TRAFODION-3261] Change logsort tool to sort GET statement output also

### DIFF
--- a/core/sql/regress/tools/logsort_src/line.c
+++ b/core/sql/regress/tools/logsort_src/line.c
@@ -561,3 +561,38 @@ else
 
 return rc;
 }
+
+/*
+
+    line_isgetheadingorfooting
+
+    This function determines if a line is a header or footer line
+    for GET statement output.
+
+    entry parameters:  line - the line to analyze
+
+    exit parameters:  returns TRUE if so, FALSE if not.
+
+                                                                          */
+
+int line_isgetheadingorfooting(char *line)
+{
+return (strncmp(line,"==========",10) == 0);
+}
+
+/*
+
+    line_issqloperationcomplete
+
+    This function determines if a line is "SQL operation complete."
+
+    entry parameters:  line - the line to analyze
+
+    exit parameters:  returns TRUE if so, FALSE if not.
+
+                                                                          */
+
+int line_issqloperationcomplete(char *line)
+{
+return (strcmp(line,"--- SQL operation complete.\n") == 0);
+}

--- a/core/sql/regress/tools/logsort_src/line.h
+++ b/core/sql/regress/tools/logsort_src/line.h
@@ -40,3 +40,5 @@ int line_isnnrows(char *line);
 int line_isignore(char *line);
 int line_isstats(char *line);
 int line_isoptstats(char *line);
+int line_isgetheadingorfooting(char *line);
+int line_issqloperationcomplete(char *line);

--- a/core/sql/regress/tools/logsort_src/tokstr.h
+++ b/core/sql/regress/tools/logsort_src/tokstr.h
@@ -51,7 +51,9 @@ struct token_stream
                                 last_stmt                             */
    int last_stmt;           /*  next slot to add a statement in the queue  */
 
-   int stmt[STMT_QUEUE_LENGTH];  /*  a circular queue for statements  */
+   enum stmtState { SELECT_WITHOUT_ORDER_BY, INTERESTING_GET, UNINTERESTING_STATEMENT };
+
+   stmtState stmt[STMT_QUEUE_LENGTH];  /*  a circular queue for statements  */
    } ;
 
 /*  public function definitions  */
@@ -59,5 +61,6 @@ struct token_stream
 struct token_stream *token_stream_create(int ignore_order_by_option);
 int token_stream_add(struct token_stream *t,char *text);
 int token_stream_interesting(struct token_stream *t);
+int token_stream_is_get(struct token_stream *t);
 void token_stream_clear(struct token_stream *t);
 void token_stream_advance(struct token_stream *t,int advance_factor);


### PR DESCRIPTION
The logsort tool is used by the developer regression suite testware to sort output in test logs that has non-deterministic order. Today it does so for SELECT statement output where the SELECT lacks an ORDER BY.

This pull request enhances logsort so that it also sorts the output of certain GET statements.