### PR TITLE
[TRAFODION-3315] Add Hive exception info to OSIM Hive error message

### DIFF
--- a/core/sql/optimizer/OptimizerSimulator.cpp
+++ b/core/sql/optimizer/OptimizerSimulator.cpp
@@ -1542,7 +1542,13 @@ NABoolean OptimizerSimulator::massageTableUID(OsimHistogramEntry* entry, NAHashD
 void OptimizerSimulator::execHiveSQL(const char* hiveSQL)
 {
     if (HiveClient_JNI::executeHiveSQL(hiveSQL) != HVC_OK)
-      raiseOsimException("Error running hive SQL.");
+    {
+        NAString error("Error running hive SQL. ");
+        const char * jniErrorStr = GetCliGlobals()->getJniErrorStr();
+        if (jniErrorStr)
+          error += jniErrorStr;
+        raiseOsimException(error.data());
+    }
 }
 
 short OptimizerSimulator::loadHistogramsTable(NAString* modifiedPath, QualifiedName * qualifiedName, unsigned int bufLen, NABoolean isHive)


### PR DESCRIPTION
When a Hive exception occurs in OSIM, OSIM puts out the rather unhelpful error message, "Error running Hive SQL." There is no clue given as to what the Hive difficulty is.

This pull request adds the Hive exception information to this message.