### PR TITLE
[TRAFODION-3281] Remove virtual nodes configuration

### DIFF
--- a/core/sqf/conf/sqconfig
+++ b/core/sqf/conf/sqconfig
@@ -20,7 +20,7 @@
 # @@@ END COPYRIGHT @@@
 
 begin node
-_virtualnodes 2
+node-id=0;node-name=HOSTNAME;cores=0-3;processors=1;roles=connection,aggregation,storage
 end node
 
 begin name-server

--- a/core/sqf/sqenvcom.sh
+++ b/core/sqf/sqenvcom.sh
@@ -221,16 +221,6 @@ if [[ "$HBASE_DISTRO" =~ "APACHE" ]]; then
     export SQL_JAR=trafodion-sql-apache-${TRAFODION_VER}.jar
 fi
 
-# check for workstation env
-# want to make sure SQ_VIRTUAL_NODES is set in the shell running sqstart
-# so we can determine if we are on a workstation or not
-if [[ -e ${TRAF_VAR}/ms.env ]] ; then
-  VIRT_NODES=$(awk '/SQ_VIRTUAL_NODES=/ { fields=split($0,virt,"=");  if ( fields == 2 ) { virtnodes=virt[2];}} END {print  virtnodes}' < $TRAF_VAR/ms.env)
-  if [[ -n "$VIRT_NODES" ]] ; then
-     export SQ_VIRTUAL_NODES="$VIRT_NODES"
-  fi
-fi
-
 export SQ_IDTMSRV=1
 
 # Turn on/off generation of Service Monitor

--- a/core/sqf/sql/scripts/gomon.cold
+++ b/core/sqf/sql/scripts/gomon.cold
@@ -23,10 +23,6 @@
 # @@@ END COPYRIGHT @@@
 #
 
-if [ -f $TRAF_VAR/sqshell.env ]; then
-    . $TRAF_VAR/sqshell.env
-fi
-
 if [[ -z ${TRAF_AGENT} ]]; then
    echo  "***"
    echo  "***" `date`  " - Starting Monitor processes"
@@ -115,11 +111,6 @@ then
 fi
 
 sqshell -c node info
-
-# If the 'shell.env' file does not exist, we are in a real cluster
-if [ -e $TRAF_VAR/sqshell.env ]; then
-   sqshell -c set CLUSTERNAME=$CLUSTERNAME
-fi
 
 # Starting TSID
 

