### PR TITLE
[TRAFODION-3276] Fix regression introduced by [TRAFODION-3270]

### DIFF
--- a/core/sql/generator/GenPreCode.cpp
+++ b/core/sql/generator/GenPreCode.cpp
@@ -130,9 +130,7 @@ static void generateKeyExpr(const ValueIdSet & externalInputs,
 						ieKeyVal);
 
       // Bind it so potential incompatible data type issues are handled
-      const NAType & keyType = listOfKeyColumns[keyNum].getType();      
-      if (keyType.supportsSQLnull())
-        keyExpr->setSpecialNulls(TRUE);  // allow NULL ieKeyVal for nullable keys
+      keyExpr->setSpecialNulls(TRUE);  // allow NULL ieKeyVal
       keyExpr->bindNode(generator->getBindWA());
 
       // Synthesize its type for and assign a ValueId to it.


### PR DESCRIPTION
In the fix for TRAFODION-3270, I did not take into account the possibility that a null value might be used as a key value in a primary key predicate. (Of course, such a value results in no rows, but nevertheless it is a valid predicate.)

This change corrects the fix for TRAFODION-3270.