### PR TITLE
fixes to trafci prepare/execute queries

### DIFF
--- a/core/conn/jdbcT4/src/main/java/org/trafodion/jdbc/t4/InterfaceStatement.java
+++ b/core/conn/jdbcT4/src/main/java/org/trafodion/jdbc/t4/InterfaceStatement.java
@@ -512,7 +512,6 @@ class InterfaceStatement {
 			break;
 		case InterfaceResultSet.SQLTYPECODE_BINARY:
 		case InterfaceResultSet.SQLTYPECODE_VARBINARY:
-                    System.out.println("here binary datatype");
 			if (paramValue instanceof InputStream) {
 				InputStream is = (InputStream)paramValue;
 				dataLen = 0;

--- a/core/conn/jdbcT4/src/main/java/org/trafodion/jdbc/t4/TrafT4Desc.java
+++ b/core/conn/jdbcT4/src/main/java/org/trafodion/jdbc/t4/TrafT4Desc.java
@@ -64,7 +64,7 @@ class TrafT4Desc {
                 case Types.BINARY:
                     return "java.sql.Binary";
                 case Types.VARBINARY:
-                    return "jave.sql.Varbinary";
+                    return "java.sql.Varbinary";
 		case Types.BIT:
 		default:
 			return null;

--- a/core/conn/trafci/src/main/java/org/trafodion/ci/DatabaseQuery.java
+++ b/core/conn/trafci/src/main/java/org/trafodion/ci/DatabaseQuery.java
@@ -503,10 +503,7 @@ public class DatabaseQuery extends QueryWrapper
 
       ParameterMetaData paramMetaData=null;
       paramMetaData = pStmt.getParameterMetaData();
-      if (paramMetaData == null)
-          {
-              System.out.println("pmd is null");
-          }
+
       String sqlQueryStr=((TrafT4Statement)pStmt).getSQL();
       List<String> namedParamList=getParamNames(sqlQueryStr);
       
@@ -580,7 +577,7 @@ public class DatabaseQuery extends QueryWrapper
                         pStmt.setNull(index+1,Types.NULL);
                      else
                      {
-                int paramType = paramMetaData.getParameterType(i+1);
+                int paramType = paramMetaData.getParameterType(index+1);
                 if ((paramType == Types.BINARY) ||
                     (paramType == Types.VARBINARY))
                     {
@@ -730,7 +727,7 @@ public class DatabaseQuery extends QueryWrapper
                          value = evaluateParameterValue(pv);
                          if (sessObj.isDebugOn())
                          {
-                        	 System.out.println("@@@Debug: DatabaseQuery:: pv = " +  pv);
+                             System.out.println("@@@Debug: DatabaseQuery:: pv = " +  pv);
                              System.out.println("@@@Debug: DatabaseQuery:: value = " + value);
                          }
                      }
@@ -1109,10 +1106,6 @@ public class DatabaseQuery extends QueryWrapper
 
             ParameterMetaData paramMetaData=null;
             paramMetaData = ps.getParameterMetaData();
-            if (paramMetaData == null)
-                {
-                    System.out.println("pmd is null");
-                }
 
             int index=0;
             for (int i=0;i < paramList.size(); i++)
@@ -1138,7 +1131,7 @@ public class DatabaseQuery extends QueryWrapper
                         ps.setNull(index+1,Types.NULL);
                      }else
                      {
-                       int paramType = paramMetaData.getParameterType(i+1);
+                       int paramType = paramMetaData.getParameterType(index+1);
                        if ((paramType == Types.BINARY) ||
                            (paramType == Types.VARBINARY))
                            {

--- a/core/sqf/tools/sqtools.sh
+++ b/core/sqf/tools/sqtools.sh
@@ -1018,6 +1018,12 @@ function cdc {
 function cdj {
     cd $TRAF_HOME/../sql/src/main/java/org/trafodion/sql
 }
+function cdci {
+    cd $TRAF_HOME/../conn/trafci/src/main/java/org/trafodion/ci
+}
+function cdt4 {
+    cd $TRAF_HOME/../conn/jdbcT4/src/main/java/org/trafodion/jdbc/t4
+}
 # ls variants
 function lst {
 ls -lsrt $*


### PR DESCRIPTION
- an extra msg 'pmd is null' no longer shows from trafci prepare execute
- trafci queries with multiple param no longer returns an 'invalid desc index' error
- changed reference to 'jave.sql.Varbinary' to 'java.sql.Varbinary'