--- a/core/sqf/sql/scripts/install_local_hadoop
+++ b/core/sqf/sql/scripts/install_local_hadoop
@@ -665,6 +665,21 @@ else
   mkdir -p traf_conf
   cp -rf  $TRAF_HOME/conf/* traf_conf/
 
+  cat <<-EOF > traf_conf/sqconfig
+  begin node
+  node-id=0;node-name=$(hostname -f);cores=0-3;processors=1;roles=connection,aggregation,storage
+  end node
+  
+  begin name-server
+  nodes=0
+  end name-server
+  
+  begin overflow
+  hdd $TRAF_VAR
+  #ssd /ssd/directory
+  end overflow
+  EOF
+
   echo
   echo "Checking Java version..."
 

--- a/core/sqf/sql/scripts/sqgen
+++ b/core/sqf/sql/scripts/sqgen
@@ -178,11 +178,6 @@ while [ $# != 0 ]
     shift
   done
 
-if [[ ! -f $SQCONFIG_FILE ]]
-then
-  echo "Using default sqconfig file"
-  cp -f $TRAF_HOME/sql/scripts/sqconfig $SQCONFIG_FILE
-fi
 
 export SQLOG_DIR=$TRAF_LOG
 mkdir -p $TRAF_VAR

--- a/core/sqf/sql/scripts/sqshell
+++ b/core/sqf/sql/scripts/sqshell
@@ -22,8 +22,4 @@
 # @@@ END COPYRIGHT @@@
 #
 
-if [ -f $TRAF_VAR/sqshell.env ]; then
-    . $TRAF_VAR/sqshell.env
-fi
-
 shell $1 $2 $3 $4 $5 $6 $7 $8 $9

--- a/core/sqf/sql/scripts/sqstart
+++ b/core/sqf/sql/scripts/sqstart
@@ -476,14 +476,6 @@ let lv_startup_status=1
 let lv_num_checks=0
 #Long recoveries on a cluster could delay TX services
 let lv_max_checks=600
-# Check if resource is a work station
-if [[ -e ${TRAF_VAR}/ms.env ]] ; then
-   VIRT_NODES=`awk '/SQ_VIRTUAL_NODES=/ { fields=split($0,virt,"=");  if ( fields == 2 ) { virtnodes=virt[2];}} END {print  virtnodes}' < $TRAF_VAR/ms.env`
-   if [[ -n "$VIRT_NODES" ]] ; then
-      #Some utilities on workstations will timeout if we wait too long
-      lv_max_checks=360
-   fi
-fi
 let lv_done=0
 let lv_process_count_curr=0
 let lv_process_count_last=0

--- a/core/sqf/sql/scripts/trafnodestatus
+++ b/core/sqf/sql/scripts/trafnodestatus
@@ -83,12 +83,6 @@ else
    lv_monitor_not_running_on_curr_node=1
 fi
 
-if [[ ! -z ${SQ_VIRTUAL_NODES} ]]; then
-    # Running in a single node environment
-    traf_echo "Trafodion has been configured to run on a single virtual node environment."
-    traf_exit 1
-fi
-
 grep_out_mon=`$TRAF_HOME/sql/scripts/cstat | grep "monitor COLD" `
 lv_ret=$?
 if [[ $lv_ret == 0 ]]; then

--- a/core/sql/regress/core/EXPECTED131
+++ b/core/sql/regress/core/EXPECTED131
@@ -148,8 +148,6 @@ Query_Invalidation_Keys explain output
 >>log;
 No. Query Invalidation Keys 
 No. Query Invalidation Keys 
-No. Query Invalidation Keys 
-numQueryInvKeys: 
 numQueryInvKeys: 
 >>
 >>exit;

--- a/core/sql/regress/core/EXPECTEDRTS
+++ b/core/sql/regress/core/EXPECTEDRTS
@@ -3974,10 +3974,6 @@ Sort TopN                -1
 ---
 > >>obey STATS_CMD_QID;
 > >>get statistics for qid MXID11000011701212378219753251307000000000206U3333300_518_S1;
-21c22
-< Number of Cpus           1
----
-> Number of Cpus           2
 38a40,50
 >    Id       DOP Table Name
 >   EstRowsAccess       ActRowsAccess    EstRowsUsed         ActRowsUsed              SE_IOs        SE_IO_KBytes       SE_IO_SumTime       SE_IO_MaxTime
@@ -4018,10 +4014,6 @@ Sort TopN                -1
 ---
 > >>obey STATS_CMD_QID;
 > >>get statistics for qid MXID11000011701212378219753251307000000000206U3333300_522_S1;
-21c22
-< Number of Cpus           1
----
-> Number of Cpus           2
 >>
 >>
 >>control query default detailed_statistics 'system' ;
@@ -4050,10 +4042,6 @@ Sort TopN                -1
 ---
 > >>obey STATS_CMD_QID;
 > >>get statistics for qid MXID11000011701212378219753251307000000000206U3333300_526_S1;
-21c22
-< Number of Cpus           1
----
-> Number of Cpus           2
 >>
 >>
 >>obey TESTRTS(exeindp2_stats);

--- a/core/sql/regress/hive/EXPECTED018
+++ b/core/sql/regress/hive/EXPECTED018
@@ -792,7 +792,7 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 ---- ---- ---- --------------------  --------  --------------------  ---------
 
 4    .    5    root                                                  1.00E+011
-3    .    4    esp_exchange                    1:4(hash2)            1.00E+011
+3    .    4    esp_exchange                    1:2(hash2)            1.00E+011
 1    .    3    unload                                                1.00E+011
 .    .    1    trafodion_scan                  CUSTOMER_DEMOGRAPHIC  1.00E+011
 
@@ -847,7 +847,7 @@ Task:  MERGE FILES     Status: Ended      Elapsed Time:    00:00:00.043
 >>
 >>log;
 regrhadoop.ksh fs -du -s /user/trafodion/bulkload/customer_demographics_salt/merged_customer_demogs_4.gz
-78431  78431  /user/trafodion/bulkload/customer_demographics_salt/merged_customer_demogs_4.gz
+78233  78233  /user/trafodion/bulkload/customer_demographics_salt/merged_customer_demogs_4.gz
 >>
 >>--exp4
 >>explain options 'f' 
@@ -859,7 +859,7 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 ---- ---- ---- --------------------  --------  --------------------  ---------
 
 4    .    5    root                                                  1.00E+011
-3    .    4    esp_exchange                    1:4(hash2)            1.00E+011
+3    .    4    esp_exchange                    1:2(hash2)            1.00E+011
 1    .    3    unload                                                1.00E+011
 .    .    1    trafodion_scan                  CUSTOMER_DEMOGRAPHIC  1.00E+011
 
@@ -887,7 +887,7 @@ Task:  EXTRACT         Status: Ended      Elapsed Time:    00:00:00.230
 regrhadoop.ksh fs -cat /user/trafodion/bulkload/customer_demographics_salt/file* | wc -l
 20000
 regrhadoop.ksh fs -ls /user/trafodion/bulkload/customer_demographics_salt/file* |  grep file | wc -l
-4
+2
 >>
 >>--unload 7
 >>UNLOAD  
@@ -2136,7 +2136,7 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 ---- ---- ---- --------------------  --------  --------------------  ---------
 
 4    .    5    root                                                  1.00E+011
-3    .    4    esp_exchange                    1:4(hash2)            1.00E+011
+3    .    4    esp_exchange                    1:2(hash2)            1.00E+011
 1    .    3    unload                                                1.00E+011
 .    .    1    trafodion_scan                  CUSTOMER_DEMOGRAPHIC  1.00E+011
 

--- a/core/sql/regress/hive/FILTER018
+++ b/core/sql/regress/hive/FILTER018
@@ -32,7 +32,7 @@ s/Logging Location:.*/Loggin Location:@loggingLocation@/
 s/Time:.*/Time:@time@/
 s/snapshot_temp_location.*/snapshot_temp_location location/g
 s/\(778224\).*\(778224\)\(.*\)/\1\3/g
