### PR TITLE
TRAFODION-3280] Reduce path length in Trafodion for improved performance and scalability

### DIFF
--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/JtaXAResource.java
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/JtaXAResource.java
@@ -149,7 +149,12 @@ public class JtaXAResource implements XAResource {
     public void start(final Xid xid, final int flags) throws XAException {
         LOG.trace("start [" + xid.toString() + "] ");
         // TODO, check flags
-        TransactionState state = this.transactionManager.beginTransaction();
+        TransactionState state =  null;
+        try {
+           state = this.transactionManager.beginTransaction();
+        } catch (IOException e) {
+           throw new XAException(e.getMessage());
+        }
         threadLocalTransactionState.set(state);
         xidToTransactionState.put(xid, state);
     }

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/RMInterface.java
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/RMInterface.java
@@ -44,7 +44,7 @@ import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.HRegionLocation;
-import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.RegionLocator;
 import org.apache.hadoop.hbase.ZooKeeperConnectionException;
 import org.apache.hadoop.hbase.client.coprocessor.Batch;
 import org.apache.hadoop.hbase.client.Connection;
@@ -94,6 +94,7 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Iterator;
 import java.util.Set;
 import java.util.HashSet;
 import java.util.concurrent.ConcurrentHashMap;
@@ -111,12 +112,14 @@ public class RMInterface {
 
     public AlgorithmType TRANSACTION_ALGORITHM;
     static Map<Long, Set<RMInterface>> mapRMsPerTransaction = new HashMap<Long,  Set<RMInterface>>();
-    private TransactionalTableClient ttable = null;
+    private TransactionalTable ttable = null;
+    private boolean bRegisterRegionsAtTransEnd;
     private ExecutorService threadPool;
     private CompletionService<Integer> compPool;
     private int intThreads = 16;
     private Connection connection;
     static TransactionManager txm;
+
     static {
         System.loadLibrary("stmlib");
         String envset = System.getenv("TM_USE_SSCC");
@@ -126,7 +129,6 @@ public class RMInterface {
            envTransactionAlgorithm = AlgorithmType.MVCC;
     }
 
-    private native void registerRegion(int port, byte[] hostname, long startcode, byte[] regionInfo);
     private native String createTableReq(byte[] lv_byte_htabledesc, byte[][] keys, int numSplits, int keyLength, long transID, byte[] tblName);
     private native String dropTableReq(byte[] lv_byte_tblname, long transID);
     private native String truncateOnAbortReq(byte[] lv_byte_tblName, long transID); 
@@ -136,19 +138,20 @@ public class RMInterface {
       System.out.println("MAIN ENTRY");
     }
 
-    private IdTm idServer;
+    protected static IdTm idServer;
     private static final int ID_TM_SERVER_TIMEOUT = 1000; // 1 sec 
 
     public enum AlgorithmType {
        MVCC, SSCC
     }
 
-    private static AlgorithmType envTransactionAlgorithm;
+    protected static AlgorithmType envTransactionAlgorithm;
     private AlgorithmType transactionAlgorithm;
 
     public RMInterface(final String tableName, Connection connection) throws IOException {
         if (LOG.isTraceEnabled()) LOG.trace("RMInterface constructor:"
 					    + " tableName: " + tableName);
+        bRegisterRegionsAtTransEnd = true; 
 
         this.connection = connection;
         transactionAlgorithm = envTransactionAlgorithm;
@@ -292,99 +295,121 @@ public class RMInterface {
        }
     }
 
-    public synchronized TransactionState registerTransaction(final TransactionalTableClient pv_table,
+    public TransactionState registerTransaction(final TransactionalTable pv_table, 
 							     final long transactionID,
-							     final byte[] row) throws IOException {
-        if (LOG.isTraceEnabled()) LOG.trace("Enter registerTransaction, transaction ID: " + transactionID
-             + " row " + Hex.encodeHexString(row));
-        boolean register = false;
-        short ret = 0;
+							     final byte[] startRow) throws IOException 
+    {
+       return registerTransaction (pv_table, transactionID, startRow, null, 
+                                 false, 0, false );
+    }
 
+    public TransactionState registerTransaction(final TransactionalTable pv_table, 
+							     final long transactionID, 
+							     final byte[] startRow,
+							     final byte[] endRow,			
+							     final boolean pv_skipConflictCheck,
+							     int pv_tmFlags) throws IOException 
+    {
+       return registerTransaction (pv_table, transactionID, startRow, endRow, 
+                                 pv_skipConflictCheck, 0, true );
+    }
+
+    public TransactionState registerTransaction(final TransactionalTable pv_table, 
+							     final long transactionID, 
+							     final byte[] startRow,
+							     final byte[] endRow,			
+							     final boolean pv_skipConflictCheck,
+							     int pv_tmFlags, boolean scanRange) 
+                                                                   throws IOException 
+    {
+        if (LOG.isTraceEnabled()) LOG.trace("Enter registerTransaction, table: " + getTableNameAsString() + " transaction ID: " + transactionID
+             + " startRow " + Hex.encodeHexString(startRow)
+             + " endRow " + Hex.encodeHexString(endRow));
+        boolean register = false;
+        
         TransactionState ts = mapTransactionStates.get(transactionID);
 
-        if (LOG.isTraceEnabled()) LOG.trace("mapTransactionStates " + mapTransactionStates + " entries " + mapTransactionStates.size());
+        if (LOG.isTraceEnabled()) 
+           LOG.trace("mapTransactionStates " + mapTransactionStates + " entries " + mapTransactionStates.size());
 
         // if we don't have a TransactionState for this ID we need to register it with the TM
-        if (ts == null) {
-           if (LOG.isTraceEnabled()) LOG.trace("registerTransaction transactionID (" + transactionID +
-                    ") not found in mapTransactionStates of size: " + mapTransactionStates.size());
-           ts = new TransactionState(transactionID);
-
-           long startIdVal = -1;
-
-           // Set the startid
-           if (transactionAlgorithm == AlgorithmType.SSCC) {
-              IdTmId startId;
-              try {
-                 startId = new IdTmId();
-                 if (LOG.isTraceEnabled()) LOG.trace("registerTransaction getting new startId with timeout " + ID_TM_SERVER_TIMEOUT);
-                 idServer.id(ID_TM_SERVER_TIMEOUT, startId);
-                 if (LOG.isTraceEnabled()) LOG.trace("registerTransaction idServer.id returned: " + startId.val);
-              } catch (IdTmException exc) {
-                 LOG.error("registerTransaction: IdTm threw exception " , exc);
-                 throw new IOException("registerTransaction: IdTm threw exception ", exc);
-              }
-              startIdVal = startId.val;
-           }
-           ts.setStartId(startIdVal);
-
-           synchronized (mapTransactionStates) {
-              TransactionState ts2 = mapTransactionStates.get(transactionID);
-              if (ts2 != null) {
-                 // Some other thread added the transaction while we were creating one.  It's already in the
-                 // map, so we can use the existing one.
-                 if (LOG.isTraceEnabled()) LOG.trace("RMInterface:registerTransaction, found TransactionState object while creating a new one " + ts2);
-                 ts = ts2;
-              }
-              else {
-                 if (LOG.isTraceEnabled()) LOG.trace("RMInterface:registerTransaction, adding new TransactionState to map " + ts);
-                 mapTransactionStates.put(transactionID, ts);
-              }
-           }// end synchronized
-           register = true;
-        }
-        else {
-            if (LOG.isTraceEnabled()) LOG.trace("RMInterface:registerTransaction - Found TS in map for tx " + ts);
+        if (ts == null) { 
+           ts = TransactionState.getInstance(transactionID);
         }
         HRegionLocation location = pv_table.getRegionLocation(row, false /*reload*/);
 
-        if (LOG.isTraceEnabled()) LOG.trace("RMInterface:registerTransaction - retrieved location with startKey="
-              + Hex.encodeHexString(location.getRegionInfo().getStartKey()) + ", endKey="
-              + Hex.encodeHexString(location.getRegionInfo().getEndKey()) + " row= " + Hex.encodeHexString(row));
-        TransactionRegionLocation trLocation = new TransactionRegionLocation(location.getRegionInfo(),
+        HRegionLocation locationRow;
+        boolean refresh = false;
+        if (createdTables.size() > 0 && createdTables.contains(Bytes.toString(pv_table.getTableName()))){
+            if (LOG.isTraceEnabled()) LOG.trace("Locations being refreshed : "
+                + Bytes.toString(pv_table.getTableName()) + " for transaction " + transactionID
+                + "  CreatedTables size " + createdTables.size());
+            refresh = true;
+            createdTables.remove(Bytes.toString(pv_table.getTableName()));
+        }
+
+        HRegionLocation location = null;
+        List<HRegionLocation> scanRegionLocations = null;
+        Iterator<HRegionLocation> scanRegionLocationsIter = null;
+        
+        // set keys to infinite
+        if ((envBroadcastMode == true) && (pv_skipConflictCheck == true))
+        { 
+            locationRow = pv_table.getRegionLocation(startRow, refresh);
+            if (LOG.isTraceEnabled()) LOG.trace("RMInterface:registerTransaction - setting keys to infinite for location " + locationRow);
+            HRegionInfo regionInfo = new HRegionInfo (locationRow.getRegionInfo().getTable(), HConstants.EMPTY_START_ROW, HConstants.EMPTY_END_ROW);
+            location = new HRegionLocation(regionInfo, locationRow.getServerName());
+            register = true;
+        }
+        if (location == null) {
+           if (scanRange) {
+              scanRegionLocations = pv_table.getRegionsInRange(startRow, endRow, refresh);
+              scanRegionLocationsIter = scanRegionLocations.iterator();
+              location = scanRegionLocationsIter.next();
+/*
+              locationRow = pv_table.getRegionLocation(startRow, refresh);
+              HRegionInfo regionInfo = new HRegionInfo (locationRow.getRegionInfo().getTable(), startRow, endRow);
+              location = new HRegionLocation(regionInfo, locationRow.getServerName());
+              register = true;
+*/
+           }
+           else 
+              location = pv_table.getRegionLocation(startRow, refresh);
+        }
+        do {
+           TransactionRegionLocation trLocation = new TransactionRegionLocation(location.getRegionInfo(),
                                                                              location.getServerName());
         if (LOG.isTraceEnabled()) LOG.trace("RMInterface:registerTransaction, created TransactionRegionLocation [" + trLocation.getRegionInfo().getRegionNameAsString() + "], endKey: "
                   + Hex.encodeHexString(trLocation.getRegionInfo().getEndKey()) + " and transaction [" + transactionID + "]");
-
-        // if this region hasn't been registered as participating in the transaction, we need to register it
-        if (ts.addRegion(trLocation)) {
-          register = true;
+           // if this region hasn't been registered as participating in the transaction, we need to register it
+           if ( (! register) && ts.addRegion(trLocation)) {
+              register = true;
           if (LOG.isTraceEnabled()) LOG.trace("RMInterface:registerTransaction, added TransactionRegionLocation ["
                   + trLocation.getRegionInfo().getRegionNameAsString() + "], endKey: "
                   + Hex.encodeHexString(trLocation.getRegionInfo().getEndKey()) + " to transaction " + transactionID
-                  + " with " + ts.getParticipantCount() + " participants");
-        }
+                        + " with " + ts.getParticipantCount() + " participants");
+           }
 
-        // register region with TM.
-        if (register) {
+           // register region with TM.
+           if (register) {
             ts.registerLocation(location);
-             if (LOG.isTraceEnabled()) LOG.trace("RMInterface:registerTransaction, called registerLocation TransactionRegionLocation [" + trLocation.getRegionInfo().getRegionNameAsString() +  "\nEncodedName: [" + trLocation.getRegionInfo().getEncodedName() + "], endKey: "
+               if (LOG.isTraceEnabled()) LOG.trace("RMInterface:registerTransaction, called registerLocation TransactionRegionLocation [" + trLocation.getRegionInfo().getRegionNameAsString() +  "\nEncodedName: [" + trLocation.getRegionInfo().getEncodedName() + "], endKey: "
                   + Hex.encodeHexString(trLocation.getRegionInfo().getEndKey()) + " to transaction [" + transactionID + "]");
-        }
-        else {
-          if (LOG.isTraceEnabled()) LOG.trace("RMInterface:registerTransaction did not send registerRegion for transaction " + transactionID);
-        }
-
-        if ((ts == null) || (ret != 0)) {
-            LOG.error("registerTransaction failed, TransactionState is NULL"); 
-            throw new IOException("registerTransaction failed with error.");
-        }
-
+           }
+           else {
+              if (LOG.isTraceEnabled()) LOG.trace("RMInterface:registerTransaction did not send registerRegion for transaction " + transactionID);
+           }
+           if (scanRange && scanRegionLocationsIter.hasNext())
+              location = scanRegionLocationsIter.next();
+           else
+              break;
+           register = false;
+        } while (true);
         if (LOG.isTraceEnabled()) LOG.trace("Exit registerTransaction, transaction ID: " + transactionID + ", startId: " + ts.getStartId());
         return ts;
     }
 
-    public synchronized TransactionState registerTransaction(final long transactionID,
+    public TransactionState registerTransaction(final long transactionID,
 							     final byte[] row) throws IOException {
 
        if (LOG.isTraceEnabled()) LOG.trace("Enter registerTransaction,"
@@ -396,54 +421,7 @@ public class RMInterface {
        return ts;
     }
 
-    public static synchronized TransactionState registerTransaction(final TransactionalTableClient pv_table,
-		     TransactionState ts,
-		     final byte[] row) throws IOException {
-       if (LOG.isTraceEnabled()) LOG.trace("Enter static registerTransaction, trans: " + ts
-              + " row " + Hex.encodeHexString(row));
-       boolean register = false;
-       final long transactionID = ts.getTransactionId();
-       short ret = 0;
-       HRegionLocation location = pv_table.getRegionLocation(row, false /*reload*/);
-
-       if (LOG.isTraceEnabled()) LOG.trace("static RMInterface:registerTransaction - retrieved location with startKey="
-               + Hex.encodeHexString(location.getRegionInfo().getStartKey()) + ", endKey="
-               + Hex.encodeHexString(location.getRegionInfo().getEndKey()) + " row= " + Hex.encodeHexString(row));
-       HRegionInfo hri = location.getRegionInfo();
-       TransactionRegionLocation trLocation = new TransactionRegionLocation(hri, location.getServerName());
-
-       if (LOG.isTraceEnabled()) LOG.trace("static RMInterface:registerTransaction, created TransactionRegionLocation [" + trLocation.getRegionInfo().getRegionNameAsString() + "], endKey: "
-               + Hex.encodeHexString(trLocation.getRegionInfo().getEndKey()) + " and transaction [" + transactionID + "]");
-
-       // if this region hasn't been registered as participating in the transaction, we need to register it
-       if (ts.addRegion(trLocation)) {
-          register = true;
-          if (LOG.isTraceEnabled()) LOG.trace("static RMInterface:registerTransaction, added TransactionRegionLocation ["
-                + trLocation.getRegionInfo().getRegionNameAsString() + "], endKey: "
-                + Hex.encodeHexString(trLocation.getRegionInfo().getEndKey()) + " to transaction " + transactionID
-                + " with " + ts.getParticipantCount() + " participants");
-       }
-
-       // register region with TM.
-       if (register) {
-          ts.registerLocation(location);
-          if (LOG.isTraceEnabled()) LOG.trace("static RMInterface:registerTransaction, called registerLocation TransactionRegionLocation [" + trLocation.getRegionInfo().getRegionNameAsString() +  "\nEncodedName: [" + trLocation.getRegionInfo().getEncodedName() + "], endKey: "
-                   + Hex.encodeHexString(trLocation.getRegionInfo().getEndKey()) + " to transaction [" + transactionID + "]");
-       }
-       else {
-          if (LOG.isTraceEnabled()) LOG.trace("static RMInterface:registerTransaction did not send registerRegion for transaction " + ts.getTransactionId());
-       }
-
-       if ((ts == null) || (ret != 0)) {
-          LOG.error("static registerTransaction failed, TransactionState is NULL");
-          throw new IOException("static registerTransaction failed with error.");
-       }
-
-       if (LOG.isTraceEnabled()) LOG.trace("Exit static registerTransaction, transaction ID: " + transactionID + ", startId: " + ts.getStartId());
-       return ts;
-    }
-
-    public long getTmId() throws IOException {
+    protected static long getTmId() throws IOException {
         if (LOG.isTraceEnabled()) LOG.trace("Enter getTmId");
 
         long IdVal = -1;
@@ -521,7 +499,7 @@ public class RMInterface {
       if (LOG.isTraceEnabled()) LOG.trace("clearTransactionStates exit txid: " + transactionID);
     }
 
-    static public synchronized void unregisterTransaction(final long transactionID) {
+    static public void unregisterTransaction(final long transactionID) {
       TransactionState ts = null;
       if (LOG.isTraceEnabled()) LOG.trace("Enter unregisterTransaction txid: " + transactionID);
       ts = mapTransactionStates.remove(transactionID);
@@ -532,13 +510,13 @@ public class RMInterface {
     }
 
     // Not used?
-    static public synchronized void unregisterTransaction(TransactionState ts) {
+    static public void unregisterTransaction(TransactionState ts) {
         if (LOG.isTraceEnabled()) LOG.trace("Enter unregisterTransaction ts: " + ts.getTransactionId());
         mapTransactionStates.remove(ts.getTransactionId());
         if (LOG.isTraceEnabled()) LOG.trace("Exit unregisterTransaction ts: " + ts.getTransactionId());
     }
 
-    public synchronized TransactionState getTransactionState(final long transactionID) throws IOException {
+    public TransactionState getTransactionState(final long transactionID) throws IOException {
         if (LOG.isTraceEnabled()) LOG.trace("getTransactionState txid: " + transactionID);
         TransactionState ts = mapTransactionStates.get(transactionID);
         if (ts == null) {
@@ -548,7 +526,7 @@ public class RMInterface {
         if (LOG.isTraceEnabled()) LOG.trace("EXIT getTransactionState");
         return ts;
     }
-    public synchronized Result get(final long transactionID, final Get get) throws IOException {
+    public Result get(final long transactionID, final Get get) throws IOException {
         if (LOG.isTraceEnabled()) LOG.trace("get txid: " + transactionID);
         TransactionState ts = registerTransaction(transactionID, get.getRow());
         Result res = ttable.get(ts, get, false);
@@ -556,7 +534,7 @@ public class RMInterface {
         return res;	
     }
 
-    public synchronized void delete(final long transactionID, final Delete delete) throws IOException {
+    public void delete(final long transactionID, final Delete delete) throws IOException {
         if (LOG.isTraceEnabled()) LOG.trace("delete txid: " + transactionID);
         TransactionState ts = registerTransaction(transactionID, delete.getRow());
         ttable.delete(ts, delete, false);
@@ -569,7 +547,7 @@ public class RMInterface {
         if (LOG.isTraceEnabled()) LOG.trace("deleteRegionTx EXIT tid: " + tid);
     }
 
-    public synchronized void delete(final long transactionID, final List<Delete> deletes) throws IOException {
+    public void delete(final long transactionID, final List<Delete> deletes) throws IOException {
         if (LOG.isTraceEnabled()) LOG.trace("Enter delete (list of deletes) txid: " + transactionID);
         TransactionState ts = null;
 	for (Delete delete : deletes) {
@@ -582,14 +560,14 @@ public class RMInterface {
         if (LOG.isTraceEnabled()) LOG.trace("Exit delete (list of deletes) txid: " + transactionID);
     }
 
-    public synchronized ResultScanner getScanner(final long transactionID, final Scan scan) throws IOException {
+    public ResultScanner getScanner(final long transactionID, final Scan scan) throws IOException {
         if (LOG.isTraceEnabled()) LOG.trace("getScanner txid: " + transactionID
            + " scan startRow=" + (Bytes.equals(scan.getStartRow(), HConstants.EMPTY_START_ROW) ?
                    "INFINITE" : Hex.encodeHexString(scan.getStartRow())) + ", endRow="
            + (Bytes.equals(scan.getStopRow(), HConstants.EMPTY_END_ROW) ?
                    "INFINITE" : Hex.encodeHexString(scan.getStopRow())));
 
-        TransactionState ts = registerTransaction(transactionID, scan.getStartRow());
+        //TransactionState ts = registerTransaction(transactionID, scan.getStartRow());
         ResultScanner res = ttable.getScanner(ts, scan);
         if (LOG.isTraceEnabled()) LOG.trace("EXIT getScanner");
         return res;
@@ -603,14 +581,14 @@ public class RMInterface {
         if (LOG.isTraceEnabled()) LOG.trace("putRegionTx Exit tid: " + tid);
     }
 
-    public synchronized void put(final long transactionID, final Put put) throws IOException {
+    public void put(final long transactionID, final Put put) throws IOException {
         if (LOG.isTraceEnabled()) LOG.trace("Enter Put txid: " + transactionID);
         TransactionState ts = registerTransaction(transactionID, put.getRow());
         ttable.put(ts, put, false);
         if (LOG.isTraceEnabled()) LOG.trace("Exit Put txid: " + transactionID);
     }
 
-    public synchronized void put(final long transactionID, final List<Put> puts) throws IOException {
+    public void put(final long transactionID, final List<Put> puts) throws IOException {
          if (LOG.isTraceEnabled()) LOG.trace("Enter put (list of puts) txid: " + transactionID);
         TransactionState ts = null;
       	for (Put put : puts) {
@@ -623,7 +601,7 @@ public class RMInterface {
         if (LOG.isTraceEnabled()) LOG.trace("Exit put (list of puts) txid: " + transactionID);
     }
 
-    public synchronized boolean checkAndPut(final long transactionID,
+    public boolean checkAndPut(final long transactionID,
                                             final byte[] row,
                                             final byte[] family,
                                             final byte[] qualifier,
@@ -645,7 +623,7 @@ public class RMInterface {
                    put, autoCommit);
     }
 
-    public synchronized boolean checkAndDelete(final long transactionID,
+    public boolean checkAndDelete(final long transactionID,
                                                final byte[] row,
                                                final byte[] family,
                                                final byte[] qualifier,

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/RMInterface.java
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/RMInterface.java
@@ -569,7 +569,6 @@ public class RMInterface {
                    "INFINITE" : Hex.encodeHexString(scan.getStopRow())));
 
         TransactionState ts = registerTransaction(ttable, transactionID, scan.getStartRow(), scan.getStopRow(), false, 0);
-        TransactionState ts = registerTransaction(ttable, transactionID, scan.getStartRow(), scan.getStopRow(), false, 0);
         ResultScanner res = ttable.getScanner(ts, scan);
         if (LOG.isTraceEnabled()) LOG.trace("EXIT getScanner");
         return res;

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/SsccTransactionalTable.java
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/SsccTransactionalTable.java
@@ -120,7 +120,7 @@ import java.util.concurrent.Executors;
 /**
  * Table with transactional support.
  */
-public class SsccTransactionalTable extends TransactionalTable implements TransactionalTableClient {
+public class SsccTransactionalTable extends TransactionalTable {
     static final Log LOG = LogFactory.getLog(RMInterface.class);
     /*   // Not necessary for 0.98
     private RpcRetryingCallerFactory rpcCallerFactory;    

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/SsccTransactionalTable.java
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/SsccTransactionalTable.java
@@ -120,7 +120,7 @@ import java.util.concurrent.Executors;
 /**
  * Table with transactional support.
  */
-public class SsccTransactionalTable extends HTable implements TransactionalTableClient {
+public class SsccTransactionalTable extends TransactionalTable implements TransactionalTableClient {
     static final Log LOG = LogFactory.getLog(RMInterface.class);
     /*   // Not necessary for 0.98
     private RpcRetryingCallerFactory rpcCallerFactory;    
@@ -150,7 +150,7 @@ public class SsccTransactionalTable extends HTable implements TransactionalTable
      * @throws IOException
      */
     public SsccTransactionalTable( final byte[] tableName, Connection connection) throws IOException {
-        super( tableName,connection, threadPool);       
+        super( tableName,connection);       
         this.connection = connection;
     }
 

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/TrafodionLocationList.java
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/TrafodionLocationList.java
@@ -1,0 +1,142 @@
+/**
+* @@@ START COPYRIGHT @@@
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+* @@@ END COPYRIGHT @@@
+**/
+
+package org.apache.hadoop.hbase.client.transactional;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.codec.binary.Hex;
+
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.ByteArrayKey;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.HRegionInfo;
+import org.apache.hadoop.hbase.HRegionLocation;
+import org.apache.hadoop.hbase.TableName;
+
+import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.ArrayList;
+//import java.util.TreeMap;
+
+import com.google.protobuf.ByteString;
+
+import java.io.IOException;
+
+public class TrafodionLocationList {
+
+  static final Log LOG = LogFactory.getLog(TrafodionLocationList.class);
+
+  private HashMap<String, HashMap<ByteArrayKey, TransactionRegionLocation>> list;
+ 
+  public TrafodionLocationList() throws IOException {
+    list = new HashMap<String, HashMap<ByteArrayKey, TransactionRegionLocation>>();
+  }
+
+  public synchronized boolean add(TransactionRegionLocation trl) {
+     if (LOG.isDebugEnabled()) LOG.debug("add Entry:  trl: " + trl);
+     boolean added = false;
+     String tableString = trl.getRegionInfo().getTable().getNameAsString();
+     if (LOG.isDebugEnabled()) LOG.debug("Retrieving locations map for table: " + tableString);
+
+     ByteArrayKey startKey =  new ByteArrayKey(trl.getRegionInfo().getStartKey());
+     HashMap<ByteArrayKey, TransactionRegionLocation> locations = null;
+     locations = list.get(tableString);
+     if (locations != null) {
+        // TableName already in the map.  Add the location to the set
+        if (! locations.containsKey(startKey)) {
+           added = true;
+           locations.put(startKey,trl);
+        }
+     }
+     else {
+        // TableName not in the Map.  We can add it immediately.
+        locations = new HashMap<ByteArrayKey,TransactionRegionLocation>();
+        locations.put(startKey,trl);
+        list.put(tableString, locations);
+        added = true;
+        if (LOG.isDebugEnabled()) LOG.debug("created locations map and added entry for keyString: " + startKey);
+     }
+     return added;
+  }
+
+  public HashMap<String, HashMap<ByteArrayKey,TransactionRegionLocation>> getList() {
+     if (LOG.isTraceEnabled()) LOG.trace("getList Entry");
+     return list;
+  }
+
+  public int tableCount() {
+     return list.size();
+  }
+
+  public int regionCount() {
+     int count = 0;
+    
+     for (Map.Entry<String, HashMap<ByteArrayKey, TransactionRegionLocation>> tableMap : list.entrySet())
+        count +=  tableMap.getValue().size();
+     return count;
+  }
+
+
+  public synchronized void clear() {
+     list = new HashMap<String, HashMap<ByteArrayKey, TransactionRegionLocation>>();
+     return;
+  }
+  
+  public int size()
+  {
+     int size = 0;
+     for (Map.Entry<String, HashMap<ByteArrayKey,TransactionRegionLocation>> tableMap : list.entrySet()) {
+        size +=  tableMap.getValue().size();
+     }
+     return size;
+  }
+
+
+  /**
+   * toString
+   * @return String this
+   *
+   */
+  @Override
+  public String toString() {
+     StringBuilder builder = new StringBuilder();
+     for (Map.Entry<String, HashMap<ByteArrayKey,TransactionRegionLocation>> tableMap : list.entrySet()) {
+        builder.append( "table " + tableMap.getKey() + "\n");
+        for (TransactionRegionLocation loc : tableMap.getValue().values()) {
+           builder.append("   start key: " + ((loc.getRegionInfo().getStartKey() != null) ?
+                    (Bytes.equals(loc.getRegionInfo().getStartKey(), HConstants.EMPTY_START_ROW) ?
+                          "INFINITE" : Hex.encodeHexString(loc.getRegionInfo().getStartKey())) : "NULL")
+            + "   end key: " + ((loc.getRegionInfo().getEndKey() != null) ?
+                    (Bytes.equals(loc.getRegionInfo().getEndKey(), HConstants.EMPTY_END_ROW) ?
+                          "INFINITE" : Hex.encodeHexString(loc.getRegionInfo().getEndKey())) : "NULL")
+            + "\n");
+       }
+    }
+    return builder.toString();
+  }
+}

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/TransactionalScanner.java.tmpl
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/TransactionalScanner.java.tmpl
@@ -180,12 +180,6 @@ public class TransactionalScanner extends AbstractClientScanner {
 
         this.closed = false;
 
-        // Need to add the next region as a participant to the transaction so it gets phase 1 notification
-        // and does not orphan the TransactionState object in the region that gets created during the scan
-        if (LOG.isTraceEnabled()) LOG.trace("nextScanner() calling RMInterface.registerTransaction for startKey "
-                  +  Hex.encodeHexString(this.currentBeginKey));
-        RMInterface.registerTransaction(ttable, ts, this.currentBeginKey);
-
       TrxRegionProtos.OpenScannerRequest.Builder requestBuilder = OpenScannerRequest.newBuilder();
       requestBuilder.setTransactionId(ts.getTransactionId());
       requestBuilder.setStartId(ts.getStartId());

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/TransactionalTable.java
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/TransactionalTable.java
@@ -106,7 +106,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 /**
  * Table with transactional support.
  */
-public class TransactionalTable extends HTable implements TransactionalTableClient {
+public class TransactionalTable extends HTable {
     static final Log LOG = LogFactory.getLog(TransactionalTable.class);
     static Configuration       config;
     static private Connection connection = null;

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/coprocessor/transactional/SsccTableClientUtils.java
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/coprocessor/transactional/SsccTableClientUtils.java
@@ -166,7 +166,7 @@ public class SsccTableClientUtils {
 
     private static HBaseAdmin admin;
 
-    private static void genTransId() {
+    private static void genTransId() throws IOException {
         // System.out.println("gen  ||  " + Thread.currentThread().getName() +
         // "   ||   " + transMap);
 

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/TrxTransactionState.java.tmpl
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/TrxTransactionState.java.tmpl
@@ -83,6 +83,7 @@ import org.apache.hadoop.hbase.regionserver.wal.WALEdit;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.VersionInfo;
+import org.apache.hadoop.hbase.util.ByteArrayKey;
 import org.apache.hadoop.io.DataInputBuffer;
 #ifdef CDH5.7 APACHE1.2
 import org.apache.hadoop.hbase.regionserver.MultiVersionConcurrencyControl.WriteEntry;

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/util/ByteArrayKey.java
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/util/ByteArrayKey.java
@@ -1,0 +1,55 @@
+/**
+ * * @@@ START COPYRIGHT @@@
+ * *
+ * * Licensed to the Apache Software Foundation (ASF) under one
+ * * or more contributor license agreements.  See the NOTICE file
+ * * distributed with this work for additional information
+ * * regarding copyright ownership.  The ASF licenses this file
+ * * to you under the Apache License, Version 2.0 (the
+ * * "License"); you may not use this file except in compliance
+ * * with the License.  You may obtain a copy of the License at
+ * *
+ * *   http://www.apache.org/licenses/LICENSE-2.0
+ * *
+ * * Unless required by applicable law or agreed to in writing,
+ * * software distributed under the License is distributed on an
+ * * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * * KIND, either express or implied.  See the License for the
+ * * specific language governing permissions and limitations
+ * * under the License.
+ * *
+ * * @@@ END COPYRIGHT @@@
+ * **/
+
+package org.apache.hadoop.hbase.util;
+
+import org.apache.hadoop.hbase.util.Bytes;
+
+public class ByteArrayKey implements Comparable<ByteArrayKey>{
+   byte[] bytes;
+
+   public ByteArrayKey(byte[] bytes) {
+      super();
+      this.bytes = bytes;
+   }
+
+   @Override
+   public int compareTo(ByteArrayKey that) {
+      return Bytes.compareTo(
+      this.bytes, that.bytes);
+   }
+
+   @Override
+   public int hashCode() {
+      return Bytes.hashCode(bytes);
+   }
+
+   @Override
+   public boolean equals(Object obj) {
+      if (obj instanceof ByteArrayKey) {
+         return Bytes.equals(this.bytes,((ByteArrayKey)obj).bytes);
+      }
+      return false;
+   }
+}
+

--- a/core/sqf/src/seatrans/tm/hbasetmlib2/testrun.cpp
+++ b/core/sqf/src/seatrans/tm/hbasetmlib2/testrun.cpp
@@ -139,7 +139,7 @@ int main () {
    printf("After lp_myHbaseTM->doCommit(transactionId = %ld), retcode = %d \n", lv_txid, lv_retcode);
 
    ctrlPtNum = lp_myHbaseTM->addControlPoint();
-   printf("After lp_myHbaseTM->addControlPoint, transactionId = %ld \n", lv_txid);
+   printf("After lp_myHbaseTM->addControlPoint, (transactionId = %ld),  ctrlPtNum = %ld \n", lv_txid, ctrlPtNum);
 
    delete lp_myHbaseTM;
    

--- a/core/sql/executor/ExHbaseAccess.cpp
+++ b/core/sql/executor/ExHbaseAccess.cpp
@@ -3314,6 +3314,16 @@ void ExHbaseAccessTcb::getErrorCount( ExpHbaseInterface * ehi,Int64 & totalExcep
   retcode = ehi->incrCounter(tabName, rowId, (const char*)"ERRORS",(const char*)"ERROR_COUNT",0, totalExceptionCount);
 }
 
+int ExHbaseAccessTcb::compareRowIds()
+{
+   UInt32 rowIdLen = hbaseAccessTdb().getRowIDLen();
+   if (beginRowId_.size() == 0)
+      return 0;
+   if (endRowId_.size() == 0)
+      return 0;
+   return endRowId_.compare(0, rowIdLen, beginRowId_);
+}
+
 static const char * const BatchSizeEnvvar = 
   getenv("SQL_CANCEL_BATCH_SIZE");
 static const Lng32 BatchSize = (BatchSizeEnvvar &&

--- a/core/sql/executor/ExHbaseAccess.h
+++ b/core/sql/executor/ExHbaseAccess.h
@@ -180,6 +180,8 @@ public:
                                char *& loggingFileName);
   static short setupError(NAHeap *heap, ex_queue_pair &qparent, Lng32 retcode, const char * str, const char * str2 = NULL);
 
+  int compareRowIds();
+
 protected:
 
   /////////////////////////////////////////////////////

--- a/core/sql/executor/ExHbaseIUD.cpp
+++ b/core/sql/executor/ExHbaseIUD.cpp
@@ -2905,6 +2905,11 @@ ExWorkProcRetcode ExHbaseUMDtrafSubsetTaskTcb::work(short &rc)
 
 	case SCAN_OPEN:
 	  {
+            // Bypass scan when beginRowId_ is less than endRowId_
+            if (tcb_->compareRowIds() < 0) {
+               step_ = DONE;
+               break;
+            }
             // Pre-fetch is disabled because it interfers with
             // Delete operations
 	    retcode = tcb_->ehi_->scanOpen(tcb_->table_, 
@@ -3323,6 +3328,11 @@ ExWorkProcRetcode ExHbaseUMDnativeSubsetTaskTcb::work(short &rc)
 	    // this row cannot be deleted.
 	    // But if there is a scan expr, then we need to also retrieve the columns used
 	    // in the pred. Add those.
+            // Bypass scan when beginRowId_ is less than endRowId_
+            if (tcb_->compareRowIds() < 0) {
+               step_ = DONE;
+               break;
+            }
 	    LIST(HbaseStr) columns(tcb_->getHeap());
 	    if (tcb_->hbaseAccessTdb().getAccessType() == ComTdbHbaseAccess::DELETE_)
 	      {

--- a/core/sql/executor/ExHbaseSelect.cpp
+++ b/core/sql/executor/ExHbaseSelect.cpp
@@ -70,6 +70,11 @@ ExWorkProcRetcode ExHbaseScanTaskTcb::work(short &rc)
 
 	    tcb_->table_.val = tcb_->hbaseAccessTdb().getTableName();
 	    tcb_->table_.len = strlen(tcb_->hbaseAccessTdb().getTableName());
+            // Bypass scan when beginRowId_ is less than endRowId_
+            if (tcb_->compareRowIds() < 0) {
+               step_ = DONE;
+               break;
+            }
 
 	    if (tcb_->setupHbaseFilterPreds())
 	      {
@@ -255,7 +260,11 @@ ExWorkProcRetcode ExHbaseScanRowwiseTaskTcb::work(short &rc)
 	  {
 	    tcb_->table_.val = tcb_->hbaseAccessTdb().getTableName();
 	    tcb_->table_.len = strlen(tcb_->hbaseAccessTdb().getTableName());
-
+            // Bypass scan when beginRowId_ is less than endRowId_
+            if (tcb_->compareRowIds() < 0) {
+               step_ = DONE;
+               break;
+            }
 	    if (tcb_->setupHbaseFilterPreds())
 	      {
 		step_ = HANDLE_ERROR;
@@ -473,7 +482,11 @@ ExWorkProcRetcode ExHbaseScanSQTaskTcb::work(short &rc)
 	  {
 	    tcb_->table_.val = tcb_->hbaseAccessTdb().getTableName();
 	    tcb_->table_.len = strlen(tcb_->hbaseAccessTdb().getTableName());
-
+            // Bypass scan when beginRowId_ is less than endRowId_
+            if (tcb_->compareRowIds() < 0) {
+               step_ = DONE;
+               break;
+            }
 	    if (tcb_->setupHbaseFilterPreds())
 	      {
 		step_ = HANDLE_ERROR;

--- a/core/sql/qmscommon/QRLogger.cpp
+++ b/core/sql/qmscommon/QRLogger.cpp
@@ -182,9 +182,7 @@ NABoolean QRLogger::initLog4cxx(const char* configFileName)
 
   // gets the top ancestor process name that will be used to name the file appender log
   char logFileSuffix [100]="";
-  NABoolean singleSqlLogFile = TRUE;
-  if (getenv("TRAF_MULTIPLE_SQL_LOG_FILE")) 
-     singleSqlLogFile = FALSE; 
+  static bool singleSqlLogFile = (getenv("TRAF_MULTIPLE_SQL_LOG_FILE") == NULL);
   switch (module_)
   {
     case QRL_NONE:
@@ -592,7 +590,7 @@ void QRLogger::log(const std::string &cat,
 NABoolean QRLogger::initLog4cxx(ExecutableModule module)
 {
    NABoolean retcode;
-   static bool singleSqlLogFile = (getenv("TRAF_MULTIPLE_SQL_LOG_FILE") != NULL);
+   static bool singleSqlLogFile = (getenv("TRAF_MULTIPLE_SQL_LOG_FILE") == NULL);
    QRLogger::instance().setModule(module);
    if (singleSqlLogFile)
       retcode =  QRLogger::instance().initLog4cxx("log4cxx.trafodion.sql.config");


### PR DESCRIPTION
Improvements in DTM register region concept.

1. TransactionalTableClient is retired. ttable in RMInterface is now HTable. SSCC transaction type might need some rework.
2. registerTransaction method is now refactored to reduce pathlength.
3. All the regions during scan are registered upfront at the time of scan instead of trying to figure out if new regions are accessed while the rows are processed.
4. Removed unnecessary synchronization of RMInterface methods.
5. Changed idTm to be one per process.
6. Changes in SQL layer to bypass the java layer when start row id is less than the end row id.
7. RegionList is now collected per table on the client side using HashMap instead of Set. This
allows client to register to TM the region only if it not already registered within a transaction.

Added to code to enable java debugging of TM process via the variable JVM_DEBUG_PORT in ms.env.
If JVM_DEBUG_PORT=xx000, then the debug port is set to xx * 1000 + <tm_pid> % 1000.