### PR TITLE
[TRAFODION-3308] Improve error reporting when a process cannot be started

### DIFF
--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -528,7 +528,7 @@
 2009 40000 99999 ADVANCED MAJOR DBADMIN The user transaction must be rolled back (or committed, if that makes sense in the application) before Compiler can be restarted and proceed.
 2010 ZZZZZ 99999 ADVANCED MAJOR DBADMIN Internal IPC error.
 2011 ZZZZZ 99999 ADVANCED MAJOR DBADMIN Server process could not be created - Operating system error $0~int0 while resolving program file name $1~string0.
-2012 ZZZZZ 99999 ADVANCED MAJOR DBADMIN Server process $0~string0 could not be created on $1~string1 - Operating system error $2~int0, TPCError = $3~int1, error detail = $4~int2.  (See variants of Seabed procedure msg_mon_start_process for details).
+2012 ZZZZZ 99999 ADVANCED MAJOR DBADMIN Server process $0~string0 could not be created on $1~string1 - Operating system error $2~int0, TPCError = $3~int1, error detail = $4~int2. $2~string2
 2013 ZZZZZ 99999 ADVANCED MAJOR DBADMIN Server process $0~string0 could not be created on $1~string1 - Operating system error $2~int0.
 2014 ZZZZZ 99999 ADVANCED MAJOR DBADMIN Server process $0~string0 could not be created on $1~string1 - Operating system error $2~int0 on swap file.
 2015 ZZZZZ 99999 ADVANCED CRTCL DIALOUT Server process $0~string0 could not be created on $1~string1 - CPU is unavailable (Operating system error $2~int0).

--- a/core/sql/cli/ExSqlComp.cpp
+++ b/core/sql/cli/ExSqlComp.cpp
@@ -172,7 +172,8 @@ ExSqlComp::ReturnStatus ExSqlComp::createServer()
   //  
   if (ret == ERROR)
   {
-	error(arkcmpErrorServer);
+	if ((!diagArea_->contains(-2013)) && (!diagArea_->contains(-2012))) // avoid generating redundant error
+	  error(arkcmpErrorServer);
 	if (getenv("DEBUG_SERVER"))
 	  MessageBox(NULL, "ExSqlComp:createServer", "error ", MB_OK|MB_ICONINFORMATION);
   }
@@ -911,7 +912,7 @@ ExSqlComp::ExSqlComp(void* ex_environment,
                      short version,
                      char *nodeName ,
                      IpcEnvironment *env):
-isShared_(FALSE), lastContext_(NULL), resendingControls_(FALSE)
+isShared_(FALSE), lastContext_(NULL), resendingControls_(FALSE), nodeName_(NULL)
 {
   h_ = h;
 
@@ -930,17 +931,11 @@ isShared_(FALSE), lastContext_(NULL), resendingControls_(FALSE)
   breakReceived_ = FALSE;
   currentISPRequest_ = 0;
   connectionType_ = CmpMessageConnectionType::DMLDDL;
-  nodeName_ = new (h_) char[9];
   if (nodeName)
    {
+     nodeName_ = new (h_) char[strlen(nodeName)+1];
      strcpy(nodeName_,nodeName);
    }
-  else
-    {
-      nodeName_[0] = '\\';
-      if (ComRtGetOSClusterName(&nodeName_[1], 8, NULL) <= 0)
-	nodeName_ = nodeName;
-    }
   server_ = 0;
 
   diagArea_ = ComDiagsArea::allocate(h_);  

--- a/core/sql/comexe/FragDir.cpp
+++ b/core/sql/comexe/FragDir.cpp
@@ -41,6 +41,8 @@
 #include "ComPackDefs.h"
 #include "PartInputDataDesc.h"
 #include "Ipc.h"
+#include "trafconf/trafconfig.h"
+static const int nodeNameLen = TC_PROCESSOR_NAME_MAX;//defined in trafconf/trafconfig.h
 
 ExFragDir::ExFragDir(Lng32 entries, Space *space,
             NABoolean multiFragments, NABoolean fragmentQuotas,
@@ -150,11 +152,13 @@ const char * ExEspNodeMap::getClusterName(Lng32 instance) const
 
 void ExEspNodeMap::setEntry(Lng32 instance,
 			    const char *clusterName,
-			    Lng32 nodeNumber)
+			    Lng32 nodeNumber,
+			    Space *space)
 {
   if (map_ && entries_ > instance)
     {
-      map_[instance].clusterName_ = clusterName;
+      map_[instance].clusterName_ = space->allocateMemory(nodeNameLen);
+      strcpy(map_[instance].clusterName_, clusterName);
       map_[instance].nodeNumber_ = nodeNumber;
     }
 }

--- a/core/sql/comexe/FragDir.h
+++ b/core/sql/comexe/FragDir.h
@@ -137,7 +137,7 @@ public:
   // Mutator methods (for code generator only)
   void setMapArray(Lng32 entries, ExEspNodeMapEntry *me) 
                                       { map_ = me; entries_ = entries; }
-  void setEntry(Lng32 instance, const char *clusterName, Lng32 nodeNumber);
+  void setEntry(Lng32 instance, const char *clusterName, Lng32 nodeNumber, Space *space);
 
   // pack and unpack
   Long pack(void * space);

--- a/core/sql/common/Ipc.cpp
+++ b/core/sql/common/Ipc.cpp
@@ -4959,9 +4959,9 @@ void IpcServerClass::freeServerProcess(IpcServer *s)
   NADELETE(s, IpcServer, environment_->getHeap());
 }
 
