### PR TITLE
Fix for cores seen with T2 JDBC applications caused by PR 1820

### DIFF
--- a/core/sql/cli/Globals.cpp
+++ b/core/sql/cli/Globals.cpp
@@ -97,6 +97,7 @@ CliGlobals::CliGlobals(NABoolean espProcess)
        langManJava_(NULL)
        , myVerifier_(-1)
        , espProcess_(espProcess)
+       , hbaseClientJNI_(NULL)
 {
   globalsAreInitialized_ = FALSE;
   executorMemory_.setThreadSafe();


### PR DESCRIPTION
New member variables were not initialized in the CliGlobals constructor