### PR TITLE
[TRAFODION-3282] Fix buffer overrun in ExHdfsScanTcb::work

### DIFF
--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -1594,6 +1594,9 @@ $1~String1 --------------------------------
 8451 ZZZZZ 99999 BEGINNER MINOR LOGONLY Error $0~String0  returned while retrieving region stats from hbase.
 8452 ZZZZZ 99999 BEGINNER MINOR LOGONLY The regular expression is invalid. Cause: $0~String0
 8453 ZZZZZ 99999 BEGINNER MINOR LOGONLY This expression results in an invalid interval value '$0~String0'
+8454 ZZZZZ 99999 UUUUUUUU UUUUU UUUUUUU --- unused ---
+8455 ZZZZZ 99999 UUUUUUUU UUUUU UUUUUUU --- unused ---
+8456 ZZZZZ 99999 UUUUUUUU UUUUU UUUUUUU --- unused ---
 8457 ZZZZZ 99999 BEGINNER MAJOR DBADMIN An unexpectedly long row was read from a Hive table. The row is too long to process.
 8550 ZZZZZ 99999 ADVANCED MAJOR DBADMIN Error $0~NSKCode was returned by the Data Access Manager.
 8551 ZZZZZ 99999 ADVANCED MAJOR DBADMIN Error $0~NSKCode was returned by the file system on $0~string0$1~string1.

--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -1594,6 +1594,7 @@ $1~String1 --------------------------------
 8451 ZZZZZ 99999 BEGINNER MINOR LOGONLY Error $0~String0  returned while retrieving region stats from hbase.
 8452 ZZZZZ 99999 BEGINNER MINOR LOGONLY The regular expression is invalid. Cause: $0~String0
 8453 ZZZZZ 99999 BEGINNER MINOR LOGONLY This expression results in an invalid interval value '$0~String0'
+8457 ZZZZZ 99999 BEGINNER MAJOR DBADMIN An unexpectedly long row was read from a Hive table. The row is too long to process.
 8550 ZZZZZ 99999 ADVANCED MAJOR DBADMIN Error $0~NSKCode was returned by the Data Access Manager.
 8551 ZZZZZ 99999 ADVANCED MAJOR DBADMIN Error $0~NSKCode was returned by the file system on $0~string0$1~string1.
 8552 ZZZZZ 99999 ADVANCED MAJOR DBADMIN Error $0~int0 was returned by the file system while fetching the version of the system $0~string0.

--- a/core/sql/executor/ExHdfsScan.cpp
+++ b/core/sql/executor/ExHdfsScan.cpp
@@ -594,6 +594,21 @@ ExWorkProcRetcode ExHdfsScanTcb::work()
           {
              BYTE *headRoomStartAddr;
              headRoomCopied_ = bufLogicalEnd_ - (BYTE *)hdfsBufNextRow_;
+
+             // make sure the tail is not unexpectedly long (otherwise we might
+             // overrun the beginning of our buffer)
+             if (headRoomCopied_ > headRoom_)
+               {
+                 ComDiagsArea * diagsArea = NULL;
+                 ExRaiseSqlError(getHeap(), &diagsArea, 
+                                 EXE_HIVE_ROW_TOO_LONG, 
+                                 NULL, NULL, NULL, NULL, 
+                                 NULL, NULL);
+                 pentry_down->setDiagsArea(diagsArea);
+                 step_ = HANDLE_ERROR;
+                 break;
+               }
+
              if (retArray_[BUF_NO] == 0)
                 headRoomStartAddr = hdfsScanBuf_[1].buf_ - headRoomCopied_;
              else

--- a/core/sql/exp/ExpErrorEnums.h
+++ b/core/sql/exp/ExpErrorEnums.h
@@ -170,6 +170,7 @@ enum ExeErrorCode
   EXE_INVALID_LOB_HANDLE                = 8443,
   EXE_ERROR_HDFS_SCAN                   = 8447,
   EXE_INVALID_INTERVAL_RESULT           = 8453,
+  EXE_HIVE_ROW_TOO_LONG                 = 8457,
   EXE_LAST_EXPRESSIONS_ERROR		= 8499,
 
   // ---------------------------------------------------------------------

--- a/core/sql/ustat/hs_globals.cpp
+++ b/core/sql/ustat/hs_globals.cpp
@@ -15998,8 +15998,7 @@ Lng32 doubleToHSDataBuffer(const double dbl, HSDataBuffer& dbf)
 /**********************************************************************/
 /* METHOD:  managePersistentSamples()                                 */
 /* PURPOSE: Create or delete persistent sample tables from update     */
-/*          statistics command line. These are NOT the automatically  */
-/*          managed persistent samples used by IUS.                   */
+/*          statistics command line.                                  */
 /* RETCODE:  0 - successful                                           */
 /*          -1 - failure                                              */
 /**********************************************************************/
@@ -16071,6 +16070,7 @@ Lng32 managePersistentSamples()
     {
       if (hs_globals->optFlags & CREATE_SAMPLE_OPT)  /* create sample requested*/
       {
+        hs_globals->setHiveMaxStringLengthInBytes();
         if (sampleList->createAndInsert(hs_globals->objDef, table, 
                                         sampleRows, tableRows, 
                                         isEstimate,
@@ -16084,6 +16084,7 @@ Lng32 managePersistentSamples()
                              table.data(), intStr, retcode); 
             LM->Log(LM->msg);
           }
+        hs_globals->resetCQDs();
       }
       if (hs_globals->optFlags & REMOVE_SAMPLE_OPT)  /* remove sample requested*/
       {

--- a/docs/messages_guide/src/asciidoc/_chapters/executor_msgs.adoc
+++ b/docs/messages_guide/src/asciidoc/_chapters/executor_msgs.adoc
@@ -229,6 +229,24 @@ available partition.
 *Recovery:* Determine why none of the partitions were available, then
 correct the error and resubmit.
 
+<<<
+[[SQL-8457]]
+== SQL 8457
+
+```
+An unexpectedly long row was read from a Hive table. The row is too long to process.
+```
+
+*Cause:* A row was read from a Hive table that is longer than what was expected. To avoid
+buffer overrun, the query was aborted.
+
+*Effect:* The operation fails.
+
+*Recovery:* If there is an external table definition in {project-name} for the Hive table,
+drop and recreate it with accurate limits on VARCHAR column size. If there is not such
+an external table definition, use CQD HIVE_MAX_STRING_LENGTH_IN_BYTES 'nnnn', where
+nnnn is the longest string in the Hive table. Then resubmit the query.
+
 [[SQL-8553]]
 == SQL 8553
 


### PR DESCRIPTION
There are two changes in this pull request:

1. Fix a buffer overrun in ExHdfsScanTcb::work, which happens when we process a Hive row longer than we expect and that row spans read buffers. Now we will raise an 8457 error in this case.

2. A workaround to avoid error 8457 is to use CQD HIVE_MAX_STRING_LENGTH_IN_BYTES 'nnnn', setting nnnn to the length of the longest string in the Hive table. There was a bug in UPDATE STATISTICS ... CREATE SAMPLE where this particular CQD was not passed down to the appropriate tdm_arkcmp, defeating the workaround. This bug has been fixed.