### PR TITLE
[TRAFODION-3299] More improvements to binder messages in Messages Guide

### DIFF
--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -1202,7 +1202,7 @@ $1~String1 --------------------------------
 4130 ZZZZZ 99999 BEGINNER MAJOR DBADMIN $0~string0 is a read-only DEFAULTS attribute and cannot be updated.
 4131 42000 99999 BEGINNER MAJOR DBADMIN Current_time, current_date, or current_timestamp is not allowed in a check constraint.
 4132 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Current_user, session_user, or system_user is not allowed in a check constraint.
-4133 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Both trim character and source have to be CHARACTER typed.
+4133 ZZZZZ 99999 BEGINNER MAJOR DBADMIN For the TRIM function, the trim character and source must be of CHARACTER type.
 4134 42000 99999 BEGINNER MAJOR DBADMIN The operation ($0~String0) is not allowed.  Try UNION ALL instead.
 4135 42000 99999 BEGINNER MAJOR DBADMIN In an INSERT-SELECT, each column in the ORDER BY clause must be one of the columns in the select list of the query.  Column in error: $0~ColumnName.
 4136 ZZZZZ 99999 BEGINNER MAJOR DBADMIN An outer SELECT was used in a DELETE [FIRST N] statement without using the [LAST 1] clause.
@@ -1386,24 +1386,24 @@ $1~String1 --------------------------------
 4391 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Parameters and outer references in the PARTITION BY or ORDER BY clause of a window function are not supported.
 4392 ZZZZZ 99999 BEGINNER MAJOR DBADMIN The REGEXP predicate only supports the default collating sequence.
 4400 ZZZZZ 99999 BEGINNER MAJOR LOGONLY Internal error
-4401 ZZZZZ 99999 BEGINNER MAJOR LOGONLY No Privileged Segment
-4402 ZZZZZ 99999 BEGINNER MAJOR LOGONLY Program file not authorized
-4403 ZZZZZ 99999 BEGINNER MAJOR LOGONLY Security Server not running
-4404 ZZZZZ 99999 BEGINNER MAJOR LOGONLY Registration with Security Server failed
-4405 ZZZZZ 99999 BEGINNER MAJOR LOGONLY No shared segment in Security Server
-4406 ZZZZZ 99999 BEGINNER MINOR LOGONLY Too many requestors to Security Server
-4407 ZZZZZ 99999 BEGINNER MAJOR LOGONLY Security policy file not found
-4408 ZZZZZ 99999 BEGINNER MAJOR LOGONLY Error in security policy file
-4409 ZZZZZ 99999 BEGINNER MAJOR LOGONLY Bad security policy
-4410 ZZZZZ 99999 BEGINNER MAJOR LOGONLY Digest mismatch
-4411 ZZZZZ 99999 BEGINNER MAJOR LOGONLY Decryption error
-4412 ZZZZZ 99999 BEGINNER MAJOR LOGONLY SECKEYS key file not found
-4413 ZZZZZ 99999 BEGINNER MAJOR LOGONLY SECKEYS key file error
-4414 ZZZZZ 99999 BEGINNER MAJOR LOGONLY Certificate expired
-4415 ZZZZZ 99999 BEGINNER MAJOR LOGONLY Certificate not found
-4416 ZZZZZ 99999 BEGINNER MINOR LOGONLY Certificate has been updated
-4417 ZZZZZ 99999 BEGINNER MAJOR LOGONLY Error in shared segment
-4418 ZZZZZ 99999 BEGINNER MAJOR LOGONLY Unauthorized user
+4401 ZZZZZ 99999 BEGINNER MAJOR LOGONLY --- unused ---
+4402 ZZZZZ 99999 BEGINNER MAJOR LOGONLY --- unused ---
+4403 ZZZZZ 99999 BEGINNER MAJOR LOGONLY --- unused ---
+4404 ZZZZZ 99999 BEGINNER MAJOR LOGONLY --- unused ---
+4405 ZZZZZ 99999 BEGINNER MAJOR LOGONLY --- unused ---
+4406 ZZZZZ 99999 BEGINNER MINOR LOGONLY --- unused ---
+4407 ZZZZZ 99999 BEGINNER MAJOR LOGONLY --- unused ---
+4408 ZZZZZ 99999 BEGINNER MAJOR LOGONLY --- unused ---
+4409 ZZZZZ 99999 BEGINNER MAJOR LOGONLY --- unused ---
+4410 ZZZZZ 99999 BEGINNER MAJOR LOGONLY --- unused ---
+4411 ZZZZZ 99999 BEGINNER MAJOR LOGONLY --- unused ---
+4412 ZZZZZ 99999 BEGINNER MAJOR LOGONLY --- unused ---
+4413 ZZZZZ 99999 BEGINNER MAJOR LOGONLY --- unused ---
+4414 ZZZZZ 99999 BEGINNER MAJOR LOGONLY --- unused ---
+4415 ZZZZZ 99999 BEGINNER MAJOR LOGONLY --- unused ---
+4416 ZZZZZ 99999 BEGINNER MINOR LOGONLY --- unused ---
+4417 ZZZZZ 99999 BEGINNER MAJOR LOGONLY --- unused ---
+4418 ZZZZZ 99999 BEGINNER MAJOR LOGONLY --- unused ---
 4450 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Function $0~String0 is not a built-in function or registered user-defined function.
 4451 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Action $0~String0 is not a registered action for user-defined function $1~String1.
 4452 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Function $0~String0 expects $1~Int0 input values but was called with $2~Int1 values.

