### PR TITLE
[TRAFODION-3325] Pass down index hints for non-VEG equality predicates

### DIFF
--- a/core/sql/optimizer/RelExpr.cpp
+++ b/core/sql/optimizer/RelExpr.cpp
@@ -811,6 +811,9 @@ RelExpr * RelExpr::copyTopNode(RelExpr *derivedNode,CollHeap* outHeap)
   if (selection_ != NULL)
     result->selection_ = selection_->copyTree(outHeap)->castToItemExpr();
 
+  // copy possible index column hints for non-VEG equality predicates
+  result->possibleIndexColumns_ = possibleIndexColumns_;
+
   // -- Triggers
   // Copy the inlining information and access sets.
   result->getInliningInfo().merge(&getInliningInfo());
@@ -1330,19 +1333,25 @@ void RelExpr::pushdownCoveredExpr(const ValueIdSet & outputExpr,
       // -----------------------------------------------------------------
       ValueIdSet referencedInputs[MAX_REL_ARITY];
       // -----------------------------------------------------------------
-      // Allocate a ValueIdSet to contain the ValueIds of the roots of
+      // Allocate an array to contain the ValueIds of the roots of
       // sub-expressions that are covered by
       // a) the Group Attributes of a child and
       // b) the new external inputs.
       // Note that the containing expression is not covered for each
       // such sub-expression.
       // -----------------------------------------------------------------
-      ValueIdSet coveredSubExprNotUsed;
+      ValueIdSet coveredSubExprNotUsed[MAX_REL_ARITY];
       // -----------------------------------------------------------------
       // Allocate an array to contain the ValueIds of predicates that
       // can be pushed down to a specific child.
       // -----------------------------------------------------------------
       ValueIdSet predPushSet[MAX_REL_ARITY];
+      // -----------------------------------------------------------------
+      // Allocate an array to contain the ValueIds of predicates from
+      // non-VEG equality predicates that might be useful hints for
+      // index selection.
+      // -----------------------------------------------------------------
+      ValueIdSet possibleIndexColumnsPushSet[MAX_REL_ARITY];
       // -----------------------------------------------------------------
       // Check which predicate factors are fully covered by a certain
       // child. Gather their ValueIds in predPushSet.
@@ -1391,8 +1400,14 @@ void RelExpr::pushdownCoveredExpr(const ValueIdSet & outputExpr,
               newExternalInputs,
               predPushSet[iter],
               referencedInputs[iter],
-              &coveredSubExprNotUsed);
-            // QSTUFF
+              &coveredSubExprNotUsed[iter]);
+            // QSTUFF            
+            ValueIdSet dummyReferencedInputs;
+            child(iter).getGroupAttr()->coverTest(possibleIndexColumns_,
+              newExternalInputs,
+              possibleIndexColumnsPushSet[iter],
+              dummyReferencedInputs,
+              &possibleIndexColumnsPushSet[iter]);            
           }
           // QSTUFF
         }
@@ -1414,7 +1429,7 @@ void RelExpr::pushdownCoveredExpr(const ValueIdSet & outputExpr,
                 emptySet,
                 predPushSet[iter],
                 referencedInputs[iter],
-                &coveredSubExprNotUsed);
+                &coveredSubExprNotUsed[iter]);
               // QSTUFF
             }
             // QSTUFF
