### PR TITLE
[TRAFODION-2311] Avoid logging error 8605 and 8609 during SQLEndTrans if no trans active

### DIFF
--- a/core/conn/odbc/src/odbc/nsksrvrcore/srvrothers.cpp
+++ b/core/conn/odbc/src/odbc/nsksrvrcore/srvrothers.cpp
@@ -3234,15 +3234,26 @@ odbc_SQLSvc_EndTransaction_sme_(
 	SRVRTRACE_ENTER(FILE_SME+5);
 
 	char stmtLabel[MAX_STMT_LABEL_LEN+1];
-	Int32 rc = SQL_SUCCESS;
 	SRVR_STMT_HDL	*pSrvrStmt = NULL;
+	bool isTransPending = (WSQL_EXEC_Xact(SQLTRANS_STATUS, 0) == 0);
+	Int32 rc = SQL_SUCCESS;
+
+	exception_->exception_nr = 0;
+	sqlWarning->_buffer = NULL;
+	sqlWarning->_length = 0;
 
 	switch (transactionOpt) {
 	case SQL_COMMIT:
-		pSrvrStmt = getSrvrStmt("STMT_COMMIT_1", FALSE);
+		if (isTransPending)
+			pSrvrStmt = getSrvrStmt("STMT_COMMIT_1", FALSE);
+		else
+			return;
 		break;
 	case SQL_ROLLBACK:
-		pSrvrStmt = getSrvrStmt("STMT_ROLLBACK_1", FALSE);
+		if (isTransPending)
+			pSrvrStmt = getSrvrStmt("STMT_ROLLBACK_1", FALSE);
+		else
+			return;
 		break;
 	default:
 		exception_->exception_nr = odbc_SQLSvc_EndTransaction_ParamError_exn_;


### PR DESCRIPTION
Frequently , during performance test runs like OE and other regression tests, following errors
are observed in master logs:

ERROR[8605] Committing a transaction which has not started.
ERROR[8609] Waited rollback performed without starting a transaction.

MXOSRVR does return success to the client for these errors but since commit/rollback is executed, the error gets logged.

Some of these can be avoided if mxosrvr implements the following ODBC standard and skips executing the commit/rollback statement.

"For drivers and data sources that support transactions, calling SQLEndTran with either SQL_COMMIT or SQL_ROLLBACK when no transaction
is active returns SQL_SUCCESS (indicating that there is no work to be committed or rolled back) and has no effect on the data source."