### PR TITLE
[TRAFODION-3314] Avoid generating redundant DDL in OSIM for unique constraints

### DIFF
--- a/core/sql/optimizer/OptimizerSimulator.cpp
+++ b/core/sql/optimizer/OptimizerSimulator.cpp
@@ -541,31 +541,43 @@ void OptimizerSimulator::dumpDDLs(const QualifiedName & qualifiedName)
                                    <<"."<< qualifiedName.getSchemaName() 
                                    << ";" << endl;
         
+        // skippingSystemGeneratedIndex is set to TRUE to avoid generating redundant
+        // DDL for system-generated indexes
+        NABoolean skippingSystemGeneratedIndex = FALSE;
         outQueue->position();//rewind
         for (int i = 0; i < outQueue->numEntries(); i++) {
             OutputInfo * vi = (OutputInfo*)outQueue->getNext();
             char * ptr = vi->get(0);
-            // skip heading newline, and add a comment line
-            // for the DDL text upto the first trailing '\n'
-            Int32 ix = 0;
-            for(; ptr[ix]=='\n'; ix++);
-            if( strstr(ptr, "CREATE TABLE") ||
-                strstr(ptr, "CREATE INDEX") ||
-                strstr(ptr, "CREATE UNIQUE INDEX") ||
-                strstr(ptr, "ALTER TABLE")  )
+            if (strcmp(ptr,"\n-- The following index is a system created index --") == 0)
+              skippingSystemGeneratedIndex = TRUE;
 
+            if (!skippingSystemGeneratedIndex)
             {
-              (*createTable) << "--";
-              char* x = ptr+ix;
-              while ( (*x) && *x != '\n' ) {
-                (*createTable) << *x;
-                x++;
-              } 
-              (*createTable) << endl;
+                // skip heading newline, and add a comment line
+                // for the DDL text upto the first trailing '\n'
+                Int32 ix = 0;
+                for(; ptr[ix]=='\n'; ix++);
+                if( strstr(ptr, "CREATE TABLE") ||
+                    strstr(ptr, "CREATE INDEX") ||
+                    strstr(ptr, "CREATE UNIQUE INDEX") ||
+                    strstr(ptr, "ALTER TABLE")  )
+
+                {
+                  (*createTable) << "--";
+                  char* x = ptr+ix;
+                  while ( (*x) && *x != '\n' ) {
+                    (*createTable) << *x;
+                    x++;
+                  } 
+                  (*createTable) << endl;
+                }
+
+                //output ddl  
+                (*createTable) << ptr << endl;
             }
 
-            //output ddl    
-            (*createTable) << ptr << endl;
+            if (skippingSystemGeneratedIndex && (strcmp(ptr,";") == 0)) // at end of DDL to be skipped?
+              skippingSystemGeneratedIndex = FALSE;
         }
     }
 }


### PR DESCRIPTION
The problem: When a table has a unique constraint, OSIM generates both the ALTER TABLE statement to create the constraint and the CREATE INDEX statement for the system-generated index into CREATE_TABLES_DDL.txt. When we then do OSIM LOAD, the CREATE INDEX is executed, then the ALTER TABLE. The ALTER TABLE fails because the index already exists.

The fix: Don't write the CREATE INDEX to the CREATE_TABLES_DDL.txt file.