-s/\(78431\).*\(78431\)\(.*\)/\1\3/g
+s/\(78233\).*\(78233\)\(.*\)/\1\3/g
 /^org\.apache\.hadoop/d
 /^org\.trafodion/d
 " $fil

--- a/core/sql/regress/seabase/DIFF025.KNOWN
+++ b/core/sql/regress/seabase/DIFF025.KNOWN
@@ -1,4 +1,51 @@
-1570c1570
-< 0
+1541c1541,1544
+< --- SQL command prepared.
 ---
-> 1
+> *** ERROR[2235] Compiler Internal Error: An unknown error, originated from file ../optimizer/NodeMap.cpp at line #nnn.
+> 
+> *** ERROR[8822] The statement was not prepared.
+> 
+1549c1552,1553
+< --- 10000 row(s) inserted.
+---
+> *** ERROR[15017] Statement INS06 was not found.
+> 
+1557c1561
+<  10000
+---
+>  0
+1611c1615,1618
+< --- SQL command prepared.
+---
+> *** ERROR[2235] Compiler Internal Error: An unknown error, originated from file ../optimizer/NodeMap.cpp at line #nnn.
+> 
+> *** ERROR[8822] The statement was not prepared.
+> 
+1617,1628c1624
+< LC RC OP OPERATOR OPT DESCRIPTION CARD
+< ---- ---- ---- -------------------- -------- -------------------- ---------
+< 
+< 8 . 9 root 1.00E+004
+< 7 . 8 esp_exchange 1:4(hash2) 1.00E+004
+< 6 . 7 esp_exchange 4(hash2):1 1.00E+004
+< 4 5 6 tuple_flow 1.00E+004
+< . . 5 TRAFODION_load h T025T007 1.00E+000
+< 3 . 4 transpose 1.00E+004
+< 2 . 3 transpose 1.00E+003
+< 1 . 2 transpose 1.00E+002
+< . . 1 tuplelist 1.00E+001
+---
+> *** ERROR[8804] The provided input statement does not exist in the current context.
+1630c1626
+< --- SQL operation complete.
+---
+> --- SQL operation failed with errors.
+1634c1630,1631
+< --- 10000 row(s) inserted.
+---
+> *** ERROR[15017] Statement INS07 was not found.
+> 
+1674c1671
+< --- 10000 row(s) inserted.
+---
+> --- 0 row(s) inserted.

