### PR TITLE
[TRAFODION-3281] Fix syntax error introduced in previous change

### DIFF
--- a/core/sqf/sql/scripts/install_local_hadoop
+++ b/core/sqf/sql/scripts/install_local_hadoop
@@ -666,19 +666,19 @@ else
   cp -rf  $TRAF_HOME/conf/* traf_conf/
 
   cat <<-EOF > traf_conf/sqconfig
-  begin node
-  node-id=0;node-name=$(hostname -f);cores=0-3;processors=1;roles=connection,aggregation,storage
-  end node
-  
-  begin name-server
-  nodes=0
-  end name-server
-  
-  begin overflow
-  hdd $TRAF_VAR
-  #ssd /ssd/directory
-  end overflow
-  EOF
+	begin node
+	node-id=0;node-name=$(hostname -f);cores=0-3;processors=1;roles=connection,aggregation,storage
+	end node
+	
+	begin name-server
+	nodes=0
+	end name-server
+	
+	begin overflow
+	hdd $TRAF_VAR
+	#ssd /ssd/directory
+	end overflow
+	EOF
 
   echo
   echo "Checking Java version..."


### PR DESCRIPTION
Earlier changes for this jira introduced syntax error in script
with spaces, where tabs are expected.