-char *IpcServerClass::getProcessName(const char *nodeName, short nodeNameLen, short cpuNum, char *processName)
+char *IpcServerClass::getProcessName(short cpuNum, char *processName)
 {
-  return getServerProcessName(serverType_, nodeName, nodeNameLen, cpuNum, processName);
+  return getServerProcessName(serverType_, cpuNum, processName);
 }
 // -----------------------------------------------------------------------
 // methods for class IpcEnvironment
@@ -5607,7 +5607,7 @@ void * operator new[](size_t size, IpcEnvironment *env)
   return env->getHeap()->allocateMemory(size);
 }
 
-char *getServerProcessName(IpcServerType serverType, const char *nodeName, short nodeNameLen, 
+char *getServerProcessName(IpcServerType serverType,
                            short cpuNum, char *processName, short *envType)
 {
   const char *processPrefix = NULL;

--- a/core/sql/common/Ipc.h
+++ b/core/sql/common/Ipc.h
@@ -2806,9 +2806,9 @@ private:
   // put server cpu location in the given string. e.g. \EJR0101 cpu 1
   void getCpuLocationString(char *location);
 
-  // the node name (Expand) on which the process is started or NULL for local
-  // node, note that this name must NOT contain the leading backslash
-  const char  * nodeName_;
+  // the node name on which the process is started (determined
+  // only if needed at process start time as a function of actualCpuNum_)
+  char  * nodeName_;
 
   // The program file name of the server; if partially qualified it gets
   // expanded with $SYSTEM.SYSTEM as the default. A DEFINE name could also
@@ -2816,8 +2816,13 @@ private:
   // name unspecified or has the same system as "nodeName_".
   const char  * className_;
 
-  // the requested CPU number (on node "nodeName_")
+  // the requested Trafodion node number to start the process on
+  // (for historical reasons this is called a CpuNum); IPC_CPU_DONT_CARE
+  // if we don't care which node 
   IpcCpuNum   cpuNum_;
+
+  // the actual Trafodion node where the process was started
+  IpcCpuNum   actualCpuNum_;
 
   // remember if node-down caused server to be created on a CPU 
   // different from the requested one. (tbd - could the IpcConnection's
@@ -2915,7 +2920,7 @@ public:
 
   inline IpcServerType getServerType() { return serverType_;}
 
-  char *getProcessName(const char *nodeName, short nodeNameLen, short cpuNum, char *processName);
+  char *getProcessName(short cpuNum, char *processName);
   NABoolean parallelOpens() { return parallelOpens_; }
   NowaitedEspServer nowaitedEspServer_;
 private:
@@ -3418,7 +3423,7 @@ void * operator new[](size_t size, IpcEnvironment *env);
 
 void operator delete(void *p, IpcEnvironment *env);
 
-char *getServerProcessName(IpcServerType serverType, const char *nodeName, short nodeNameLen, 
+char *getServerProcessName(IpcServerType serverType,
                            short cpuNum, char *processName, short *envType = NULL);
 
 #endif /* IPC_H */

--- a/core/sql/executor/ExCancel.cpp
+++ b/core/sql/executor/ExCancel.cpp
@@ -512,8 +512,7 @@ void ExCancelTcb::reportError(ComDiagsArea *da, bool addCondition,
         char processName[50];
         ContextCli *context = getGlobals()->castToExExeStmtGlobals()->
                 castToExMasterStmtGlobals()->getStatement()->getContext();
-        context->getSsmpManager()->getServerClass()->getProcessName(nodeName, (short)
-                           str_len(nodeName), cpu, processName);
+        context->getSsmpManager()->getServerClass()->getProcessName(cpu, processName);
         *diagsArea << DgString0(processName);
       }
 

--- a/core/sql/executor/ExExeUtil.h
+++ b/core/sql/executor/ExExeUtil.h
@@ -207,14 +207,6 @@ class ExExeUtilTcb : public ex_tcb
                           char * &gluedQuery,
                           Lng32 &gluedQuerySize);
 
-  short extractObjectParts(
-                           char * objectName,
-                           char * sys,
-                           char * &cat,
-                           char * &sch,
-                           char * &tab,
-                           char * ansiNameBuf);
-
   // extract parts from 'objectName' and fixes up delimited names.
   Lng32 extractParts
   (char * objectName,

--- a/core/sql/executor/ExExeUtilCommon.cpp
+++ b/core/sql/executor/ExExeUtilCommon.cpp
@@ -286,41 +286,6 @@ short ExExeUtilTcb::work()
   return -1;
 }
 
-short ExExeUtilTcb::extractObjectParts(
-     char * objectName,
-     char * sys,
-     char * &cat,
-     char * &sch,
-     char * &tab,
-     char * ansiNameBuf)
-{
-  Lng32 error = 0;
-
-  error = ComRtGetOSClusterName(sys, 10, NULL);
-  if (error <= 0)
-    {
-      return -1;
-    }
-
-  char * parts[3];
-  Lng32 numParts;
-  if (LateNameInfo::extractParts(objectName,
-				 ansiNameBuf,
-				 numParts,
-				 parts,
-				 FALSE) ||
-      (numParts != 3))
-    {
-      return -1;
-    }
-
-  cat = parts[0];
-  sch = parts[1];
-  tab = parts[2];
-
-  return 0;
-}
-
 NABoolean ExExeUtilTcb::isUpQueueFull(short size)
 {
   if ((qparent_.up->getSize() - qparent_.up->getLength()) < size)

--- a/core/sql/executor/ExUdrServer.cpp
+++ b/core/sql/executor/ExUdrServer.cpp
@@ -272,17 +272,6 @@ ExUdrServer::ExUdrServerStatus ExUdrServer::start(ComDiagsArea **diags,
 #endif
     UdrDebug1("  Using a nowait depth of %d", nowaitDepth);
 
-    // If everything is successful, nodeName is not deallocated
-    // because allocateServerProcess() creates IpcGuardianServer
-    // instance which stores nodeName pointer.
-    char *nodeName = new (myIpcHeap()) char[9];
-    nodeName[0] = '\\';
-    if (ComRtGetOSClusterName(&nodeName[1], 8, NULL) <= 0)
-    {
-      myIpcHeap()->deallocateMemory(nodeName);
-      nodeName = NULL;
-    }
-
     NABoolean waitedCreation = TRUE;
     // co-locate the tdm_udrserv with the executor process (master or ESP)
     // This is done for a couple of reasons: One is that since the ESPs
@@ -298,7 +287,7 @@ ExUdrServer::ExUdrServerStatus ExUdrServer::start(ComDiagsArea **diags,
     ipcServer_ =
       udrServerClass_->allocateServerProcess(diags,
                                              diagsHeap,
-                                             nodeName,
+                                             NULL,
                                              collocatedCPU,
                                              IPC_PRIORITY_DONT_CARE,
                                              1,   // espLevel (not relevant for UDR servers) 
@@ -957,14 +946,6 @@ ExUdrServerManager::ExUdrServerManager(IpcEnvironment* env,
     , traceFile_(NULL)
 #endif
 {
-  char *nodeName = new (myIpcHeap()) char[9];
-  nodeName[0] = '\\';
-  if (ComRtGetOSClusterName(&nodeName[1], 8, NULL) <= 0)
-  {
-    myIpcHeap()->deallocateMemory(nodeName);
-    nodeName = NULL;
-  }
-
   //
   // Create the UDR server class. This does not actually
   // start any processes. Use allocateServerProcess() to

--- a/core/sql/runtimestats/ssmpipc.cpp
+++ b/core/sql/runtimestats/ssmpipc.cpp
@@ -81,8 +81,7 @@ IpcServer *ExSsmpManager::getSsmpServer(NAHeap *heap, char *nodeName, short cpuN
 
    char *tmpProcessName;
 
-   tmpProcessName = ssmpServerClass_->getProcessName(nodeName,
-             (short) str_len(nodeName), cpuNum, ssmpProcessName);
+   tmpProcessName = ssmpServerClass_->getProcessName(cpuNum, ssmpProcessName);
    ex_assert(tmpProcessName != NULL, "ProcessName can't be null");
 
    processNameLen = str_len(tmpProcessName);
@@ -146,8 +145,7 @@ void ExSsmpManager::removeSsmpServer(char *nodeName, short cpuNum)
    Int32 processNameLen = 0;
 
    char *tmpProcessName;
-   tmpProcessName = ssmpServerClass_->getProcessName(nodeName,
-             (short) str_len(nodeName), cpuNum, ssmpProcessName);
+   tmpProcessName = ssmpServerClass_->getProcessName(cpuNum, ssmpProcessName);
    ex_assert(tmpProcessName != NULL, "ProcessName can't be null");
 
    processNameLen = str_len(tmpProcessName);
@@ -432,8 +430,7 @@ ULng32 SsmpGlobals::deAllocateServer(char *nodeName, short nodeNameLen,  short c
   serverId.nodeName_[0] = '\0';
   serverId.cpuNum_ = cpuNum;
   char *tmpProcessName;
-  tmpProcessName = sscpServerClass_->getProcessName(serverId.nodeName_,
-            (short) str_len(serverId.nodeName_), cpuNum, sscpProcessName);
+  tmpProcessName = sscpServerClass_->getProcessName(cpuNum, sscpProcessName);
   ex_assert(tmpProcessName != NULL, "ProcessName can't be null");
 
   sscps_->position(tmpProcessName, str_len(tmpProcessName));
@@ -500,8 +497,7 @@ void SsmpGlobals::allocateServerOnNextRequest(char *nodeName,
   // we will pretend that we got a NodeDown and NodeUp message and
   // issue an EMS event.
   char *tmpProcessName;
-  tmpProcessName = sscpServerClass_->getProcessName(serverId.nodeName_,
-            (short) str_len(serverId.nodeName_), cpuNum, sscpProcessName);
+  tmpProcessName = sscpServerClass_->getProcessName(cpuNum, sscpProcessName);
   ex_assert(tmpProcessName != NULL, "ProcessName can't be null");
 
   sscps_->position(tmpProcessName, str_len(tmpProcessName));

--- a/docs/messages_guide/src/asciidoc/_chapters/compiler_msgs.adoc
+++ b/docs/messages_guide/src/asciidoc/_chapters/compiler_msgs.adoc
@@ -79,36 +79,44 @@ correct the problem.
 == SQL 2012
 
 ```
-Server process <name> could not be created - error <number> <number-1>, TPCError = <number-2>, error detail = <text>.
+Server process <name> could not be created on <node> - Operating system error <OSerror>, TPCError = <Msgerror>, error detail = <detail>. <reason>
 ```
 
 Where <name> is the name of the server process.
 
-Where <number-1> is the error number.
+Where <node> is the node where {project-name} attempted to create the process.
 
-Where <number-2> is the TPCError.
+Where <OSerror> is the error number returned by the {project-name} monitor layer.
 
-Where <text> is the error message text.
+Where <Msgerror> is the error number returned by the {project-name} message layer.
+
+Where <detail> is additional error information from the message layer.
+
+Where <reason> is text that interprets the error information.
 
 *Cause:* {project-name} was unable to create server
 process <name> because of the process control procedure error <number>
-it received. More information appears in detail <text>.
+it received on the program file. More information appears in <reason>.
 
 *Effect:* The operation fails.
 
-*Recovery:* Use the process control procedure error to diagnose and correct the problem.
+*Recovery:* Use the error information to diagnose and correct the problem. For example, if the <reason> is "Could not access executable file", it may
+be that there is a file system problem on the executable file or the directory it resides in. Execute permission may have
+been removed, or the file itself may no longer be there.
 
 <<<
 [[SQL-2013]]
 == SQL 2013
 
 ```
-Server process <name> could not be created - error <number> on program file.
+Server process <name> could not be created on <node> - Operating system error <OSerror>.
 ```
 
 Where <name> is the name of the server process.
 
-Where <number> is the error number.
+Where <node> is the node where {project-name} attempted to create the process.
+
+Where <OSerror> is the error number returned by the {project-name} monitor layer.
 
 *Cause:* {project-name} was unable to create server
 process <name> because of the process control procedure error <number>

--- a/docs/messages_guide/src/asciidoc/_chapters/sqlstate.adoc
+++ b/docs/messages_guide/src/asciidoc/_chapters/sqlstate.adoc
@@ -216,8 +216,8 @@ numbers) and error messages (negative SQLCODE numbers).
 | 01609    | 2009    | The user transaction must be rolled back (or committed, if that makes sense in the application) before MXCMP can be restarted and proceed.
 | 0160A    | 2010    | Internal IPC error.
 | 0160B    | 2011    | Unable to create server process.  error <num> while resolving program file name <name>.
-| 0160C    | 2012    | Unable to create server process <name>.  error <num>, TPC error = <num>, error detail = <num>. (See  procedure PROCESS_LAUNCH_ for details).
-| 0160D    | 2013    | Unable to create server process <name>.  error <num> on program file.
+| 0160C    | 2012    | Server process <name> could not be created on <node> - Operating system error <OSerror>, TPCError = <Msgerror>, error detail = <detail>. <reason>
+| 0160D    | 2013    | Server process <name> could not be created on <node> - Operating system error <OSerror>.
 | 0160E    | 2014    | Unable to create server process <name>.  error <num> on swap file.
 | 0160F    | 2015    | Unable to create server process <name>. CPU is unavailable ( error <num>).
 | 0160G    | 2016    | Server process <name> was started but had undefined externals.
@@ -1663,8 +1663,8 @@ Suggestion: a) Inspect the CQS in effect; or b) Raise the optimization level to 
 | X0208    | -2008   | Internal error: out of virtual memory.
 | X020A    | -2010   | Internal IPC error.
 | X020B    | -2011   | Unable to create server process. Error <num> while resolving program file name <name>.
-| X020C    | -2012   | Unable to create server process <name>. Error <num>, TPC Error = <num>, error detail = <text>. (See  procedure PROCESS_LAUNCH_ for details).
-| X020D    | -2013   | Unable to create server process <name>.  error <num> on program file.
+| X020C    | -2012   | Server process <name> could not be created on <node> - Operating system error <OSerror>, TPCError = <Msgerror>, error detail = <detail>. <reason>
+| X020D    | -2013   | Server process <name> could not be created on <node> - Operating system error <OSerror>.
 | X020E    | -2014   | Unable to create server process <name>.  error <num> on swap file.
 | X020F    | -2015   | Unable to create server process <name>. CPU is unavailable ( error <num>).
 | X020G    | -2016   | Server process <name> was started but had undefined externals.


### PR DESCRIPTION
This pull request contains improvements to error reporting when a process server cannot be started. The following changes are made:

1. Logic in the compiler (optimizer/NodeMap.cpp) to compute node names has been corrected. Thanks to @sandhyasun for this change.
2. The correct node name is now reported in error messages 2012 and 2013 (common/IpcGuardian.cpp). Formerly, a hard-coded value of "NSK" was reported.
3. Redundant 2013 and 2002 error messages are no longer generated (common/IpcGuardian.cpp and cli/ExSqlComp.cpp).
4. Interpretive text has been added to error 2012 to give a more human-understandable reason behind certain common error codes (common/IpcGuardian.cpp and bin/SqlciErrors.txt).
5. The nodeName_ member in IpcGuardianServer is now computed at run time, and only if needed (common/IpcGuardian.cpp). (This happens during error reporting only.) This is done because the compile time value may be different in the case of ESPs due to node down conditions. Former logic that put "NSK" in this field has been removed.
6. The function ComRtGetOSClusterName is an obsolete function that in predecessor products returned the cluster name. On Trafodion, it just returns the string "NSK". I removed much but not all of the logic that calls this function. This resulted in the removal of some dead code (executor/ExCancel.cpp, executor/ExExeUtilCommon.cpp).
7. The method IpcServerClass::getProcessName required the node name in predecessor products but does not in Trafodion. I removed the node name and node name length parameters from this method and associated code (common/Ipc.cpp). I was motivated to do this because the old calling code sometimes took strlen(nodeName_) to get the node name length, but due to the changes above nodeName_ is now null in some cases.
8. The Messages Guide entries for messages 2012 and 2013 has been updated.
