### PR TITLE
[TRAFODION-3284] Make overflow processing for float SUM consistent

### DIFF
--- a/core/sql/exp/exp_ieee.cpp
+++ b/core/sql/exp/exp_ieee.cpp
@@ -107,6 +107,12 @@ double doConvReal64ToReal64(double op1)
   return temp;
 }
 
+// Note: A copy of this function's logic has been inlined
+// in exp_eval.cpp. So if you change this, change that logic
+// also. (We may ultimately want to inline this function 
+// everywhere, or even all the functions in this module, but 
+// that requires a more complete study of performance impacts 
+// than I am prepared to invest at the moment.)
 
 double MathReal64Add(double x, double y, short *ov)
 {

--- a/core/sql/exp/exp_ieee.h
+++ b/core/sql/exp/exp_ieee.h
@@ -40,4 +40,6 @@ double MathConvReal64ToReal64(double x, short * ov);
 }
 #endif
 
+void MathEvalException(double result, unsigned long exc, short * ov); // so exp_eval.cpp can get it
+
 #endif


### PR DESCRIPTION
This change makes overflow checking on floating point datatypes for SUM (and AVG) consistent with floating point overflow checking elsewhere in the product.

To do so required inlining certain code in order to not regress performance.