### PR TITLE
[TRAFODION-3260] SSMP may wait 3 seconds before handling requests

### DIFF
--- a/core/sql/common/Ipc.cpp
+++ b/core/sql/common/Ipc.cpp
@@ -1161,7 +1161,7 @@ WaitReturnStatus IpcAllConnections::waitOnAll(
 
   if (timeout != IpcImmediately && timeout != IpcInfiniteTimeout) {
      short mask;
-     if (ipcEnv_->getControlConnection() != NULL) {
+     if (ipcEnv_->getControlConnection() != NULL && (! GetCliGlobals()->isEspProcess())) {
         mask = XWAIT(LREQ | LDONE, timeout);
         if (mask & LREQ) 
            retcode = ipcEnv_->getControlConnection()->castToGuaReceiveControlConnection()->wait(IpcImmediately);


### PR DESCRIPTION
The commit 95c2712b131adc2ba06b4e620ad67f93c2658497 introduced
a regression with ESPs acting as master to run SQL queries. These SQL
queries were stuck at close.