@@ -1433,6 +1448,44 @@ void RelExpr::pushdownCoveredExpr(const ValueIdSet & outputExpr,
       // -----------------------------------------------------------------
       computeValuesReqdForPredicates(predicatesOnParent,
                                      exprToEvalOnParent);
+
+      // -----------------------------------------------------------------
+      // Check for equality predicates that could not be pushed down.
+      // This may happen if we have an equality predicate that was not
+      // transformed into a VEG predicate. 
+      //
+      // If there are column references in the equality predicate, it
+      // may prove useful to tell the leaf nodes about it, as the equality
+      // predicate might be pushed down later during a Join to TSJ 
+      // transformation. Telling the leaf nodes about it might allow the
+      // use of an index in this case (see Scan::addIndexInfo; this is
+      // called once at the beginning of optimization, before any Join
+      // to TSJ transformations have been attempted).
+      // -----------------------------------------------------------------
+      ValueId pred;
+      for (pred = predicatesOnParent.init();
+           predicatesOnParent.next(pred);
+           predicatesOnParent.advance(pred))
+        {
+          ItemExpr * ie = pred.getItemExpr();
+          if (ie->getOperatorType() == ITM_EQUAL) // non-VEG, equality predicate
+            {
+              for (iter = firstChild; iter < lastChild; iter++)
+                {
+                  for (CollIndex i = 0; i < ie->getArity(); i++)
+                    {
+                      // If the child is covered, it might contain a column reference
+                      // that is useful for index selection. Push that down.
+                      ItemExpr * ieChildi = ie->child(i);
+                      if ((CmpCommon::getDefault(COMP_BOOL_194) == DF_ON) &&
+                          (coveredSubExprNotUsed[iter].contains(ieChildi->getValueId())))
+                        {
+                          possibleIndexColumnsPushSet[iter] += ieChildi->getValueId();
+                        }
+                    }
+                } 
+            }     
+        }
 
       // -----------------------------------------------------------------
       // Perform predicate pushdown
@@ -1457,7 +1510,7 @@ void RelExpr::pushdownCoveredExpr(const ValueIdSet & outputExpr,
   						    referencedInputs[iter],
   						    predPushSet[iter],
   						    inputsNeededByPredicates,
-  						    &coveredSubExprNotUsed);
+  						    &coveredSubExprNotUsed[iter]);
 	      child(iter).getPtr()->getGroupAttr()->addCharacteristicInputs
 	                                            (inputsNeededByPredicates);
 	      ValueIdSet essChildOutputs;
@@ -1493,6 +1546,8 @@ void RelExpr::pushdownCoveredExpr(const ValueIdSet & outputExpr,
                                                        &extraHubNonEssOutputs
                                                        );
 
+            // pass down index column hints for non-VEG equality predicates
+            child(iter).getPtr()->addToPossibleIndexColumns(possibleIndexColumnsPushSet[iter]);
             };
 	} // for loop to pushdown predicates
     } // endif (NOT predicatesOnParent.isEmpty())
@@ -8706,6 +8761,9 @@ void Scan::addIndexInfo()
             }
             else
                disjuncts=preds;
+
+	    // add in index column hints from non-VEG equality predicates
+	    disjuncts += possibleIndexColumns();
 
 	    disjuncts.isCovered(
 	      getGroupAttr()->getCharacteristicInputs(),

--- a/core/sql/optimizer/RelExpr.cpp
+++ b/core/sql/optimizer/RelExpr.cpp
@@ -1462,29 +1462,31 @@ void RelExpr::pushdownCoveredExpr(const ValueIdSet & outputExpr,
       // called once at the beginning of optimization, before any Join
       // to TSJ transformations have been attempted).
       // -----------------------------------------------------------------
-      ValueId pred;
-      for (pred = predicatesOnParent.init();
-           predicatesOnParent.next(pred);
-           predicatesOnParent.advance(pred))
+      if (CmpCommon::getDefault(COMP_BOOL_194) == DF_ON)
         {
-          ItemExpr * ie = pred.getItemExpr();
-          if (ie->getOperatorType() == ITM_EQUAL) // non-VEG, equality predicate
+          ValueId pred;
+          for (pred = predicatesOnParent.init();
+               predicatesOnParent.next(pred);
+               predicatesOnParent.advance(pred))
             {
-              for (iter = firstChild; iter < lastChild; iter++)
+              ItemExpr * ie = pred.getItemExpr();
+              if (ie->getOperatorType() == ITM_EQUAL) // non-VEG, equality predicate
                 {
-                  for (CollIndex i = 0; i < ie->getArity(); i++)
+                  for (iter = firstChild; iter < lastChild; iter++)
                     {
-                      // If the child is covered, it might contain a column reference
-                      // that is useful for index selection. Push that down.
-                      ItemExpr * ieChildi = ie->child(i);
-                      if ((CmpCommon::getDefault(COMP_BOOL_194) == DF_ON) &&
-                          (coveredSubExprNotUsed[iter].contains(ieChildi->getValueId())))
+                      for (CollIndex i = 0; i < ie->getArity(); i++)
                         {
-                          possibleIndexColumnsPushSet[iter] += ieChildi->getValueId();
+                          // If the child is covered, it might contain a column reference
+                          // that is useful for index selection. Push that down.
+                          ItemExpr * ieChildi = ie->child(i);
+                          if (coveredSubExprNotUsed[iter].contains(ieChildi->getValueId()))
+                            {
+                              possibleIndexColumnsPushSet[iter] += ieChildi->getValueId();
+                            }
                         }
-                    }
-                } 
-            }     
+                    } 
+                }     
+            }
         }
 
       // -----------------------------------------------------------------