--- a/core/sql/regress/seabase/EXPECTED031
+++ b/core/sql/regress/seabase/EXPECTED031
@@ -599,7 +599,7 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 
 4    .    5    root                                                  1.00E+000
 3    .    4    sort_partial_aggr_ro                                  1.00E+000
-2    .    3    esp_exchange                    1:4(hash2)            1.00E+000
+2    .    3    esp_exchange                    1:2(hash2)            1.00E+000
 1    .    2    sort_partial_aggr_le                                  1.00E+000
 .    .    1    hive_scan                       T031HIVE              1.00E+000
 

--- a/core/sql/regress/tools/runallsb
+++ b/core/sql/regress/tools/runallsb
@@ -125,18 +125,7 @@ fi
 #
 # Now that we have our SQF environment, let's make sure it's running
 #
-
-# Check if resource is a cluster
-SQCONFIG=$TRAF_CONF/sqconfig
-CONN_NODE=$(grep -v '^#' $SQCONFIG | grep -m 1 connection | sed -e "s@node-name=\(n[0-9]*\);.*@\1@" | cut -d ';' -f2)
-
-# if CONN_NODE is empty then resource is a workstation otherwise resource is a cluster
-if [ -z $CONN_NODE ]
-then
-    sqcheck
-else
-    ssh $CONN_NODE $TRAF_HOME/sql/scripts/sqcheck
-fi
+sqcheck
 
 if [[ $? -ne 0 ]]; then
    echo ""

--- a/core/sql/regress/udr/EXPECTED001
+++ b/core/sql/regress/udr/EXPECTED001
@@ -386,10 +386,10 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 ---- ---- ---- --------------------  --------  --------------------  ---------
 
 5    .    6    root                                                  1.79E+001
-4    .    5    esp_exchange                    1:4(hash2)            5.00E+001
+4    .    5    esp_exchange                    1:2(hash2)            5.00E+001
 3    .    4    tmudf                           XO                    5.00E+001
 2    .    3    sort                                                  1.00E+002
-1    .    2    esp_exchange                    4(hash2):1            1.00E+002
+1    .    2    esp_exchange                    2(hash2):1            1.00E+002
 .    .    1    trafodion_scan                  CLICKS                1.00E+002
 
 --- SQL operation complete.
@@ -478,11 +478,11 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 ---- ---- ---- --------------------  --------  --------------------  ---------
 
 6    .    7    root                                                  1.79E+001
-5    .    6    esp_exchange                    1:4(hash2) (m)        5.00E+001
+5    .    6    esp_exchange                    1:2(hash2) (m)        5.00E+001
 4    .    5    sort                                                  5.00E+001
 3    .    4    tmudf                           XO                    5.00E+001
 2    .    3    sort                                                  1.00E+002
-1    .    2    esp_exchange                    4(hash2):1            1.00E+002
+1    .    2    esp_exchange                    2(hash2):1            1.00E+002
 .    .    1    trafodion_scan                  CLICKS                1.00E+002
 
 --- SQL operation complete.

--- a/install/python-installer/scripts/traf_sqconfig.py
+++ b/install/python-installer/scripts/traf_sqconfig.py
@@ -43,12 +43,9 @@ def run():
     core = int(core)-1 if int(core) <= 256 else 255
 
     lines = ['begin node\n']
-    if len(nodes) == 1:
-        lines.append('_virtualnodes 2\n')
-    else:
-        for node_id, node in enumerate(nodes):
-            line = 'node-id=%s;node-name=%s;cores=0-%d;processors=%s;roles=connection,aggregation,storage\n' % (node_id, node, core, processor)
-            lines.append(line)
+    for node_id, node in enumerate(nodes):
+        line = 'node-id=%s;node-name=%s;cores=0-%d;processors=%s;roles=connection,aggregation,storage\n' % (node_id, node, core, processor)
+        lines.append(line)
 
     lines.append('end node\n')
     lines.append('\n')


### PR DESCRIPTION
Changed workstation mode (aka install_local_hadoop aka ILH) to use
single-node configuration instead of virtual nodes.
* ILH script generates sqconfig for current node.
* template sqconfig file moved to config template dir.
* Updated expected files accordingly.
** Filed jira [TRAFODION-3283] for bug found.

Removed setting and use of SQ_VIRTUAL_NODES variable.

Removed virtual nodes support in sqgen.

Changed installer to not treat single-node clusters specially.