### PR TITLE
[TRAFODION-3323] Remove AppUnicodeType=utf16 from Client Install Guide

### DIFF
--- a/docs/client_install/src/asciidoc/_chapters/odb.adoc
+++ b/docs/client_install/src/asciidoc/_chapters/odb.adoc
@@ -123,7 +123,6 @@ $ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ODBCHOME/lib
 
 ```
 [ODBC]
-AppUnicodeType=utf16
 
 [<DATA_SOURCE_NAME>]
 Description = DSN Description
@@ -150,7 +149,6 @@ UsageCount = 1
 $ cat odbc.ini
 
 [ODBC]
-AppUnicodeType=utf16
 
 [traf]
 Description = traf DSN 


### PR DESCRIPTION
This change removes the line "AppUnicodeType=utf16" from the odbc.ini examples used for the odb utility with the Unix ODBC driver. It is no longer needed, and indeed odb no longer works correctly if this line is present.