### PR TITLE
[TRAFODION-3325] Enable index access for non-VEG equality join predicates

### DIFF
--- a/core/sql/optimizer/opt.cpp
+++ b/core/sql/optimizer/opt.cpp
@@ -6266,9 +6266,12 @@ void OptDebug::showEstLogProp( const EstLogPropSharedPtr& estLogProp,
 
     ColStatsSharedPtr colStats = stats[i]->getColStats();
 
-    out << prefix << "Table Column: "
-        << colStats->getStatColumns()[0]->getFullColRefNameAsAnsiString().data()
-        << endl;
+    out << prefix << "Table Column: ";
+    if (colStats->getStatColumns().entries() > 0)
+      out << colStats->getStatColumns()[0]->getFullColRefNameAsAnsiString().data();
+    else
+      out << "(None)";
+    out << endl;
 
     if (colStats->isFakeHistogram())
       out << prefix << "*** FAKE HISTOGRAM ***" << endl;

--- a/core/sql/sqlcomp/DefaultConstants.h
+++ b/core/sql/sqlcomp/DefaultConstants.h
@@ -1730,6 +1730,7 @@ enum DefaultConstants
   COMP_BOOL_191,
   COMP_BOOL_192,
   COMP_BOOL_193,
+  COMP_BOOL_194,  // Can be used to turn off fix to JIRA Trafodion 3325
   COMP_BOOL_196,
   COMP_BOOL_197,
   COMP_BOOL_198,

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -671,6 +671,7 @@ SDDkwd__(CAT_ENABLE_QUERY_INVALIDATION, "ON"),
   DDkwd__(COMP_BOOL_191,      "OFF"), // Temp for UDF metadata switch
   DDkwd__(COMP_BOOL_192,      "OFF"),
   DDkwd__(COMP_BOOL_193,      "OFF"),
+  DDkwd__(COMP_BOOL_194,      "ON"),  // If "OFF", turns off JIRA Trafodion 3325 fix
   DDkwd__(COMP_BOOL_196,      "OFF"),
   DDkwd__(COMP_BOOL_197,      "OFF"),
   DDkwd__(COMP_BOOL_198,      "OFF"),


### PR DESCRIPTION
The problem is that sometimes join equality predicates are not converted into VEGs, and therefore do not get pushed down to their children. That prevents Scan::addIndexInfo from considering indexes when there are column references in the join predicate. That can result in missed opportunities to use efficient index plans and instead doing full table scans + hash joins.

The fix is to look for equality predicates that didn't get pushed down, and if we find one and it has a child that is covered, we create an IS NOT NULL predicate on that child and push that down. That allows Scan::addIndexInfo to notice that an index might be useful. Later, if the join is converted to a TSJ, the equality predicate will be pushed down and the Optimizer can make use of the index.

An example of a join equality predicate that is not converted to a VEG is a join predicate involving a tuple list.

I added a CQD, COMP_BOOL_194, which if set to 'OFF' turns off this fix. The default is 'ON'.

When unit testing this fix, I noticed a bug in some of the optimizer debugging code that caused a core. I fixed that too (optimizer/opt.cpp).