### PR TITLE
Fix for [Trafodion-2997]

### DIFF
--- a/docs/src/site/markdown/download.md
+++ b/docs/src/site/markdown/download.md
@@ -64,24 +64,24 @@ To build Trafodion from source code, see the [Trafodion Contributor Guide](https
     * [Ambari Plugin][ap220]  -  [PGP][appgp220] [SHA1][apsha220]
 * [Documentation](documentation.html#220_Release)
 
-[src220]: http://www.apache.org/dyn/closer.lua/trafodion/apache-trafodion-2.2.0/src/apache-trafodion-2.2.0-src.tar.gz
-[pgp220]: http://www.apache.org/dist/trafodion/apache-trafodion-2.2.0/src/apache-trafodion-2.2.0-src.tar.gz.asc
-[sha220]: http://www.apache.org/dist/trafodion/apache-trafodion-2.2.0/src/apache-trafodion-2.2.0-src.tar.gz.sha
-[pins220]: http://www.apache.org/dyn/closer.lua/trafodion/apache-trafodion-2.2.0/bin/apache-trafodion_pyinstaller-2.2.0.tar.gz
-[pinpgp220]: http://www.apache.org/dist/trafodion/apache-trafodion-2.2.0/bin/apache-trafodion_pyinstaller-2.2.0.tar.gz.asc
-[pinsha220]: http://www.apache.org/dist/trafodion/apache-trafodion-2.2.0/bin/apache-trafodion_pyinstaller-2.2.0.tar.gz.sha
-[ser220]: http://www.apache.org/dyn/closer.lua/trafodion/apache-trafodion-2.2.0/bin/apache-trafodion_server-2.2.0-RH6-x86_64.tar.gz
-[sepgp220]: http://www.apache.org/dist/trafodion/apache-trafodion-2.2.0/bin/apache-trafodion_server-2.2.0-RH6-x86_64.tar.gz.asc
-[sesha220]: http://www.apache.org/dist/trafodion/apache-trafodion-2.2.0/bin/apache-trafodion_server-2.2.0-RH6-x86_64.tar.gz.sha
-[cl220]: http://www.apache.org/dyn/closer.lua/trafodion/apache-trafodion-2.2.0/bin/apache-trafodion_clients-2.2.0-RH6-x86_64.tar.gz
-[clpgp220]: http://www.apache.org/dist/trafodion/apache-trafodion-2.2.0/bin/apache-trafodion_clients-2.2.0-RH6-x86_64.tar.gz.asc
-[clsha220]: http://www.apache.org/dist/trafodion/apache-trafodion-2.2.0/bin/apache-trafodion_clients-2.2.0-RH6-x86_64.tar.gz.sha
-[ar220]: http://www.apache.org/dyn/closer.lua/trafodion/apache-trafodion-2.2.0/bin/traf_ambari_rpms/apache-trafodion_server-2.2.0-1.x86_64.rpm
-[arpgp220]: http://www.apache.org/dist/trafodion/apache-trafodion-2.2.0/bin/traf_ambari_rpms/apache-trafodion_server-2.2.0-1.x86_64.rpm.asc
-[arsha220]: http://www.apache.org/dist/trafodion/apache-trafodion-2.2.0/bin/traf_ambari_rpms/apache-trafodion_server-2.2.0-1.x86_64.rpm.sha
-[ap220]: http://www.apache.org/dyn/closer.lua/trafodion/apache-trafodion-2.2.0/bin/traf_ambari_rpms/traf_ambari-2.2.0-1.noarch.rpm
-[appgp220]: http://www.apache.org/dist/trafodion/apache-trafodion-2.2.0/bin/traf_ambari_rpms/traf_ambari-2.2.0-1.noarch.rpm.asc
-[apsha220]: http://www.apache.org/dist/trafodion/apache-trafodion-2.2.0/bin/traf_ambari_rpms/traf_ambari-2.2.0-1.noarch.rpm.sha
+[src220]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.2.0/src/apache-trafodion-2.2.0-src.tar.gz
+[pgp220]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.2.0/src/apache-trafodion-2.2.0-src.tar.gz.asc
+[sha220]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.2.0/src/apache-trafodion-2.2.0-src.tar.gz.sha
+[pins220]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.2.0/bin/apache-trafodion_pyinstaller-2.2.0.tar.gz
+[pinpgp220]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.2.0/bin/apache-trafodion_pyinstaller-2.2.0.tar.gz.asc
+[pinsha220]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.2.0/bin/apache-trafodion_pyinstaller-2.2.0.tar.gz.sha
+[ser220]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.2.0/bin/apache-trafodion_server-2.2.0-RH6-x86_64.tar.gz
+[sepgp220]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.2.0/bin/apache-trafodion_server-2.2.0-RH6-x86_64.tar.gz.asc
+[sesha220]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.2.0/bin/apache-trafodion_server-2.2.0-RH6-x86_64.tar.gz.sha
+[cl220]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.2.0/bin/apache-trafodion_clients-2.2.0-RH6-x86_64.tar.gz
+[clpgp220]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.2.0/bin/apache-trafodion_clients-2.2.0-RH6-x86_64.tar.gz.asc
+[clsha220]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.2.0/bin/apache-trafodion_clients-2.2.0-RH6-x86_64.tar.gz.sha
+[ar220]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.2.0/bin/traf_ambari_rpms/apache-trafodion_server-2.2.0-1.x86_64.rpm
+[arpgp220]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.2.0/bin/traf_ambari_rpms/apache-trafodion_server-2.2.0-1.x86_64.rpm.asc
+[arsha220]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.2.0/bin/traf_ambari_rpms/apache-trafodion_server-2.2.0-1.x86_64.rpm.sha
+[ap220]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.2.0/bin/traf_ambari_rpms/traf_ambari-2.2.0-1.noarch.rpm
+[appgp220]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.2.0/bin/traf_ambari_rpms/traf_ambari-2.2.0-1.noarch.rpm.asc
+[apsha220]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.2.0/bin/traf_ambari_rpms/traf_ambari-2.2.0-1.noarch.rpm.sha
 
 
 ## 2.1.0 (May 2017)
@@ -97,34 +97,34 @@ To build Trafodion from source code, see the [Trafodion Contributor Guide](https
     * [Ambari Plugin][ap210]  -  [PGP][appgp210] [MD5][apmd5210] [SHA1][apsha210]
 * [Documentation](documentation.html#210_Release)
 
-[src210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/src/apache-trafodion-2.1.0-incubating-src.tar.gz
-[pgp210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/src/apache-trafodion-2.1.0-incubating-src.tar.gz.asc
-[md5210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/src/apache-trafodion-2.1.0-incubating-src.tar.gz.md5
-[sha210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/src/apache-trafodion-2.1.0-incubating-src.tar.gz.sha
-[ins210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_installer-2.1.0-incubating.tar.gz
-[inpgp210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_installer-2.1.0-incubating.tar.gz.asc
-[inmd5210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_installer-2.1.0-incubating.tar.gz.md5
-[insha210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_installer-2.1.0-incubating.tar.gz.sha
-[pins210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_pyinstaller-2.1.0-incubating.tar.gz
-[pinpgp210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_pyinstaller-2.1.0-incubating.tar.gz.asc
-[pinmd5210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_pyinstaller-2.1.0-incubating.tar.gz.md5
-[pinsha210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_pyinstaller-2.1.0-incubating.tar.gz.sha
-[ser210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_server-2.1.0-RH6-x86_64-incubating.tar.gz
-[sepgp210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_server-2.1.0-RH6-x86_64-incubating.tar.gz.asc
-[semd5210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_server-2.1.0-RH6-x86_64-incubating.tar.gz.md5
-[sesha210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_server-2.1.0-RH6-x86_64-incubating.tar.gz.sha
-[cl210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_clients-2.1.0-RH6-x86_64-incubating.tar.gz
-[clpgp210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_clients-2.1.0-RH6-x86_64-incubating.tar.gz.asc
-[clmd5210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_clients-2.1.0-RH6-x86_64-incubating.tar.gz.md5
-[clsha210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_clients-2.1.0-RH6-x86_64-incubating.tar.gz.sha
-[ar210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/traf_ambari_rpms/apache-trafodion_server-2.1.0-1.x86_64.rpm
-[arpgp210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/traf_ambari_rpms/apache-trafodion_server-2.1.0-1.x86_64.rpm.asc
-[armd5210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/traf_ambari_rpms/apache-trafodion_server-2.1.0-1.x86_64.rpm.md5
-[arsha210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/traf_ambari_rpms/apache-trafodion_server-2.1.0-1.x86_64.rpm.sha
-[ap210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/traf_ambari_rpms/traf_ambari-2.1.0-1.noarch.rpm
-[appgp210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/traf_ambari_rpms/traf_ambari-2.1.0-1.noarch.rpm.asc
-[apmd5210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/traf_ambari_rpms/traf_ambari-2.1.0-1.noarch.rpm.md5
-[apsha210]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/traf_ambari_rpms/traf_ambari-2.1.0-1.noarch.rpm.sha
+[src210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/src/apache-trafodion-2.1.0-incubating-src.tar.gz
+[pgp210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/src/apache-trafodion-2.1.0-incubating-src.tar.gz.asc
+[md5210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/src/apache-trafodion-2.1.0-incubating-src.tar.gz.md5
+[sha210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/src/apache-trafodion-2.1.0-incubating-src.tar.gz.sha
+[ins210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_installer-2.1.0-incubating.tar.gz
+[inpgp210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_installer-2.1.0-incubating.tar.gz.asc
+[inmd5210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_installer-2.1.0-incubating.tar.gz.md5
+[insha210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_installer-2.1.0-incubating.tar.gz.sha
+[pins210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_pyinstaller-2.1.0-incubating.tar.gz
+[pinpgp210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_pyinstaller-2.1.0-incubating.tar.gz.asc
+[pinmd5210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_pyinstaller-2.1.0-incubating.tar.gz.md5
+[pinsha210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_pyinstaller-2.1.0-incubating.tar.gz.sha
+[ser210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_server-2.1.0-RH6-x86_64-incubating.tar.gz
+[sepgp210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_server-2.1.0-RH6-x86_64-incubating.tar.gz.asc
+[semd5210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_server-2.1.0-RH6-x86_64-incubating.tar.gz.md5
+[sesha210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_server-2.1.0-RH6-x86_64-incubating.tar.gz.sha
+[cl210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_clients-2.1.0-RH6-x86_64-incubating.tar.gz
+[clpgp210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_clients-2.1.0-RH6-x86_64-incubating.tar.gz.asc
+[clmd5210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_clients-2.1.0-RH6-x86_64-incubating.tar.gz.md5
+[clsha210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_clients-2.1.0-RH6-x86_64-incubating.tar.gz.sha
+[ar210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/traf_ambari_rpms/apache-trafodion_server-2.1.0-1.x86_64.rpm
+[arpgp210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/traf_ambari_rpms/apache-trafodion_server-2.1.0-1.x86_64.rpm.asc
+[armd5210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/traf_ambari_rpms/apache-trafodion_server-2.1.0-1.x86_64.rpm.md5
+[arsha210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/traf_ambari_rpms/apache-trafodion_server-2.1.0-1.x86_64.rpm.sha
+[ap210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/traf_ambari_rpms/traf_ambari-2.1.0-1.noarch.rpm
+[appgp210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/traf_ambari_rpms/traf_ambari-2.1.0-1.noarch.rpm.asc
+[apmd5210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/traf_ambari_rpms/traf_ambari-2.1.0-1.noarch.rpm.md5
+[apsha210]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.1.0-incubating/bin/traf_ambari_rpms/traf_ambari-2.1.0-1.noarch.rpm.sha
 
 ## 2.0.1 (June 2016)
 
@@ -137,21 +137,21 @@ To build Trafodion from source code, see the [Trafodion Contributor Guide](https
 * [Documentation](documentation.html#20x_Releases)
 
 [src201]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/apache-trafodion-2.0.1-incubating-src.tar.gz
-[pgp201]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/apache-trafodion-2.0.1-incubating-src.tar.gz.asc
-[md5201]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/apache-trafodion-2.0.1-incubating-src.tar.gz.md5
-[sha201]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/apache-trafodion-2.0.1-incubating-src.tar.gz.sha
+[pgp201]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/apache-trafodion-2.0.1-incubating-src.tar.gz.asc
+[md5201]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/apache-trafodion-2.0.1-incubating-src.tar.gz.md5
+[sha201]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/apache-trafodion-2.0.1-incubating-src.tar.gz.sha
 [ins201]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/installer-2.0.1.tar.gz
-[inpgp201]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/installer-2.0.1.tar.gz.asc
-[inmd5201]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/installer-2.0.1.tar.gz.md5
-[insha201]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/installer-2.0.1.tar.gz.sha
+[inpgp201]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/installer-2.0.1.tar.gz.asc
+[inmd5201]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/installer-2.0.1.tar.gz.md5
+[insha201]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/installer-2.0.1.tar.gz.sha
 [ser201]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/apache-trafodion_server-2.0.1-incubating.tar.gz
-[sepgp201]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/apache-trafodion_server-2.0.1-incubating.tar.gz.asc
-[semd5201]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/apache-trafodion_server-2.0.1-incubating.tar.gz.md5
-[sesha201]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/apache-trafodion_server-2.0.1-incubating.tar.gz.sha
-[cl201]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/apache-trafodion_clients-2.0.1-incubating.tar.gz
-[clpgp201]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/apache-trafodion_clients-2.0.1-incubating.tar.gz.asc
-[clmd5201]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/apache-trafodion_clients-2.0.1-incubating.tar.gz.md5
-[clsha201]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/apache-trafodion_clients-2.0.1-incubating.tar.gz.sha
+[sepgp201]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/apache-trafodion_server-2.0.1-incubating.tar.gz.asc
+[semd5201]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/apache-trafodion_server-2.0.1-incubating.tar.gz.md5
+[sesha201]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/apache-trafodion_server-2.0.1-incubating.tar.gz.sha
+[cl201]: httpss://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/apache-trafodion_clients-2.0.1-incubating.tar.gz
+[clpgp201]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/apache-trafodion_clients-2.0.1-incubating.tar.gz.asc
+[clmd5201]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/apache-trafodion_clients-2.0.1-incubating.tar.gz.md5
+[clsha201]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.1-incubating/apache-trafodion_clients-2.0.1-incubating.tar.gz.sha
 
 ## 2.0.0 (June 2016)
 
@@ -164,25 +164,25 @@ To build Trafodion from source code, see the [Trafodion Contributor Guide](https
 * [Documentation](documentation.html#20x_Releases)
 
 [src200]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion-2.0.0-incubating-src.tar.gz
-[pgp200]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion-2.0.0-incubating-src.tar.gz.asc
-[md5200]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion-2.0.0-incubating-src.tar.gz.md5
-[sha200]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion-2.0.0-incubating-src.tar.gz.sha
+[pgp200]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion-2.0.0-incubating-src.tar.gz.asc
+[md5200]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion-2.0.0-incubating-src.tar.gz.md5
+[sha200]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion-2.0.0-incubating-src.tar.gz.sha
 [ins200]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion_installer-2.0.0-incubating.tar.gz
-[inpgp200]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion_installer-2.0.0-incubating.tar.gz.asc
-[inmd5200]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion_installer-2.0.0-incubating.tar.gz.md5
-[insha200]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion_installer-2.0.0-incubating.tar.gz.sha
+[inpgp200]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion_installer-2.0.0-incubating.tar.gz.asc
+[inmd5200]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion_installer-2.0.0-incubating.tar.gz.md5
+[insha200]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion_installer-2.0.0-incubating.tar.gz.sha
 [ser200]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion_server-2.0.0-incubating.tar.gz
-[sepgp200]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion_server-2.0.0-incubating.tar.gz.asc
-[semd5200]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion_server-2.0.0-incubating.tar.gz.md5
-[sesha200]: http://archive.apache.org/dist/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion_server-2.0.0-incubating.tar.gz.sha
+[sepgp200]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion_server-2.0.0-incubating.tar.gz.asc
+[semd5200]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion_server-2.0.0-incubating.tar.gz.md5
+[sesha200]: https://archive.apache.org/dist/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion_server-2.0.0-incubating.tar.gz.sha
 
 ## 1.3.0 (January 2016)
 
 * [Release Notes](release-notes-1-3-0.html)
-* [Source Code Release](https://archive.apache.org/dist/trafodion/apache-trafodion-1.3.0-incubating/apache-trafodion-1.3.0-incubating-src.tar.gz) -  [PGP](https://archive.apache.org/dist/trafodion/trafodion-1.3.0-incubating/apache-trafodion-1.3.0-incubating-src.tar.gz.asc) [MD5](http://archive.apache.org/dist/trafodion/apache-trafodion-1.3.0-incubating/apache-trafodion-1.3.0-incubating-src.tar.gz.md5) [SHA1](http://archive.apache.org/dist/trafodion/apache-trafodion-1.3.0-incubating/apache-trafodion-1.3.0-incubating-src.tar.gz.sha)
-* [log4c++ RPM](http://traf-builds.esgyn.com/downloads/trafodion/publish/release/1.3.0/log4cxx-0.10.0-13.el6.x86_64.rpm)
+* [Source Code Release](https://archive.apache.org/dist/trafodion/apache-trafodion-1.3.0-incubating/apache-trafodion-1.3.0-incubating-src.tar.gz) -  [PGP](https://archive.apache.org/dist/trafodion/trafodion-1.3.0-incubating/apache-trafodion-1.3.0-incubating-src.tar.gz.asc) [MD5](https://archive.apache.org/dist/trafodion/apache-trafodion-1.3.0-incubating/apache-trafodion-1.3.0-incubating-src.tar.gz.md5) [SHA1](https://archive.apache.org/dist/trafodion/apache-trafodion-1.3.0-incubating/apache-trafodion-1.3.0-incubating-src.tar.gz.sha)
+* [log4c++ RPM](https://traf-builds.esgyn.com/downloads/trafodion/publish/release/1.3.0/log4cxx-0.10.0-13.el6.x86_64.rpm)
 * [Documentation](documentation.html#130_Release)
 
 * * * *
 
-Note: when downloading from a mirror please check the [md5sum](http://www.apache.org/dev/release-signing#md5) and verify the [OpenPGP](http://www.apache.org/dev/release-signing#openpgp) compatible signature from the main [Apache](http://www.apache.org/) site. Links are provided above (next to the release download link). This [KEYS](http://www.apache.org/dist/trafodion/KEYS) file contains the public keys used for signing release. It is recommended that (when possible) a [web of trust](http://www.apache.org/dev/release-signing#web-of-trust) is used to confirm the identity of these keys. For more information, please see the [Apache Release FAQ](http://www.apache.org/dev/release.html).
+Note: when downloading from a mirror please check the [md5sum](https://www.apache.org/dev/release-signing#md5) and verify the [OpenPGP](https://www.apache.org/dev/release-signing#openpgp) compatible signature from the main [Apache](https://www.apache.org/) site. Links are provided above (next to the release download link). This [KEYS](https://www.apache.org/dist/trafodion/KEYS) file contains the public keys used for signing release. It is recommended that (when possible) a [web of trust](https://www.apache.org/dev/release-signing#web-of-trust) is used to confirm the identity of these keys. For more information, please see the [Apache Release FAQ](https://www.apache.org/dev/release.html).

--- a/docs/src/site/markdown/index.md
+++ b/docs/src/site/markdown/index.md
@@ -3,7 +3,7 @@
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,8 +31,8 @@ Running out of room with your current SQL solution? Starting a new operational a
 
 Trafodion provides SQL access to structured, semi-structured, and unstructured data allowing you to run operational, historical, and analytical workloads on a single platform.
 
-[revolution]: http://trafodion.apache.org
-[scale]: http://trafodion.apache.org
+[revolution]: https://trafodion.apache.org
+[scale]: https://trafodion.apache.org
 [stack]: index.html
 
 
@@ -45,15 +45,15 @@ Trafodion provides SQL access to structured, semi-structured, and unstructured d
   <p><h5>We're working on release 2.4!</h5></p>
   <p>Check out the <a href="https://cwiki.apache.org/confluence/display/TRAFODION/Roadmap">Roadmap</a> page for planned content.</p>
   <p><h5>Apache Trafodion 2.3.0 was released February 28, 2019.</h5></p>
-  <p>Check it out on the <a href="http://trafodion.apache.org/download.html">Download</a> page.</p>
+  <p>Check it out on the <a href="https://trafodion.apache.org/download.html">Download</a> page.</p>
   <p><h5>Apache Trafodion 2.2.0, our first release as a Top Level Project, was released on March 12, 2018.</h5></p>
-  <p>Check it out on the <a href="http://trafodion.apache.org/download.html">Download</a> page.</p>
+  <p>Check it out on the <a href="https://trafodion.apache.org/download.html">Download</a> page.</p>
   <p><h5>Apache Trafodion is now a Top Level Project!</h5></p>
-  <p>See the <a href="http://globenewswire.com/news-release/2018/01/10/1286517/0/en/The-Apache-Software-Foundation-Announces-Apache-Trafodion-as-a-Top-Level-Project.html">NewsWire</a> article for the official announcement.</p>
+  <p>See the <a href="https://globenewswire.com/news-release/2018/01/10/1286517/0/en/The-Apache-Software-Foundation-Announces-Apache-Trafodion-as-a-Top-Level-Project.html">NewsWire</a> article for the official announcement.</p>
   <p>See also this nice <a href="https://thenewstack.io/sql-hadoop-database-trafodion-bridges-transactions-analysis-divide/">article</a> where Trafodion's own Suresh Subbiah spreads the word on Trafodion's features.</p>
   <p><h5>Apache Trafodion 2.1.0-incubating was released on May 1, 2017.</h5></p>  
   <p><h5>Want to discuss Trafodion in Chinese? Join the Trafodion discussion on Tencent QQ!</h5></p> 
-  <p><a href="http://im.qq.com/">QQ</a> Group ID: 233105278.</p>
+  <p><a href="https://im.qq.com/">QQ</a> Group ID: 233105278.</p>
 </td></tr></table>
 
 <!-- 20160524 GTA Need more logos before using this part.


### PR DESCRIPTION
Update the web pages to use https for KEYS, sigs and hashes for archive locations.
Previous changes only affected the current release