--- a/core/sql/regress/executor/EXPECTED001
+++ b/core/sql/regress/executor/EXPECTED001
@@ -33,7 +33,7 @@
 >>invoke t001t1;
 
 -- Definition of Trafodion table TRAFODION.SCH.T001T1
--- Definition current  Tue Aug  9 03:54:49 2016
+-- Definition current  Mon Apr 22 18:33:14 2019
 
   (
     SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -55,7 +55,7 @@
 >>invoke t001t2;
 
 -- Definition of Trafodion table TRAFODION.SCH.T001T2
--- Definition current  Tue Aug  9 03:54:50 2016
+-- Definition current  Mon Apr 22 18:33:17 2019
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -71,7 +71,7 @@
 >>invoke t001t3;
 
 -- Definition of Trafodion table TRAFODION.SCH.T001T3
--- Definition current  Tue Aug  9 03:54:50 2016
+-- Definition current  Mon Apr 22 18:33:18 2019
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -89,7 +89,7 @@
 >>invoke $$TEST_SCHEMA$$.t001ut1;
 
 -- Definition of Trafodion table TRAFODION.SCH.T001UT1
--- Definition current  Tue Aug  9 03:54:50 2016
+-- Definition current  Mon Apr 22 18:33:20 2019
 
   (
     SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -105,7 +105,7 @@
 >>invoke $$TEST_SCHEMA_NAME$$.t001ut2;
 
 -- Definition of Trafodion table TRAFODION.SCH.T001UT2
--- Definition current  Tue Aug  9 03:54:50 2016
+-- Definition current  Mon Apr 22 18:33:21 2019
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -121,7 +121,7 @@
 >>invoke         t001ut3;
 
 -- Definition of Trafodion table TRAFODION.SCH.T001UT3
--- Definition current  Tue Aug  9 03:54:51 2016
+-- Definition current  Mon Apr 22 18:33:23 2019
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -466,13 +466,13 @@ select a from t001t1 where b like _SJIS'sj';
 >>
 >>select a from t001t1 where trim(1 from 2) = '';
 
-*** ERROR[4133] Both trim character and source have to be CHARACTER typed.
+*** ERROR[4133] For the TRIM function, the trim character and source must be of CHARACTER type.
 
 *** ERROR[8822] The statement was not prepared.
 
 >>select a from t001t1 where trim(1 from b) = '';
 
-*** ERROR[4133] Both trim character and source have to be CHARACTER typed.
+*** ERROR[4133] For the TRIM function, the trim character and source must be of CHARACTER type.
 
 *** ERROR[8822] The statement was not prepared.
 

--- a/docs/messages_guide/src/asciidoc/_chapters/binder_msgs.adoc
+++ b/docs/messages_guide/src/asciidoc/_chapters/binder_msgs.adoc
@@ -540,7 +540,7 @@ It does not support this in the BEFORE part of a trigger.
 == SQL 4034
 
 ```
-The operation (<data-type> <operation-data-type>) operation is not allowed.
+The operation (<data-type> <operation> <data-type>) <additional-info> is not allowed.
 ```
 
 *Cause:* You specified an operation that is not supported. Sometimes this message is accompanied
@@ -1926,16 +1926,15 @@ or system_user.
 == SQL 4133
 
 ```
-Both trim character and source have to be CHARACTER type.
+For the TRIM function, the trim character and source must be of CHARACTER type.
 ```
 
-*Cause:* The type of the trim source and trim character is not
+*Cause:* The type of the trim source or trim character is not
 CHARACTER.
 
 *Effect:* The operation fails.
 
-*Recovery:* Make sure the type of the source and trim character is
-CHARACTER.
+*Recovery:* Correct the statement and resubmit.
 
 [[SQL-4134]]
 == SQL 4134
@@ -1956,7 +1955,7 @@ database software does not allow.
 
 ```
 In an INSERT-SELECT, each column in the ORDER BY clause must be one
-of the columns in the select list of the query. Column in error: B.
+of the columns in the select list of the query. Column in error: <column-name>.
 ```
 
 *Cause:* You tried to SQL-compile an INSERT-SELECT statement that
@@ -2504,6 +2503,20 @@ columns that are part of a referential constraint.
 
 *Recovery:* Modify the statement and resubmit.
 
+[[SQL-4185]]
+== SQL 4185
+
+```
+Select list index is not allowed to be specified in the GROUP BY clause for this query.
+```
+
+*Cause:* In a GROUP BY clause, you specified an index (that is, a number), but the index is not valid.
+For example, the select list might be "*", or the index might refer to an aggregate function.
+
+*Effect:* The operation fails.
+
+*Recovery:* Modify the statement and resubmit.
+
 [[SQL-4189]]
 == SQL 4189
 
@@ -2519,6 +2532,48 @@ clause.
 
 *Recovery:* Do not use ORDER BY with an embedded INSERT, UPDATE, or
 DELETE statement.
+
+[[SQL-4191]]
+== SQL 4191
+
+```
+Schema name <schema-name> specified as part of the volatile table or index must be the same as the current user name, <user-name>.
+```
+
+*Cause:* The inferred or specified schema name of a volatile object is incorrect. One way this can happen is by attempting
+to create a volatile index on a non-volatile table. That is not allowed.
+
+*Effect:* The statement does not compile.
+
+*Recovery:* If the intent was to create an index on a non-volatile table, omit the keyword VOLATILE in the CREATE INDEX statement.
+
+[[SQL-4192]]
+== SQL 4192
+
+```
+An invalid volatile object name was specified.
+```
+
+*Cause:* In a context where {project-name} expected a volatile object name, a non-volatile object name was specified
+instead. One way this can happen is if you specify CREATE VOLATILE INDEX on a non-volatile table.
+
+*Effect:* The statement does not compile.
+
+*Recovery:* Correct the statement and resubmit.
+
+[[SQL-4193]]
+== SQL 4193
+
+```
+The schema name prefix <prefix> is reserved and cannot be used.
+```
+
+*Cause:* You attempted to use a schema name beginning with <prefix>. This is not allowed as {project-name} reserves 
+these names for internal use.
+
+*Effect:* The statement does not compile.
+
+*Recovery:* Correct the statement and resubmit.
 
 [[SQL-4200]]
 == SQL 4200


### PR DESCRIPTION
Added documentation for messages 4185, 4191, 4192, 4193.

Removed some unused messages from the code.

Edited the message text for a few others. In one case, this required an update to the expected results of one regression test.