### PR TITLE
fix TRAFODION-3317

### DIFF
--- a/core/conn/odb/src/odb.c
+++ b/core/conn/odb/src/odb.c
@@ -5474,6 +5474,7 @@ static void etabadd(char type, char *run, int id)
             }
             do {
                 if ( fl ) {                         /* input file with list of tables */
+                    etabnew(-1);
                     etab[no] = edef;
                     if ( etab[no].seqp ) {          /* :seq option at command line level: set global sequence */
                         f2 |= 0002 ;                /* switch global sequence flag on */


### PR DESCRIPTION
**root cause:**
odb create a 'etab' for each table to be extracted,  'etab' is execution table and the preallocated chunk is 8. When the number of the list tables bigger than 8,  odb will write to unallocated memory.
**solution:**
try to enlarge 'etab' array when trying to create a 'etab' for a table.