--- a/core/sql/optimizer/opt.cpp
+++ b/core/sql/optimizer/opt.cpp
@@ -6266,9 +6266,12 @@ void OptDebug::showEstLogProp( const EstLogPropSharedPtr& estLogProp,
 
     ColStatsSharedPtr colStats = stats[i]->getColStats();
 
-    out << prefix << "Table Column: "
-        << colStats->getStatColumns()[0]->getFullColRefNameAsAnsiString().data()
-        << endl;
+    out << prefix << "Table Column: ";
+    if (colStats->getStatColumns().entries() > 0)
+      out << colStats->getStatColumns()[0]->getFullColRefNameAsAnsiString().data();
+    else
+      out << "(None)";
+    out << endl;
 
     if (colStats->isFakeHistogram())
       out << prefix << "*** FAKE HISTOGRAM ***" << endl;

--- a/core/sql/sqlcomp/DefaultConstants.h
+++ b/core/sql/sqlcomp/DefaultConstants.h
@@ -1730,6 +1730,7 @@ enum DefaultConstants
   COMP_BOOL_191,
   COMP_BOOL_192,
   COMP_BOOL_193,
+  COMP_BOOL_194,  // Can be used to turn off fix to JIRA Trafodion 3325
   COMP_BOOL_196,
   COMP_BOOL_197,
   COMP_BOOL_198,

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -671,6 +671,7 @@ SDDkwd__(CAT_ENABLE_QUERY_INVALIDATION, "ON"),
   DDkwd__(COMP_BOOL_191,      "OFF"), // Temp for UDF metadata switch
   DDkwd__(COMP_BOOL_192,      "OFF"),
   DDkwd__(COMP_BOOL_193,      "OFF"),
+  DDkwd__(COMP_BOOL_194,      "ON"),  // If "OFF", turns off JIRA Trafodion 3325 fix
   DDkwd__(COMP_BOOL_196,      "OFF"),
   DDkwd__(COMP_BOOL_197,      "OFF"),
   DDkwd__(COMP_BOOL_198,      "OFF"),


### PR DESCRIPTION
The problem is that sometimes join equality predicates are not converted into VEGs, and therefore do not get pushed down to their children. That prevents Scan::addIndexInfo from considering indexes when there are column references in the join predicate. That can result in missed opportunities to use efficient index plans and instead doing full table scans + hash joins.

My first attempt at fixing this problem was to generate an IS NOT NULL predicate for the children of such equality predicates, then attempt to push those down. This didn't work well: If the column was not nullable, logic in HBaseTable.java would try to optimize it out resulting in a null filter which resulted in an exception. Too, it also resulted in redundant predicates of the form \<constant\> = \<constant\> in explain plans for some queries.

So, this fix takes a different approach. We add a member to RelExpr, possibleIndexColumns_, to contain the covered children of non-VEG equality predicates. We push down such children. At Scan::addIndexInfo, we consider such ValueIds when computing the set of indexes to try. That is, this fix creates an alternative mechanism to push down information to Scan::addIndexInfo, without generating possibly redundant predicates.

An example of a join equality predicate that is not converted to a VEG is a join predicate involving a tuple list.

I added a CQD, COMP_BOOL_194, which if set to 'OFF' turns off this fix. The default is 'ON'.

When unit testing this fix, I noticed a bug in some of the optimizer debugging code that caused a core. I fixed that too (optimizer/opt.cpp).